### PR TITLE
Fix label update

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -316,7 +316,7 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
             } else if (c.type == "input-field") {
                 widgets[surf].emplace_back(std::make_unique<CPasswordInputField>(surf->size, c.values));
             } else if (c.type == "label") {
-                widgets[surf].emplace_back(std::make_unique<CLabel>(surf->size, c.values, /* evil */ const_cast<CSessionLockSurface*>(surf)));
+                widgets[surf].emplace_back(std::make_unique<CLabel>(surf->size, c.values, surf->output->stringPort));
             }
         }
     }

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -56,8 +56,8 @@ void CLabel::plantTimer() {
         labelTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((int)label.updateEveryMs), onTimer, this);
 }
 
-CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, CSessionLockSurface* surface_) :
-    surface(surface_), shadow(this, props, viewport_) {
+CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
+    outputStringPort(output), shadow(this, props, viewport_) {
     labelPreFormat         = std::any_cast<Hyprlang::STRING>(props.at("text"));
     std::string fontFamily = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
     CColor      labelColor = std::any_cast<Hyprlang::INT>(props.at("color"));
@@ -122,5 +122,13 @@ bool CLabel::draw(const SRenderData& data) {
 }
 
 void CLabel::renderSuper() {
-    surface->render();
+    const auto MON =
+        std::find_if(g_pHyprlock->m_vOutputs.begin(), g_pHyprlock->m_vOutputs.end(), [this](const auto& other) { return other->stringPort == this->outputStringPort; });
+
+    if (MON == g_pHyprlock->m_vOutputs.end() || !MON->get())
+        return;
+
+    const auto PMONITOR = MON->get();
+
+    PMONITOR->sessionLockSurface->render();
 }

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -121,6 +121,11 @@ bool CLabel::draw(const SRenderData& data) {
     return !pendingResourceID.empty();
 }
 
+static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {
+    const auto PLABEL = (CLabel*)data;
+    PLABEL->renderSuper();
+}
+
 void CLabel::renderSuper() {
     const auto MON =
         std::find_if(g_pHyprlock->m_vOutputs.begin(), g_pHyprlock->m_vOutputs.end(), [this](const auto& other) { return other->stringPort == this->outputStringPort; });
@@ -131,4 +136,7 @@ void CLabel::renderSuper() {
     const auto PMONITOR = MON->get();
 
     PMONITOR->sessionLockSurface->render();
+
+    if (!pendingResourceID.empty()) /* did not consume the pending resource */
+        g_pHyprlock->addTimer(std::chrono::milliseconds(100), onAssetCallbackTimer, this);
 }

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -118,7 +118,7 @@ bool CLabel::draw(const SRenderData& data) {
     shadow.draw(data);
     g_pRenderer->renderTexture(box, asset->texture, data.opacity);
 
-    return !pendingResourceID.empty();
+    return false;
 }
 
 static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {

--- a/src/renderer/widgets/Label.hpp
+++ b/src/renderer/widgets/Label.hpp
@@ -14,7 +14,7 @@ class CSessionLockSurface;
 
 class CLabel : public IWidget {
   public:
-    CLabel(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props, CSessionLockSurface* surface_);
+    CLabel(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props, const std::string& output);
     ~CLabel();
 
     virtual bool draw(const SRenderData& data);
@@ -35,8 +35,9 @@ class CLabel : public IWidget {
     std::string                             resourceID;
     std::string                             pendingResourceID; // if dynamic label
     std::string                             halign, valign;
-    SPreloadedAsset*                        asset   = nullptr;
-    CSessionLockSurface*                    surface = nullptr;
+    SPreloadedAsset*                        asset = nullptr;
+
+    std::string                             outputStringPort;
 
     CAsyncResourceGatherer::SPreloadRequest request;
 


### PR DESCRIPTION
#147 Did not fully do the trick.

When  `frameCallback` is set, the `render` function will instantly return. That will make onAssetCallback not update the asset via renderSuper and the label get's stuck with it's current asset until the next render.

31cbb83b824605b5aef0516f0d113644a93fb131 is what fixes the problem.

ed9c1c29aafc76be3e9fd75b9697d66a7f239ec4 was just to check my sanity but it seemed like a sensible change so I left it in

The fix from #147 is not really needed any more since it is now handled via the callback.

Fixes #105