### PR TITLE
core: force update labels on `SIGUSR2`

### DIFF
--- a/src/core/Timer.cpp
+++ b/src/core/Timer.cpp
@@ -1,7 +1,8 @@
 #include "Timer.hpp"
 
-CTimer::CTimer(std::chrono::system_clock::duration timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data_) : cb(cb_), data(data_) {
-    expires = std::chrono::system_clock::now() + timeout;
+CTimer::CTimer(std::chrono::system_clock::duration timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data_, bool force) : cb(cb_), data(data_) {
+    expires          = std::chrono::system_clock::now() + timeout;
+    allowForceUpdate = force;
 }
 
 bool CTimer::passed() {
@@ -22,4 +23,8 @@ void CTimer::call(std::shared_ptr<CTimer> self) {
 
 float CTimer::leftMs() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(expires - std::chrono::system_clock::now()).count();
+}
+
+bool CTimer::canForceUpdate() {
+    return allowForceUpdate;
 }

--- a/src/core/Timer.hpp
+++ b/src/core/Timer.hpp
@@ -5,10 +5,11 @@
 
 class CTimer {
   public:
-    CTimer(std::chrono::system_clock::duration timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data_);
+    CTimer(std::chrono::system_clock::duration timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data_, bool force);
 
     void  cancel();
     bool  passed();
+    bool  canForceUpdate();
 
     float leftMs();
 
@@ -19,5 +20,6 @@ class CTimer {
     std::function<void(std::shared_ptr<CTimer> self, void* data)> cb;
     void*                                                         data = nullptr;
     std::chrono::system_clock::time_point                         expires;
-    bool                                                          wasCancelled = false;
+    bool                                                          wasCancelled     = false;
+    bool                                                          allowForceUpdate = false;
 };

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -35,7 +35,8 @@ class CHyprlock {
     void                            onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
     void                            onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);
 
-    std::shared_ptr<CTimer>         addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data);
+    std::shared_ptr<CTimer>         addTimer(const std::chrono::system_clock::duration& timeout, std::function<void(std::shared_ptr<CTimer> self, void* data)> cb_, void* data,
+                                             bool force = false);
 
     void                            onLockLocked();
     void                            onLockFinished();
@@ -83,6 +84,7 @@ class CHyprlock {
     Vector2D                              m_vLastEnterCoords = {};
 
     std::vector<std::unique_ptr<COutput>> m_vOutputs;
+    std::vector<std::shared_ptr<CTimer>>  getTimers();
 
     struct {
         void*                        linuxDmabuf         = nullptr;

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -79,6 +79,11 @@ IWidget::SFormatResult IWidget::formatString(std::string in) {
         for (const auto& v : vars) {
             if (v.starts_with("update:")) {
                 try {
+                    if (v.substr(7).contains(':')) {
+                        auto str                = v.substr(v.substr(7).find_first_of(':') + 8);
+                        result.allowForceUpdate = str == "true" || std::stoull(str) == 1;
+                    }
+
                     result.updateEveryMs = std::stoull(v.substr(7));
                 } catch (std::exception& e) { Debug::log(ERR, "Error parsing {} in cmd[]", v); }
             } else {

--- a/src/renderer/widgets/IWidget.hpp
+++ b/src/renderer/widgets/IWidget.hpp
@@ -15,9 +15,10 @@ class IWidget {
 
     struct SFormatResult {
         std::string formatted;
-        float       updateEveryMs = 0; // 0 means don't (static)
-        bool        alwaysUpdate  = false;
-        bool        cmd           = false;
+        float       updateEveryMs    = 0; // 0 means don't (static)
+        bool        alwaysUpdate     = false;
+        bool        cmd              = false;
+        bool        allowForceUpdate = false;
     };
 
     virtual SFormatResult formatString(std::string in);

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -53,7 +53,7 @@ void CLabel::onTimerUpdate() {
 
 void CLabel::plantTimer() {
     if (label.updateEveryMs != 0)
-        labelTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((int)label.updateEveryMs), onTimer, this);
+        labelTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((int)label.updateEveryMs), onTimer, this, label.allowForceUpdate);
 }
 
 CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -54,6 +54,8 @@ void CLabel::onTimerUpdate() {
 void CLabel::plantTimer() {
     if (label.updateEveryMs != 0)
         labelTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((int)label.updateEveryMs), onTimer, this, label.allowForceUpdate);
+    else if (label.updateEveryMs == 0 && label.allowForceUpdate)
+        labelTimer = g_pHyprlock->addTimer(std::chrono::hours(1), onTimer, this, true);
 }
 
 CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :


### PR DESCRIPTION
reasons behind: https://github.com/hyprwm/hyprlock/pull/150#issuecomment-1987201385

by default force update is disabled and can be enabled with:
`[update:12345:1]` or `[update:12345:true]`

are you ok with parsing like that? i think it makes more sense than config option