### PR TITLE
Fallback to background color when background image not found

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -5,6 +5,7 @@
 #include <pango/pangocairo.h>
 #include <algorithm>
 #include "../core/hyprlock.hpp"
+#include "../helpers/Log.hpp"
 
 std::mutex cvmtx;
 
@@ -61,12 +62,18 @@ void CAsyncResourceGatherer::gather() {
             if (path.empty())
                 continue;
 
-            std::string id = std::string{"background:"} + path;
-
             // preload bg img
             const auto CAIROISURFACE = cairo_image_surface_create_from_png(path.c_str());
 
-            const auto CAIRO = cairo_create(CAIROISURFACE);
+            // Make sure the img was actually loaded
+            if (cairo_surface_status(CAIROISURFACE) != CAIRO_STATUS_SUCCESS) {
+                Debug::log(WARN, "Background image could not be loaded: {}", path);
+                continue;
+            }
+
+            std::string id = std::string{"background:"} + path;
+
+            const auto  CAIRO = cairo_create(CAIROISURFACE);
             cairo_scale(CAIRO, 1, 1);
 
             const auto TARGET = &preloadTargets.emplace_back(CAsyncResourceGatherer::SPreloadTarget{});

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -5,7 +5,6 @@
 #include <pango/pangocairo.h>
 #include <algorithm>
 #include "../core/hyprlock.hpp"
-#include "../helpers/Log.hpp"
 
 std::mutex cvmtx;
 
@@ -62,18 +61,12 @@ void CAsyncResourceGatherer::gather() {
             if (path.empty())
                 continue;
 
+            std::string id = std::string{"background:"} + path;
+
             // preload bg img
             const auto CAIROISURFACE = cairo_image_surface_create_from_png(path.c_str());
 
-            // Make sure the img was actually loaded
-            if (cairo_surface_status(CAIROISURFACE) != CAIRO_STATUS_SUCCESS) {
-                Debug::log(WARN, "Background image could not be loaded: {}", path);
-                continue;
-            }
-
-            std::string id = std::string{"background:"} + path;
-
-            const auto  CAIRO = cairo_create(CAIROISURFACE);
+            const auto CAIRO = cairo_create(CAIROISURFACE);
             cairo_scale(CAIRO, 1, 1);
 
             const auto TARGET = &preloadTargets.emplace_back(CAsyncResourceGatherer::SPreloadTarget{});

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -13,6 +13,7 @@
 
 struct SPreloadedAsset {
     CTexture texture;
+    bool     valid;
 };
 
 class CAsyncResourceGatherer {
@@ -69,6 +70,7 @@ class CAsyncResourceGatherer {
     struct SPreloadTarget {
         eTargetType type = TARGET_IMAGE;
         std::string id   = "";
+        bool        valid;
 
         void*       data;
         void*       cairo;

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -9,6 +9,7 @@
 #include <GLES3/gl3ext.h>
 
 #include <algorithm>
+#include <filesystem>
 
 #include "Shaders.hpp"
 
@@ -255,8 +256,8 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
             // by type
             if (c.type == "background") {
                 const std::string PATH = std::any_cast<Hyprlang::STRING>(c.values.at("path"));
-                widgets[surf].emplace_back(
-                    std::make_unique<CBackground>(surf->size, PATH.empty() ? "" : std::string{"background:"} + PATH, std::any_cast<Hyprlang::INT>(c.values.at("color"))));
+                widgets[surf].emplace_back(std::make_unique<CBackground>(surf->size, PATH.empty() || !std::filesystem::exists(PATH) ? "" : std::string{"background:"} + PATH,
+                                                                         std::any_cast<Hyprlang::INT>(c.values.at("color"))));
             } else if (c.type == "input-field") {
                 widgets[surf].emplace_back(std::make_unique<CPasswordInputField>(surf->size, c.values));
             } else if (c.type == "label") {

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -6,17 +6,20 @@ CBackground::CBackground(const Vector2D& viewport_, const std::string& resourceI
 }
 
 bool CBackground::draw(const SRenderData& data) {
-    if (!asset)
-        asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
 
-    // If background image does not exist, for whatever reason, fallback to color
-    if (!asset) {
+    if (resourceID.empty()) {
         CBox   monbox = {0, 0, viewport.x, viewport.y};
         CColor col    = color;
         col.a *= data.opacity;
         g_pRenderer->renderRect(monbox, col, 0);
         return data.opacity < 1.0;
     }
+
+    if (!asset)
+        asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
+
+    if (!asset)
+        return false;
 
     CBox     texbox = {{}, asset->texture.m_vSize};
 

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -6,20 +6,17 @@ CBackground::CBackground(const Vector2D& viewport_, const std::string& resourceI
 }
 
 bool CBackground::draw(const SRenderData& data) {
+    if (!asset)
+        asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
 
-    if (resourceID.empty()) {
+    // If background image does not exist, for whatever reason, fallback to color
+    if (!asset) {
         CBox   monbox = {0, 0, viewport.x, viewport.y};
         CColor col    = color;
         col.a *= data.opacity;
         g_pRenderer->renderRect(monbox, col, 0);
         return data.opacity < 1.0;
     }
-
-    if (!asset)
-        asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
-
-    if (!asset)
-        return false;
 
     CBox     texbox = {{}, asset->texture.m_vSize};
 

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -7,19 +7,17 @@ CBackground::CBackground(const Vector2D& viewport_, const std::string& resourceI
 
 bool CBackground::draw(const SRenderData& data) {
 
+    // Early fallback to background color if image does not exist
     if (resourceID.empty()) {
-        CBox   monbox = {0, 0, viewport.x, viewport.y};
-        CColor col    = color;
-        col.a *= data.opacity;
-        g_pRenderer->renderRect(monbox, col, 0);
-        return data.opacity < 1.0;
+        return draw_color_bg(data);
     }
 
     if (!asset)
         asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
 
-    if (!asset)
-        return false;
+    // Fallback to background color if texture is invalid
+    if (!asset || asset->valid)
+        return draw_color_bg(data);
 
     CBox     texbox = {{}, asset->texture.m_vSize};
 
@@ -37,5 +35,13 @@ bool CBackground::draw(const SRenderData& data) {
 
     g_pRenderer->renderTexture(texbox, asset->texture, data.opacity);
 
+    return data.opacity < 1.0;
+}
+
+bool CBackground::draw_color_bg(const SRenderData& data) {
+    CBox   monbox = {0, 0, viewport.x, viewport.y};
+    CColor col    = color;
+    col.a *= data.opacity;
+    g_pRenderer->renderRect(monbox, col, 0);
     return data.opacity < 1.0;
 }

--- a/src/renderer/widgets/Background.hpp
+++ b/src/renderer/widgets/Background.hpp
@@ -18,4 +18,6 @@ class CBackground : public IWidget {
     std::string      resourceID;
     CColor           color;
     SPreloadedAsset* asset = nullptr;
+
+    bool             draw_color_bg(const SRenderData& data);
 };


### PR DESCRIPTION
Confirms if the background image was actually loaded and logs a warning if not.

If no asset exists for a background image, fall back to background color. 

Tested by having a background image where hyprlock expects it. Background is rendered properly. Deleted the background image from disk and hyprlock reverts to background color. Deleted background color in config and hyprlock reverts to default color. 

Fixes #45 

Disclaimer: I haven't written any C++ code since I was in college 20 years ago so please review this. 