### PR TITLE
README: improve docs for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,24 @@ Hyprland's simple, yet multi-threaded and GPU-accelerated screen locking utility
 ## Building
 
 ### Deps
+Hyprlock requires `hyprlang` >= 0.4.0. See the 
+[README](https://github.com/hyprwm/hyprlang/blob/main/README.md#building-and-installation) for 
+build instructions.
+
+You also need the following dependencies
  - wayland-client
  - wayland-protocols
+ - mesa
+ And the development libraries for the following:-
  - cairo
- - gles3.2
  - libdrm
  - pango
- - hyprlang>=0.4.0
  - xkbcommon
  - pam
- - mesa
+Development libraries are usually suffixed with `-devel` or `-dev` in most distro repos.
+
+You also need to install `mesa-libgdm-devel` on some distros like RPM based ones where its not
+bundled with the mesa package.
 
 ### Building
 


### PR DESCRIPTION
Improved the dependencies section in the README. Also removed `gles3.2` dependency as it is usually provided by mesa