### PR TITLE
grace: ignore key up and fix typo

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -658,7 +658,7 @@ std::optional<std::string> CHyprlock::passwordLastFailReason() {
 void CHyprlock::onKey(uint32_t key, bool down) {
     const auto SYM = xkb_state_key_get_one_sym(m_pXKBState, key + 8);
 
-    if (std::chrono::system_clock::now() < g_pHyprlock->m_tGraceEnd) {
+    if (down && std::chrono::system_clock::now() < g_pHyprlock->m_tGraceEnds) {
         unlockSession();
         return;
     }


### PR DESCRIPTION
Fix typo and ignore key up 

When you start hyprlock via a key press, then there is a stray key up event that would trigger the grace period unlock.
~This is also notable because without ignoring key up also ran into a racy bug that is probably the same as #107. So unlocking the screen quickly after startup seems to trigger it. Did not figure out what is going on yet tough.~ (That was because of locking a locked session)

Fixes #112
