### PR TITLE
fix libc++ compatibility v2

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <glob.h>
 #include <cstring>
+#include <mutex>
 
 static Hyprlang::CParseResult handleSource(const char* c, const char* v) {
     const std::string      VALUE   = v;


### PR DESCRIPTION
Fixes https://github.com/hyprwm/hyprlock/issues/73. Tested with Clang/libc++ 17 and 18