### PR TITLE
Add support for 90/270 degree rotated monitors

### DIFF
--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -11,7 +11,13 @@ static void handleGeometry(void* data, wl_output* output, int32_t x, int32_t y, 
 
 static void handleMode(void* data, wl_output* output, uint32_t flags, int32_t width, int32_t height, int32_t refresh) {
     const auto POUTPUT = (COutput*)data;
-    POUTPUT->size      = {width, height};
+
+    // handle portrait mode and flipped cases
+    if (POUTPUT->transform == WL_OUTPUT_TRANSFORM_270 || POUTPUT->transform == WL_OUTPUT_TRANSFORM_90 ||
+        POUTPUT->transform == WL_OUTPUT_TRANSFORM_FLIPPED_270 || POUTPUT->transform == WL_OUTPUT_TRANSFORM_FLIPPED_90)
+        POUTPUT->size = {height, width};
+    else
+        POUTPUT->size = {width, height};
 }
 
 static void handleDone(void* data, wl_output* output) {


### PR DESCRIPTION
Currently there is an issue with rotated setups
![image](https://github.com/hyprwm/hyprlock/assets/19814368/1be07e6d-d95f-4885-94d9-c1222a473846)


Added support for monitors rotated at 90/270 degrees to fix display issues with rotated setups.