### PR TITLE
Input fade out timeout v2

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -46,6 +46,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:hide_cursor", Hyprlang::INT{0});
     m_config.addConfigValue("general:grace", Hyprlang::INT{0});
     m_config.addConfigValue("general:no_fade_in", Hyprlang::INT{0});
+    m_config.addConfigValue("general:input_empty_fade_timeout", Hyprlang::INT{1000});
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("background", "monitor", Hyprlang::STRING{""});

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -78,7 +78,8 @@ class CHyprlock {
 
     //
     std::chrono::system_clock::time_point m_tGraceEnds;
-    Vector2D                              m_vLastEnterCoords = {};
+    Vector2D                              m_vLastEnterCoords        = {};
+    uint64_t                              m_iEmptyPasswordTimeoutMs = 0;
 
     std::vector<std::unique_ptr<COutput>> m_vOutputs;
 
@@ -117,6 +118,7 @@ class CHyprlock {
         std::string                                     passBuffer = "";
         std::shared_ptr<CPassword::SVerificationResult> result;
         std::optional<std::string>                      lastFailReason;
+        std::shared_ptr<CTimer>                         emptyBufferTimer;
     } m_sPasswordState;
 
     struct {

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -489,3 +489,11 @@ void CRenderer::popFb() {
     boundFBs.pop_back();
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, boundFBs.empty() ? 0 : boundFBs.back());
 }
+
+void CRenderer::onEmptyPasswordFade() {
+    for (auto& [surf, w] : widgets) {
+        for (auto& widget : w) {
+            widget->onEmptyPasswordTimer();
+        }
+    }
+}

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -34,6 +34,7 @@ class CRenderer {
     void                                    renderRect(const CBox& box, const CColor& col, int rounding = 0);
     void                                    renderTexture(const CBox& box, const CTexture& tex, float a = 1.0, int rounding = 0, std::optional<wl_output_transform> tr = {});
     void                                    blurFB(const CFramebuffer& outfb, SBlurParams params);
+    void                                    onEmptyPasswordFade();
 
     std::unique_ptr<CAsyncResourceGatherer> asyncResourceGatherer;
     std::chrono::system_clock::time_point   gatheredAt;

--- a/src/renderer/widgets/IWidget.hpp
+++ b/src/renderer/widgets/IWidget.hpp
@@ -11,6 +11,8 @@ class IWidget {
 
     virtual bool     draw(const SRenderData& data) = 0;
 
+    virtual void     onEmptyPasswordTimer(){};
+
     virtual Vector2D posFromHVAlign(const Vector2D& viewport, const Vector2D& size, const Vector2D& offset, const std::string& halign, const std::string& valign);
 
     struct SFormatResult {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -37,6 +37,10 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     }
 }
 
+void CPasswordInputField::onEmptyPasswordTimer() {
+    fade.allowFadeOut = true;
+}
+
 void CPasswordInputField::updateFade() {
     const auto PASSLEN = g_pHyprlock->getPasswordBufferLen();
 
@@ -45,11 +49,12 @@ void CPasswordInputField::updateFade() {
         return;
     }
 
-    if (PASSLEN == 0 && fade.a != 0.0 && (!fade.animated || fade.appearing)) {
-        fade.a         = 1.0;
-        fade.animated  = true;
-        fade.appearing = false;
-        fade.start     = std::chrono::system_clock::now();
+    if (PASSLEN == 0 && fade.a != 0.0 && fade.allowFadeOut && (!fade.animated || fade.appearing)) {
+        fade.a            = 1.0;
+        fade.animated     = true;
+        fade.appearing    = false;
+        fade.start        = std::chrono::system_clock::now();
+        fade.allowFadeOut = false;
     } else if (PASSLEN > 0 && fade.a != 1.0 && (!fade.animated || !fade.appearing)) {
         fade.a         = 0.0;
         fade.animated  = true;
@@ -216,7 +221,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
-    return dots.currentAmount != PASSLEN || data.opacity < 1.0 || forceReload;
+    return dots.currentAmount != PASSLEN || fade.animated || data.opacity < 1.0 || forceReload;
 }
 
 void CPasswordInputField::updateFailTex() {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -84,11 +84,6 @@ void CPasswordInputField::updateDots() {
         dots.lastFrame     = std::chrono::system_clock::now();
     }
 
-    if (PASSLEN == 0 && !placeholder.failID.empty()) {
-        dots.currentAmount = PASSLEN;
-        return;
-    }
-
     const auto  DELTA = std::clamp((int)std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - dots.lastFrame).count(), 0, 20000);
 
     const float TOADD = DELTA / 1000000.0 * dots.speedPerSecond;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -16,6 +16,7 @@ class CPasswordInputField : public IWidget {
     CPasswordInputField(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props);
 
     virtual bool draw(const SRenderData& data);
+    virtual void onEmptyPasswordTimer();
 
   private:
     void     updateDots();
@@ -45,9 +46,10 @@ class CPasswordInputField : public IWidget {
 
     struct {
         std::chrono::system_clock::time_point start;
-        float                                 a         = 0;
-        bool                                  appearing = true;
-        bool                                  animated  = false;
+        float                                 a            = 0;
+        bool                                  appearing    = true;
+        bool                                  animated     = false;
+        bool                                  allowFadeOut = false;
     } fade;
 
     struct {


### PR DESCRIPTION
Successor to #109 

The goal is to be able to show the placeholder text for a certain amount of time and then fade out the input field. That would allow to also handle the failure text better.

I felt like it was bad to add a timer within the renderer, as we have to acquire a lock for that.
That's why I added a virtual function to IWidget and implemented it for CPasswordInputField. This way we could implement it for CLabel as well and have some UI element fade together with the input field (don't know if anyone would want that).

Initiating the timer is done in onKey (to check if the password input was cleared) and in the onPasswordCheckTimer function (to add the timer when a auth failure happens).

Not ready to merge yet, would like some feedback first.
