### PR TITLE
Fade out timeout

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -62,6 +62,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "dots_center", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "dots_spacing", Hyprlang::FLOAT{0.2});
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
+    m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{1000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
     m_config.addSpecialConfigValue("input-field", "halign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("input-field", "valign", Hyprlang::STRING{"center"});
@@ -136,6 +137,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"dots_spacing", m_config.getSpecialConfigValue("input-field", "dots_spacing", k.c_str())},
                 {"dots_center", m_config.getSpecialConfigValue("input-field", "dots_center", k.c_str())},
                 {"fade_on_empty", m_config.getSpecialConfigValue("input-field", "fade_on_empty", k.c_str())},
+                {"fade_timeout", m_config.getSpecialConfigValue("input-field", "fade_timeout", k.c_str())},
                 {"font_color", m_config.getSpecialConfigValue("input-field", "font_color", k.c_str())},
                 {"halign", m_config.getSpecialConfigValue("input-field", "halign", k.c_str())},
                 {"valign", m_config.getSpecialConfigValue("input-field", "valign", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -105,11 +105,6 @@ void CPasswordInputField::updateDots() {
         dots.lastFrame     = std::chrono::system_clock::now();
     }
 
-    if (PASSLEN == 0 && !placeholder.failID.empty()) {
-        dots.currentAmount = PASSLEN;
-        return;
-    }
-
     const auto  DELTA = std::clamp((int)std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - dots.lastFrame).count(), 0, 20000);
 
     const float TOADD = DELTA / 1000000.0 * dots.speedPerSecond;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -3,6 +3,7 @@
 #include "IWidget.hpp"
 #include "../../helpers/Vector2D.hpp"
 #include "../../helpers/Color.hpp"
+#include "../../core/Timer.hpp"
 #include <chrono>
 #include <vector>
 #include <any>
@@ -15,6 +16,7 @@ class CPasswordInputField : public IWidget {
     CPasswordInputField(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props);
 
     virtual bool draw(const SRenderData& data);
+    void         onFadeOutTimer();
 
   private:
     void     updateDots();
@@ -44,6 +46,7 @@ class CPasswordInputField : public IWidget {
         float                                 a         = 0;
         bool                                  appearing = true;
         bool                                  animated  = false;
+        std::shared_ptr<CTimer>               timer;
     } fade;
 
     struct {
@@ -63,4 +66,5 @@ class CPasswordInputField : public IWidget {
     } hiddenInputState;
 
     bool fadeOnEmpty;
+    long fadeTimeoutMs;
 };


### PR DESCRIPTION
Hi!

A bit of a follow up to #98

This handles the placeholder text in combination with fadeOnEmpty better, as it allows the user to specify a timeout for fading out the password field.

It now behaves the same weather an authentication failure happens or weather I empty the password input field (via ESC or Backspace).

This is how it looks with a default timeout of 1 second:

https://github.com/hyprwm/hyprlock/assets/78690852/69578892-cb34-480c-a7d0-215adaea0bf6

