### PR TITLE
Adding a pam configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,3 +80,5 @@ protocol("unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml" "linux-dmabuf-unst
 
 # Installation
 install(TARGETS hyprlock)
+
+install(FILES "pam/hyprlock" DESTINATION "/etc/pam.d")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ include_directories(
   "protocols/"
 )
 
+include(GNUInstallDirs)
+
 # configure
 set(CMAKE_CXX_STANDARD 23)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value
@@ -81,4 +83,5 @@ protocol("unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml" "linux-dmabuf-unst
 # Installation
 install(TARGETS hyprlock)
 
-install(FILES "pam/hyprlock" DESTINATION "/etc/pam.d")
+install(FILES "pam/hyprlock" DESTINATION "${CMAKE_INSTALL_FULL_SYSCONFDIR}/pam.d")
+

--- a/pam/hyprlock
+++ b/pam/hyprlock
@@ -1,0 +1,5 @@
+# PAM configuration file for hyprlock
+# the 'login' configuration file (see /etc/pam.d/login)
+
+auth        include     login
+

--- a/src/core/Password.cpp
+++ b/src/core/Password.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<CPassword::SVerificationResult> CPassword::verify(const std::str
         const pam_conv localConv = {conv, NULL};
         pam_handle_t*  handle    = NULL;
 
-        int            ret = pam_start("su", getlogin(), &localConv, &handle);
+        int            ret = pam_start("hyprlock", getlogin(), &localConv, &handle);
 
         if (ret != PAM_SUCCESS) {
             result->success    = false;


### PR DESCRIPTION
This pull request would make hyprlock use it's own pam configuration file instead of the `su` one

This allows the user to include random pam services into it without touching stuff required by other programs.

By default, this just includes the `/etc/pam.d/login` configuration, which contains, by default:
```
#%PAM-1.0
auth       required     pam_securetty.so
auth       requisite    pam_nologin.so
auth       include      system-local-login
account    include      system-local-login
session    include      system-local-login
password   include      system-local-login
```

Basically just asks for a password.

Creating a custom pam configuration is exactly what https://github.com/hyprwm/hyprlock/issues/4 is asking for, and that issue is therefore fixed by this PR

On a sidenote, I'm not really sure about this line in `CMakeLists.txt`:
```cmake
# [...]
install(FILES "pam/hyprlock" DESTINATION "/etc/pam.d")
```
Is this the best way to do that? I'm not sure if using an absolute path is the best approach, but I didn't find anything better. Of course it can still be modified by using `DESTDIR`