### PR TITLE
label: add `$FAIL` and `$ATTEMPTS`

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -307,14 +307,18 @@ static void handleUnlockSignal(int sig) {
     }
 }
 
+static void forceUpdateTimers() {
+    for (auto& t : g_pHyprlock->getTimers()) {
+        if (t->canForceUpdate()) {
+            t->call(t);
+            t->cancel();
+        }
+    }
+}
+
 static void handleForceUpdateSignal(int sig) {
     if (sig == SIGUSR2) {
-        for (auto& t : g_pHyprlock->getTimers()) {
-            if (t->canForceUpdate()) {
-                t->call(t);
-                t->cancel();
-            }
-        }
+        forceUpdateTimers();
     }
 }
 
@@ -707,6 +711,7 @@ void CHyprlock::onPasswordCheckTimer() {
         m_sPasswordState.passBuffer     = "";
         m_sPasswordState.failedAttempts += 1;
         Debug::log(LOG, "Failed attempts: {}", m_sPasswordState.failedAttempts);
+        forceUpdateTimers();
 
         for (auto& o : m_vOutputs) {
             o->sessionLockSurface->render();

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -51,24 +51,22 @@ static void replaceAll(std::string& str, const std::string& from, const std::str
 static void replaceAllAttempts(std::string& str) {
 
     const size_t      ATTEMPTS = g_pHyprlock->getPasswordFailedAttempts();
-    const std::string from     = "$ATTEMPTS";
-    const std::string to       = std::to_string(ATTEMPTS);
+    const std::string STR      = std::to_string(ATTEMPTS);
+    size_t            pos      = 0;
 
-    size_t            pos = 0;
-
-    while ((pos = str.find(from, pos)) != std::string::npos) {
+    while ((pos = str.find("$ATTEMPTS", pos)) != std::string::npos) {
         if (str.substr(pos, 10).ends_with('[') && str.substr(pos).contains(']')) {
-            const std::string repl = str.substr(pos + 10, str.find_first_of(']', pos) - 10 - pos);
+            const std::string REPL = str.substr(pos + 10, str.find_first_of(']', pos) - 10 - pos);
             if (ATTEMPTS == 0) {
-                str.replace(pos, 11 + repl.length(), repl);
-                pos += repl.length();
+                str.replace(pos, 11 + REPL.length(), REPL);
+                pos += REPL.length();
             } else {
-                str.replace(pos, 11 + repl.length(), to);
-                pos += to.length();
+                str.replace(pos, 11 + REPL.length(), STR);
+                pos += STR.length();
             }
         } else {
-            str.replace(pos, 9, to);
-            pos += to.length();
+            str.replace(pos, 9, STR);
+            pos += STR.length();
         }
     }
 }

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -98,6 +98,12 @@ IWidget::SFormatResult IWidget::formatString(std::string in) {
         result.updateEveryMs = result.updateEveryMs != 0 && result.updateEveryMs < 1000 ? result.updateEveryMs : 1000;
     }
 
+    if (in.contains("$FAIL")) {
+        const auto FAIL = g_pHyprlock->passwordLastFailReason();
+        replaceAll(in, "$FAIL", FAIL.has_value() ? FAIL.value() : "");
+        result.allowForceUpdate = true;
+    }
+
     if (in.contains("$ATTEMPTS")) {
         replaceAllAttempts(in);
         result.allowForceUpdate = true;

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -1,6 +1,7 @@
 #include "IWidget.hpp"
 #include "../../helpers/Log.hpp"
 #include "../../helpers/VarList.hpp"
+#include "../../core/hyprlock.hpp"
 #include <chrono>
 #include <unistd.h>
 
@@ -47,6 +48,31 @@ static void replaceAll(std::string& str, const std::string& from, const std::str
     }
 }
 
+static void replaceAllAttempts(std::string& str) {
+
+    const size_t      ATTEMPTS = g_pHyprlock->getPasswordFailedAttempts();
+    const std::string from     = "$ATTEMPTS";
+    const std::string to       = std::to_string(ATTEMPTS);
+
+    size_t            pos = 0;
+
+    while ((pos = str.find(from, pos)) != std::string::npos) {
+        if (str.substr(pos, 10).ends_with('[') && str.substr(pos).contains(']')) {
+            const std::string repl = str.substr(pos + 10, str.find_first_of(']', pos) - 10 - pos);
+            if (ATTEMPTS == 0) {
+                str.replace(pos, 11 + repl.length(), repl);
+                pos += repl.length();
+            } else {
+                str.replace(pos, 11 + repl.length(), to);
+                pos += to.length();
+            }
+        } else {
+            str.replace(pos, 9, to);
+            pos += to.length();
+        }
+    }
+}
+
 static std::string getTime() {
     const auto current_zone = std::chrono::current_zone();
     const auto HHMMSS       = std::chrono::hh_mm_ss{current_zone->to_local(std::chrono::system_clock::now()) -
@@ -70,6 +96,11 @@ IWidget::SFormatResult IWidget::formatString(std::string in) {
     if (in.contains("$TIME")) {
         replaceAll(in, "$TIME", getTime());
         result.updateEveryMs = result.updateEveryMs != 0 && result.updateEveryMs < 1000 ? result.updateEveryMs : 1000;
+    }
+
+    if (in.contains("$ATTEMPTS")) {
+        replaceAllAttempts(in);
+        result.allowForceUpdate = true;
     }
 
     if (in.starts_with("cmd[") && in.contains("]")) {


### PR DESCRIPTION
should resolve #179 
should resolve #180

`$ATTEMPTS[blabla]` can be used to show blabla or nothing when no failed attempts

https://github.com/hyprwm/hyprlock/assets/130279855/f68dc058-b7f1-448d-a1cb-c7196bfe8f96

one thing to mention, when `$ATTEMPTS` used in cmd, sometimes failasset in input-field doesn't draw
maybe smth could be done?
when `sleep 0.1` is the first command in `cmd`, all ok
