### PR TITLE
label: fix rendering with multiple timers that fire at the same time

### DIFF
--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -114,7 +114,7 @@ bool CLabel::draw(const SRenderData& data) {
     shadow.draw(data);
     g_pRenderer->renderTexture(box, asset->texture, data.opacity);
 
-    return false;
+    return !pendingResourceID.empty();
 }
 
 void CLabel::renderSuper() {


### PR DESCRIPTION
The problem is that `getAssetByID` might return a `nullptr` if `asyncLoopState.busy` is true.
In that case the callback of the `asyncResourceGatherer` does trigger rendering, but the asset is not getting updated.

Not sure if you want to re=render like this or handle this case (`asyncLoopState.busy` beeing true) specifically.

Fixes #134
