### PR TITLE
Allow and fix empty passwords

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -714,11 +714,9 @@ void CHyprlock::onKey(uint32_t key, bool down) {
         if (m_sPasswordState.passBuffer.length() > 0)
             m_sPasswordState.passBuffer = m_sPasswordState.passBuffer.substr(0, m_sPasswordState.passBuffer.length() - 1);
     } else if (SYM == XKB_KEY_Return || SYM == XKB_KEY_KP_Enter) {
-        if (m_sPasswordState.passBuffer.length() > 0) {
-            Debug::log(LOG, "Authenticating");
+        Debug::log(LOG, "Authenticating");
 
-            m_sPasswordState.result = g_pPassword->verify(m_sPasswordState.passBuffer);
-        }
+        m_sPasswordState.result = g_pPassword->verify(m_sPasswordState.passBuffer);
     } else if (SYM == XKB_KEY_Escape) {
         Debug::log(LOG, "Clearing password buffer");
 


### PR DESCRIPTION
This reverts commit 6a085d7f8ea2e4092c3dae2042893489a504ff7c.

This should be handled by the distros pam configuration. There are actual use cases for an empty password.

Fixes #138
