### PR TITLE
Unbreak build with libc++

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -95,7 +95,11 @@ void CAsyncResourceGatherer::gather() {
     progress = 0;
     for (auto& c : CWIDGETS) {
         if (c.type == "background") {
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 180100
+            progress = progress + 1.0 / (preloads + 1.0);
+#else
             progress += 1.0 / (preloads + 1.0);
+#endif
 
             std::string path = std::any_cast<Hyprlang::STRING>(c.values.at("path"));
 

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -4,6 +4,16 @@
 #include <chrono>
 #include <unistd.h>
 
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 190100
+#pragma comment(lib, "date-tz")
+#include <date/tz.h>
+namespace std {
+    namespace chrono {
+        using date::current_zone;
+    }
+}
+#endif
+
 Vector2D IWidget::posFromHVAlign(const Vector2D& viewport, const Vector2D& size, const Vector2D& offset, const std::string& halign, const std::string& valign) {
     Vector2D pos = offset;
     if (halign == "center")


### PR DESCRIPTION
Fixes #70. Tested with Clang/libc++ 17

- libc++ 18 has [atomic floats](https://github.com/llvm/llvm-project/commit/de7fbfeef598) but libc++ < 18 may still be common on distros
- libc++ 19 has [tzdb](https://github.com/llvm/llvm-project/commit/d332d88b919f) and [soon](https://github.com/llvm/llvm-project/pulls?q=is%3Apr+is%3Aopen+current_zone) will have `current_zone`
