### PR TITLE
hidden-input-field: add seed for random colors in hidden input field outline

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -241,6 +241,7 @@ void CPasswordInputField::updateHiddenInputState() {
     // randomize new thang
     hiddenInputState.lastPasswordLength = g_pHyprlock->getPasswordBufferLen();
 
+    srand(std::chrono::system_clock::now().time_since_epoch().count());
     float r1 = (rand() % 100) / 255.0;
     float r2 = (rand() % 100) / 255.0;
     int   r3 = rand() % 3;


### PR DESCRIPTION
The colors in the outline and quadrant of the hidden input field aren't random because it lacks a seed; it always repeats the same color pattern: yellow, yellow, blue, blue, magenta, pink, green, magenta and so on. I'm unsure if this is the intended behavior, but this should fix it.