### PR TITLE
Nix/HM module: remove shadow options from backgrounds

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -151,8 +151,7 @@ in {
               type = float;
               default = 0.05;
             };
-          }
-          // shadow;
+          };
       });
       default = [
         {}
@@ -403,10 +402,6 @@ in {
             brightness = ${toString background.brightness}
             vibrancy = ${toString background.vibrancy}
             vibrancy_darkness = ${toString background.vibrancy_darkness}
-            shadow_passes = ${toString background.shadow_passes}
-            shadow_size = ${toString background.shadow_size}
-            shadow_color = ${background.shadow_color}
-            shadow_boost = ${toString background.shadow_boost}
           }
         '')
         cfg.backgrounds)}


### PR DESCRIPTION
Currently shadow options wrongfully apply to backgrounds in the nix hm module.
@fufexan 