### PR TITLE
Show autentication failReason without additional input

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -638,6 +638,10 @@ void CHyprlock::onPasswordCheckTimer() {
         Debug::log(LOG, "Authentication failed: {}", m_sPasswordState.result->failReason);
         m_sPasswordState.lastFailReason = m_sPasswordState.result->failReason;
         m_sPasswordState.passBuffer     = "";
+
+        for (auto& o : m_vOutputs) {
+            o->sessionLockSurface->render();
+        }
     }
 
     m_sPasswordState.result.reset();

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -77,6 +77,11 @@ void CPasswordInputField::updateDots() {
         dots.lastFrame     = std::chrono::system_clock::now();
     }
 
+    if (PASSLEN == 0 && !placeholder.failID.empty()) {
+        dots.currentAmount = PASSLEN;
+        return;
+    }
+
     const auto  DELTA = std::clamp((int)std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - dots.lastFrame).count(), 0, 20000);
 
     const float TOADD = DELTA / 1000000.0 * dots.speedPerSecond;


### PR DESCRIPTION
This makes it so that
1. The renderer is triggered when the onPasswordCheckTimer callback is fired. Previously you had to give an additional input for the renderer to be triggered and the fail reason to show.
2. The updateDots function now sets dots.currentAmout to 0, when a failID is present and PASSLEN is 0. That leads to the draw function to return false and the failReason to be displayed until another input happens.

Addresses #97

**Previous behavior (I pressed a key at the end)**

https://github.com/hyprwm/hyprlock/assets/78690852/df047d4b-7ab6-4fa9-9abb-b1844841821f

**Behavior introduced here** 

https://github.com/hyprwm/hyprlock/assets/78690852/b900be89-fe30-449b-a60f-441770c8490f

