### PR TITLE
background: handle missing assets

### DIFF
--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -29,7 +29,7 @@ bool CBackground::draw(const SRenderData& data) {
         asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
 
     if (!asset)
-        return false;
+        return true;
 
     if ((blurPasses > 0 || isScreenshot) && !blurredFB.isAllocated()) {
         // make it brah

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -31,6 +31,12 @@ bool CBackground::draw(const SRenderData& data) {
     if (!asset)
         return true;
 
+    if (asset->texture.m_iType == TEXTURE_INVALID) {
+        g_pRenderer->asyncResourceGatherer->unloadAsset(asset);
+        resourceID = "";
+        return true;
+    }
+
     if ((blurPasses > 0 || isScreenshot) && !blurredFB.isAllocated()) {
         // make it brah
         Vector2D size = asset->texture.m_vSize;


### PR DESCRIPTION
When there is only a background widget on the surface and the first render fails to get the resource from the gatherer the background will not get rendered.

490fe4bb42615c8f3684300b1dfbe8561781b44b fixes that

The other two commits allow the background to fall back to the background color if cairo fails to handle the path.
Hope TEXTURE_INVALID is the right thing to use for that.

Fixes #155 