### PR TITLE
render: remove alpha check for input-field

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -194,7 +194,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
-    return dots.currentAmount != PASSLEN || data.opacity < 1.0 || fade.a < 1.0 || forceReload;
+    return dots.currentAmount != PASSLEN || data.opacity < 1.0 || forceReload;
 }
 
 void CPasswordInputField::updateFailTex() {


### PR DESCRIPTION
i think we can do this cause already checked with
```c
dots.currentAmount != PASSLEN
```

gpu not happy when `fade_on_empty = true`