### PR TITLE
input-field: `check_color` + some fixes

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -261,6 +261,12 @@ in {
               default = -1;
             };
 
+            check_color = mkOption {
+              description = "The outer color of the input field while checking password";
+              type = str;
+              default = "rgb(204, 136, 34)";
+            };
+
             fail_color = mkOption {
               description = "If authentication failed, changes outer color and fail message color";
               type = str;
@@ -432,6 +438,7 @@ in {
             shadow_size = ${toString input-field.shadow_size}
             shadow_color = ${input-field.shadow_color}
             shadow_boost = ${toString input-field.shadow_boost}
+            check_color = ${input-field.check_color}
             fail_color = ${input-field.fail_color}
             fail_text = ${input-field.fail_text}
             fail_transition = ${toString input-field.fail_transition}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -78,6 +78,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "placeholder_text", Hyprlang::STRING{"<i>Input Password</i>"});
     m_config.addSpecialConfigValue("input-field", "hide_input", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("input-field", "check_color", Hyprlang::INT{0xFFCC8822});
     m_config.addSpecialConfigValue("input-field", "fail_color", Hyprlang::INT{0xFFCC2222});
     m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{"<i>$FAIL</i>"});
     m_config.addSpecialConfigValue("input-field", "fail_transition", Hyprlang::INT{300});
@@ -168,6 +169,8 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"placeholder_text", m_config.getSpecialConfigValue("input-field", "placeholder_text", k.c_str())},
                 {"hide_input", m_config.getSpecialConfigValue("input-field", "hide_input", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
+                {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
+                {"check_color", m_config.getSpecialConfigValue("input-field", "check_color", k.c_str())},
                 {"fail_color", m_config.getSpecialConfigValue("input-field", "fail_color", k.c_str())},
                 {"fail_text", m_config.getSpecialConfigValue("input-field", "fail_text", k.c_str())},
                 {"fail_transition", m_config.getSpecialConfigValue("input-field", "fail_transition", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -39,7 +39,7 @@ class CPasswordInputField : public IWidget {
 
     int         outThick, rounding;
 
-    CColor      inner, outer, font;
+    CColor      inner, outer, font, checkColor;
 
     struct {
         float                                 currentAmount  = 0;


### PR DESCRIPTION
`check_color` to change outer when waiting for check

- shadow animated on fade (not so heavy as i thought)
- resize extra width on fail kinda animated a bit now
- fixed fail counter not updated on empty password input (if no `fade_on_empty`)