### PR TITLE
input-field: fail display improvments

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -268,9 +268,9 @@ in {
             };
 
             fail_text = mkOption {
-              description = "The text shown if authentication failed. $FAIL variable is available to show pam fail reason";
+              description = "The text shown if authentication failed. $FAIL (reason) and $ATTEMPTS variables are available";
               type = str;
-              default = "";
+              default = "<i>$FAIL</i>";
             };
 
             fail_transition = mkOption {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -262,7 +262,7 @@ in {
             };
 
             fail_color = mkOption {
-              description = "The font color of fail reason text and changed outer color";
+              description = "If authentication failed, changes outer color and fail message color";
               type = str;
               default = "rgb(204, 34, 34)";
             };
@@ -274,7 +274,7 @@ in {
             };
 
             fail_transition = mkOption {
-              description = "The transition time between normal outer color and fail color";
+              description = "The transition time (ms) between normal outer color and fail color";
               type = int;
               default = 300;
             };

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -261,6 +261,24 @@ in {
               default = -1;
             };
 
+            fail_color = mkOption {
+              description = "The font color of fail reason text and changed outer color";
+              type = str;
+              default = "rgb(204, 34, 34)";
+            };
+
+            fail_text = mkOption {
+              description = "The text shown if authentication failed. $FAIL variable is available to show pam fail reason";
+              type = str;
+              default = "";
+            };
+
+            fail_transition = mkOption {
+              description = "The transition time between normal outer color and fail color";
+              type = int;
+              default = 300;
+            };
+
             position = {
               x = mkOption {
                 description = "X position of the label";
@@ -414,6 +432,9 @@ in {
             shadow_size = ${toString input-field.shadow_size}
             shadow_color = ${input-field.shadow_color}
             shadow_boost = ${toString input-field.shadow_boost}
+            fail_color = ${input-field.fail_color}
+            fail_text = ${input-field.fail_text}
+            fail_transition = ${toString input-field.fail_transition}
 
             position = ${toString input-field.position.x}, ${toString input-field.position.y}
             halign = ${input-field.halign}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -79,7 +79,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "hide_input", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "fail_color", Hyprlang::INT{0xFFCC2222});
-    m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{"<i>$FAIL</i>"});
     m_config.addSpecialConfigValue("input-field", "fail_transition", Hyprlang::INT{300});
     SHADOWABLE("input-field");
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -78,6 +78,9 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "placeholder_text", Hyprlang::STRING{"<i>Input Password</i>"});
     m_config.addSpecialConfigValue("input-field", "hide_input", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("input-field", "fail_color", Hyprlang::INT{0xFFCC2222});
+    m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("input-field", "fail_transition", Hyprlang::INT{300});
     SHADOWABLE("input-field");
 
     m_config.addSpecialCategory("label", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
@@ -165,6 +168,9 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"placeholder_text", m_config.getSpecialConfigValue("input-field", "placeholder_text", k.c_str())},
                 {"hide_input", m_config.getSpecialConfigValue("input-field", "hide_input", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
+                {"fail_color", m_config.getSpecialConfigValue("input-field", "fail_color", k.c_str())},
+                {"fail_text", m_config.getSpecialConfigValue("input-field", "fail_text", k.c_str())},
+                {"fail_transition", m_config.getSpecialConfigValue("input-field", "fail_transition", k.c_str())},
                 SHADOWABLE("input-field"),
             }
         });

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -681,6 +681,7 @@ void CHyprlock::onPasswordCheckTimer() {
         Debug::log(LOG, "Authentication failed: {}", m_sPasswordState.result->failReason);
         m_sPasswordState.lastFailReason = m_sPasswordState.result->failReason;
         m_sPasswordState.passBuffer     = "";
+        m_sPasswordState.failedAttempts += 1;
 
         for (auto& o : m_vOutputs) {
             o->sessionLockSurface->render();
@@ -818,6 +819,10 @@ wp_viewporter* CHyprlock::getViewporter() {
 
 size_t CHyprlock::getPasswordBufferLen() {
     return m_sPasswordState.passBuffer.length();
+}
+
+size_t CHyprlock::getPasswordFailedAttempts() {
+    return m_sPasswordState.failedAttempts;
 }
 
 std::shared_ptr<CTimer> CHyprlock::addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data) {

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -682,6 +682,7 @@ void CHyprlock::onPasswordCheckTimer() {
         m_sPasswordState.lastFailReason = m_sPasswordState.result->failReason;
         m_sPasswordState.passBuffer     = "";
         m_sPasswordState.failedAttempts += 1;
+        Debug::log(LOG, "Failed attempts: {}", m_sPasswordState.failedAttempts);
 
         for (auto& o : m_vOutputs) {
             o->sessionLockSurface->render();

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -54,6 +54,7 @@ class CHyprlock {
     std::optional<std::string>      passwordLastFailReason();
 
     size_t                          getPasswordBufferLen();
+    size_t                          getPasswordFailedAttempts();
 
     ext_session_lock_manager_v1*    getSessionLockMgr();
     ext_session_lock_v1*            getSessionLock();
@@ -117,6 +118,7 @@ class CHyprlock {
         std::string                                     passBuffer = "";
         std::shared_ptr<CPassword::SVerificationResult> result;
         std::optional<std::string>                      lastFailReason;
+        size_t                                          failedAttempts = 0;
     } m_sPasswordState;
 
     struct {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -19,7 +19,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     rounding                     = std::any_cast<Hyprlang::INT>(props.at("rounding"));
     placeholder.failColor        = std::any_cast<Hyprlang::INT>(props.at("fail_color"));
     placeholder.failTransitionMs = std::any_cast<Hyprlang::INT>(props.at("fail_transition"));
-    placeholder.failText         = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
+    configFailText               = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
     viewport                     = viewport_;
 
     auto POS__ = std::any_cast<Hyprlang::VEC2>(props.at("position"));
@@ -48,10 +48,12 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     }
 }
 
-static void replaceAllFails(std::string& str, const std::string& to) {
+static void replaceAllFail(std::string& str, const std::string& from, const std::string& to) {
+    if (from.empty())
+        return;
     size_t pos = 0;
-    while ((pos = str.find("$FAIL", pos)) != std::string::npos) {
-        str.replace(pos, 5, to);
+    while ((pos = str.find(from, pos)) != std::string::npos) {
+        str.replace(pos, from.length(), to);
         pos += to.length();
     }
 }
@@ -299,10 +301,9 @@ void CPasswordInputField::updateFailTex() {
     if (!FAIL.has_value() || !placeholder.canGetNewFail)
         return;
 
-    if (placeholder.failText.empty())
-        placeholder.failText = "<span style=\"italic\">" + FAIL.value() + "</span>";
-    else
-        replaceAllFails(placeholder.failText, FAIL.value());
+    placeholder.failText = configFailText;
+    replaceAllFail(placeholder.failText, "$FAIL", FAIL.value());
+    replaceAllFail(placeholder.failText, "$ATTEMPTS", std::to_string(g_pHyprlock->getPasswordFailedAttempts()));
 
     // query
     CAsyncResourceGatherer::SPreloadRequest request;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -20,20 +20,26 @@ class CPasswordInputField : public IWidget {
     void         onFadeOutTimer();
 
   private:
-    void     updateDots();
-    void     updateFade();
-    void     updateFailTex();
-    void     updateHiddenInputState();
+    void        updateDots();
+    void        updateFade();
+    void        updateFailTex();
+    void        updateHiddenInputState();
+    void        updateOuter();
 
-    bool     firstRender = true;
+    bool        firstRender   = true;
+    bool        redrawShadow  = false;
+    bool        outerAnimated = false;
 
-    Vector2D size;
-    Vector2D pos;
-    Vector2D viewport;
+    Vector2D    size;
+    Vector2D    pos;
+    Vector2D    viewport;
+    Vector2D    configPos;
 
-    int      outThick, rounding;
+    std::string halign, valign;
 
-    CColor   inner, outer, font;
+    int         outThick, rounding;
+
+    CColor      inner, outer, font;
 
     struct {
         float                                 currentAmount  = 0;
@@ -61,6 +67,9 @@ class CPasswordInputField : public IWidget {
         std::string      failID        = "";
         SPreloadedAsset* failAsset     = nullptr;
         bool             canGetNewFail = true;
+        CColor           failColor;
+        int              failTransitionMs = 0;
+        std::string      failText         = "";
     } placeholder;
 
     struct {

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -35,7 +35,7 @@ class CPasswordInputField : public IWidget {
     Vector2D    viewport;
     Vector2D    configPos;
 
-    std::string halign, valign;
+    std::string halign, valign, configFailText;
 
     int         outThick, rounding;
 


### PR DESCRIPTION
- pango-parseable `fail_text` with `$FAIL` as pam fail-reason
- `fail_color` to change untagged text color and outer color
- `fail_transition` to configure transition time between `outer` and `fail`
- temporarily resize input-field if fail-message is too long

should fix #97 (https://github.com/hyprwm/hyprlock/issues/97#issuecomment-1981655505)
also accidentally fixed #144, but i'm not sure, maybe it is intended behaviour?
if so, i'll just add check in resize thing to not reshadow if `fade_on_empty = true`

i definitely focked-up somewhere, so double-check plz :heart:


https://github.com/hyprwm/hyprlock/assets/130279855/e09d91ab-80b3-4156-8d8e-775d39e96016

