### PR TITLE
misc: path handling improvements

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -219,7 +219,7 @@ std::optional<std::string> CConfigManager::handleSource(const std::string& comma
     for (size_t i = 0; i < glob_buf->gl_pathc; i++) {
         const auto PATH = absolutePath(glob_buf->gl_pathv[i], CURRENTDIR);
 
-        if (PATH.empty()) {
+        if (PATH.empty() || PATH == configCurrentPath) {
             Debug::log(WARN, "source= skipping invalid path");
             continue;
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -208,20 +208,18 @@ std::optional<std::string> CConfigManager::handleSource(const std::string& comma
     std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
     memset(glob_buf.get(), 0, sizeof(glob_t));
 
-    if (auto r = glob(absolutePath(rawpath, configCurrentPath)->c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
+    if (auto r = glob(absolutePath(rawpath, configCurrentPath).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
         std::string err = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
         Debug::log(ERR, "{}", err);
         return err;
     }
 
     for (size_t i = 0; i < glob_buf->gl_pathc; i++) {
-        auto pathValueOpt = absolutePath(glob_buf->gl_pathv[i], configCurrentPath);
-        if (pathValueOpt->empty()) {
+        auto pathValue = absolutePath(glob_buf->gl_pathv[i], configCurrentPath);
+        if (pathValue.empty()) {
             Debug::log(WARN, "source= skipping invalid path");
             continue;
         }
-
-        auto pathValue = pathValueOpt.value();
 
         if (!std::filesystem::is_regular_file(pathValue)) {
             if (std::filesystem::exists(pathValue)) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -208,34 +208,37 @@ std::optional<std::string> CConfigManager::handleSource(const std::string& comma
     std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
     memset(glob_buf.get(), 0, sizeof(glob_t));
 
-    if (auto r = glob(absolutePath(rawpath, configCurrentPath).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
+    const auto CURRENTDIR = std::filesystem::path(configCurrentPath).parent_path().string();
+
+    if (auto r = glob(absolutePath(rawpath, CURRENTDIR).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
         std::string err = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
         Debug::log(ERR, "{}", err);
         return err;
     }
 
     for (size_t i = 0; i < glob_buf->gl_pathc; i++) {
-        auto pathValue = absolutePath(glob_buf->gl_pathv[i], configCurrentPath);
-        if (pathValue.empty()) {
+        const auto PATH = absolutePath(glob_buf->gl_pathv[i], CURRENTDIR);
+
+        if (PATH.empty()) {
             Debug::log(WARN, "source= skipping invalid path");
             continue;
         }
 
-        if (!std::filesystem::is_regular_file(pathValue)) {
-            if (std::filesystem::exists(pathValue)) {
-                Debug::log(WARN, "source= skipping non-file {}", pathValue);
+        if (!std::filesystem::is_regular_file(PATH)) {
+            if (std::filesystem::exists(PATH)) {
+                Debug::log(WARN, "source= skipping non-file {}", PATH);
                 continue;
             }
 
             Debug::log(ERR, "source= file doesnt exist");
-            return "source file " + pathValue + " doesn't exist!";
+            return "source file " + PATH + " doesn't exist!";
         }
 
         // allow for nested config parsing
         auto backupConfigPath = configCurrentPath;
-        configCurrentPath     = pathValue;
+        configCurrentPath     = PATH;
 
-        m_config.parseFile(pathValue.c_str());
+        m_config.parseFile(PATH.c_str());
 
         configCurrentPath = backupConfigPath;
     }

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,7 +1,7 @@
 #include <filesystem>
 #include "MiscFunctions.hpp"
 
-std::optional<std::string> absolutePath(const std::string& rawpath, const std::string& rawcurrentpath) {
+std::string absolutePath(const std::string& rawpath, const std::string& rawcurrentpath) {
     std::filesystem::path path(rawpath);
 
     // Handling where rawpath starts with '~'

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -12,12 +12,8 @@ std::optional<std::string> absolutePath(const std::string& rawpath, const std::s
     // Handling e.g. ./, ../
     else if (path.is_relative()) {
         const std::filesystem::path currentDir = std::filesystem::path(rawcurrentpath).parent_path();
-
-        auto                        finalPath = currentDir / path;
-        if (exists(finalPath))
-            return std::filesystem::canonical(currentDir / path);
-        return {};
+        return std::filesystem::weakly_canonical(currentDir / path);
     } else {
-        return std::filesystem::canonical(path);
+        return std::filesystem::weakly_canonical(path);
     }
 }

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,7 +1,7 @@
 #include <filesystem>
 #include "MiscFunctions.hpp"
 
-std::string absolutePath(const std::string& rawpath, const std::string& rawcurrentpath) {
+std::string absolutePath(const std::string& rawpath, const std::string& currentDir) {
     std::filesystem::path path(rawpath);
 
     // Handling where rawpath starts with '~'
@@ -11,8 +11,7 @@ std::string absolutePath(const std::string& rawpath, const std::string& rawcurre
     }
     // Handling e.g. ./, ../
     else if (path.is_relative()) {
-        const std::filesystem::path currentDir = std::filesystem::path(rawcurrentpath).parent_path();
-        return std::filesystem::weakly_canonical(currentDir / path);
+        return std::filesystem::weakly_canonical(std::filesystem::path(currentDir) / path);
     } else {
         return std::filesystem::weakly_canonical(path);
     }

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -3,4 +3,4 @@
 #include <string>
 #include <optional>
 
-std::optional<std::string> absolutePath(const std::string&, const std::string&);
+std::string absolutePath(const std::string&, const std::string&);

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -132,7 +132,7 @@ void CAsyncResourceGatherer::gather() {
                 continue;
 
             std::string id           = std::string{"background:"} + path;
-            const auto  ABSOLUTEPATH = absolutePath(path, "").value_or(path);
+            const auto  ABSOLUTEPATH = absolutePath(path, "");
 
             // preload bg img
             const auto CAIROISURFACE = cairo_image_surface_create_from_png(ABSOLUTEPATH.c_str());


### PR DESCRIPTION
Using weakly_canonical avoids a runtime error when the path does not exist.
`absolutePath` now does not check if the file exists. That is done later on anyways.
