### PR TITLE
Support background paths relative to the home directory

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -5,6 +5,7 @@
 #include <pango/pangocairo.h>
 #include <algorithm>
 #include "../core/hyprlock.hpp"
+#include "../helpers/MiscFunctions.hpp"
 
 std::mutex cvmtx;
 
@@ -130,10 +131,11 @@ void CAsyncResourceGatherer::gather() {
             if (path.empty())
                 continue;
 
-            std::string id = std::string{"background:"} + path;
+            std::string id           = std::string{"background:"} + path;
+            const auto  ABSOLUTEPATH = absolutePath(path, "").value_or(path);
 
             // preload bg img
-            const auto CAIROISURFACE = cairo_image_surface_create_from_png(path.c_str());
+            const auto CAIROISURFACE = cairo_image_surface_create_from_png(ABSOLUTEPATH.c_str());
 
             const auto CAIRO = cairo_create(CAIROISURFACE);
             cairo_scale(CAIRO, 1, 1);


### PR DESCRIPTION
I used the existing `absolutePath` function with `rawcurrentpath` set to "" in order to expand "~" with ENVHOME.
The resource ids stay the same.

When the path is relative, absolutePath returns an empty option and it would use the original string.
That code path is kind of useless and maybe it would be better to just expand "~" outside of absolutePath.
Behaviour would be the same though.

Fixes #38 