### PR TITLE
core: terminate the poll thread

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -292,11 +292,11 @@ void CHyprlock::onGlobalRemoved(void* data, struct wl_registry* registry, uint32
 
 // end wl_registry
 
-static void registerSignalAction(int sig, void (*handler)(int)) {
+static void registerSignalAction(int sig, void (*handler)(int), int sa_flags = 0) {
     struct sigaction sa;
     sa.sa_handler = handler;
     sigemptyset(&sa.sa_mask);
-    sa.sa_flags = 0;
+    sa.sa_flags = sa_flags;
     sigaction(sig, &sa, NULL);
 }
 
@@ -354,7 +354,7 @@ void CHyprlock::run() {
 
     lockSession();
 
-    registerSignalAction(SIGUSR1, handleUnlockSignal);
+    registerSignalAction(SIGUSR1, handleUnlockSignal, SA_RESTART);
     registerSignalAction(SIGUSR2, handlePollTerminate);
     registerSignalAction(SIGSEGV, handleCriticalSignal);
     registerSignalAction(SIGABRT, handleCriticalSignal);

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -292,6 +292,14 @@ void CHyprlock::onGlobalRemoved(void* data, struct wl_registry* registry, uint32
 
 // end wl_registry
 
+static void registerSignalAction(int sig, void (*handler)(int)) {
+    struct sigaction sa;
+    sa.sa_handler = handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(sig, &sa, NULL);
+}
+
 static void handleUnlockSignal(int sig) {
     if (sig == SIGUSR1) {
         Debug::log(LOG, "Unlocking with a SIGUSR1");
@@ -346,10 +354,10 @@ void CHyprlock::run() {
 
     lockSession();
 
-    signal(SIGUSR1, handleUnlockSignal);
-    signal(SIGUSR2, handlePollTerminate);
-    signal(SIGSEGV, handleCriticalSignal);
-    signal(SIGABRT, handleCriticalSignal);
+    registerSignalAction(SIGUSR1, handleUnlockSignal);
+    registerSignalAction(SIGUSR2, handlePollTerminate);
+    registerSignalAction(SIGSEGV, handleCriticalSignal);
+    registerSignalAction(SIGABRT, handleCriticalSignal);
 
     pollfd pollfds[] = {
         {


### PR DESCRIPTION
Poll will return when it catches any signal. 
I used `SIGUSR2` to register a signal that does nothing, so that we can use it for terminating the poll thread without any coredumps. 
To clarify the need for the signal handler: When we `pthread_kill` and poll is currently blocking, then it would not coredump anyways. But if we `pthread_kill` and the poll thread is currently not blocking, then it would core dump without a handler.

If you would signal SIGUSR2 to the whole process while hyprlock is running, then nothing would happen.

The `sigaction` change is just because it is more consistent and could prevent a future headache on a weird system.

Fixes #149