### PR TITLE
input-field: display utf-8 codepoint length

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -825,6 +825,11 @@ size_t CHyprlock::getPasswordBufferLen() {
     return m_sPasswordState.passBuffer.length();
 }
 
+size_t CHyprlock::getPasswordBufferDisplayLen() {
+    // Counts utf-8 codepoints in the buffer. A byte is counted if it does not match 0b10xxxxxx.
+    return std::count_if(m_sPasswordState.passBuffer.begin(), m_sPasswordState.passBuffer.end(), [](char c) { return (c & 0xc0) != 0x80; });
+}
+
 size_t CHyprlock::getPasswordFailedAttempts() {
     return m_sPasswordState.failedAttempts;
 }

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -54,6 +54,7 @@ class CHyprlock {
     std::optional<std::string>      passwordLastFailReason();
 
     size_t                          getPasswordBufferLen();
+    size_t                          getPasswordBufferDisplayLen();
     size_t                          getPasswordFailedAttempts();
 
     ext_session_lock_manager_v1*    getSessionLockMgr();

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -121,7 +121,7 @@ void CPasswordInputField::updateFade() {
 }
 
 void CPasswordInputField::updateDots() {
-    const auto PASSLEN = g_pHyprlock->getPasswordBufferLen();
+    const auto PASSLEN = g_pHyprlock->getPasswordBufferDisplayLen();
 
     if (PASSLEN == dots.currentAmount)
         return;
@@ -320,11 +320,11 @@ void CPasswordInputField::updateFailTex() {
 }
 
 void CPasswordInputField::updateHiddenInputState() {
-    if (!hiddenInputState.enabled || (size_t)hiddenInputState.lastPasswordLength == g_pHyprlock->getPasswordBufferLen())
+    if (!hiddenInputState.enabled || (size_t)hiddenInputState.lastPasswordLength == g_pHyprlock->getPasswordBufferDisplayLen())
         return;
 
     // randomize new thang
-    hiddenInputState.lastPasswordLength = g_pHyprlock->getPasswordBufferLen();
+    hiddenInputState.lastPasswordLength = g_pHyprlock->getPasswordBufferDisplayLen();
 
     srand(std::chrono::system_clock::now().time_since_epoch().count());
     float r1 = (rand() % 100) / 255.0;


### PR DESCRIPTION
Only counts codepoints, which is fine, since you can only enter one at a time anyways.

Fixes #129