### PR TITLE
Revert "core: dispatch on exit instead of roundtrip"

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -725,7 +725,7 @@ void CHyprlock::unlockSession() {
     m_bTerminate = true;
     m_bLocked    = false;
 
-    wl_display_dispatch(m_sWaylandState.display);
+    wl_display_roundtrip(m_sWaylandState.display);
 }
 
 void CHyprlock::onLockLocked() {


### PR DESCRIPTION
This reverts commit 2c7027d2b5901fb607046e60db650b034e12e261. Without the roundtrip it was possible that session_lock_surface_destroy gets called before unlock_and_destroy is processed.

fixes #107
