### PR TITLE
renderer, Nix/HM module: add fade out animation and property to disable

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -85,6 +85,11 @@ in {
         type = bool;
         default = false;
       };
+      no_fade_out = mkOption {
+          description = "Do not fade out";
+          type = bool;
+          default = false;
+      };
     };
 
     backgrounds = mkOption {
@@ -417,6 +422,7 @@ in {
         grace = ${toString cfg.general.grace}
         hide_cursor = ${boolToString cfg.general.hide_cursor}
         no_fade_in = ${boolToString cfg.general.no_fade_in}
+        no_fade_out = ${boolToString cfg.general.no_fade_out}
       }
 
       ${builtins.concatStringsSep "\n" (map (background: ''

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -46,6 +46,8 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:hide_cursor", Hyprlang::INT{0});
     m_config.addConfigValue("general:grace", Hyprlang::INT{0});
     m_config.addConfigValue("general:no_fade_in", Hyprlang::INT{0});
+    m_config.addConfigValue("general:no_fade_out", Hyprlang::INT{0});
+
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("background", "monitor", Hyprlang::STRING{""});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -713,7 +713,7 @@ void CHyprlock::onPasswordCheckTimer() {
     if (m_sPasswordState.result->success) {
         if (**PNOFADEOUT || SZCURRENTD != "Hyprland")
             unlockSession();
-        m_tFadeEnds = std::chrono::system_clock::now() + std::chrono::milliseconds(600);
+        m_tFadeEnds = std::chrono::system_clock::now() + std::chrono::milliseconds(500);
         m_bFadeStarted = true;
     } else {
         Debug::log(LOG, "Authentication failed: {}", m_sPasswordState.result->failReason);

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -702,12 +702,14 @@ static const ext_session_lock_v1_listener sessionLockListener = {
 
 void CHyprlock::onPasswordCheckTimer() {
     static auto* const PNOFADEOUT  = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:no_fade_out");
+    const auto CURRENTDESKTOP = getenv("XDG_CURRENT_DESKTOP");
+    const auto SZCURRENTD     = std::string{CURRENTDESKTOP ? CURRENTDESKTOP : ""};
+
     // check result
     if (m_sPasswordState.result->success) {
-        if (**PNOFADEOUT) {
+        if (**PNOFADEOUT || SZCURRENTD != "Hyprland")
             unlockSession();
-        }
-        m_tFadeEnds = std::chrono::system_clock::now() + std::chrono::seconds(1);
+        m_tFadeEnds = std::chrono::system_clock::now() + std::chrono::milliseconds(600);
         m_bFadeStarted = true;
     } else {
         Debug::log(LOG, "Authentication failed: {}", m_sPasswordState.result->failReason);

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -81,9 +81,10 @@ class CHyprlock {
 
     bool                            m_bCapsLock = false;
     bool                            m_bNumLock  = false;
-
+    bool                            m_bFadeStarted = false;
     //
     std::chrono::system_clock::time_point m_tGraceEnds;
+    std::chrono::system_clock::time_point m_tFadeEnds;
     Vector2D                              m_vLastEnterCoords = {};
 
     std::vector<std::unique_ptr<COutput>> m_vOutputs;

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -202,7 +202,7 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
             bga = 1.0;
 
         if (g_pHyprlock->m_bFadeStarted && !**PNOFADEOUT) {
-            bga = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(g_pHyprlock->m_tFadeEnds - std::chrono::system_clock::now()).count() / 600000.0 - 0.02, 0.0, 1.0);
+            bga = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(g_pHyprlock->m_tFadeEnds - std::chrono::system_clock::now()).count() / 500000.0 - 0.02, 0.0, 1.0);
             // - 0.02 so that the fade ends a little earlier than the final second
         }
         // render widgets
@@ -216,7 +216,7 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
 
     Debug::log(TRACE, "frame {}", frames);
 
-    feedback.needsFrame = feedback.needsFrame || !asyncResourceGatherer->ready || bga != 1.0;
+    feedback.needsFrame = feedback.needsFrame || !asyncResourceGatherer->ready || bga < 1.0;
 
     glDisable(GL_BLEND);
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -202,7 +202,7 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
             bga = 1.0;
 
         if (g_pHyprlock->m_bFadeStarted && !**PNOFADEOUT) {
-            bga = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(g_pHyprlock->m_tFadeEnds - std::chrono::system_clock::now()).count() / 1000000.0 - 0.02, 0.0, 1.0);
+            bga = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(g_pHyprlock->m_tFadeEnds - std::chrono::system_clock::now()).count() / 600000.0 - 0.02, 0.0, 1.0);
             // - 0.02 so that the fade ends a little earlier than the final second
         }
         // render widgets

--- a/src/renderer/widgets/Shadowable.cpp
+++ b/src/renderer/widgets/Shadowable.cpp
@@ -37,6 +37,6 @@ bool CShadowable::draw(const IWidget::SRenderData& data) {
         return true;
 
     CBox box = {0, 0, viewport.x, viewport.y};
-    g_pRenderer->renderTexture(box, shadowFB.m_cTex, 1.0, 0, WL_OUTPUT_TRANSFORM_NORMAL);
+    g_pRenderer->renderTexture(box, shadowFB.m_cTex, data.opacity, 0, WL_OUTPUT_TRANSFORM_NORMAL);
     return true;
 }


### PR DESCRIPTION
Fades out the lockscreen on successful authentication. Closes #60.

https://github.com/hyprwm/hyprlock/assets/84299080/5e74e3fc-57b8-4ea0-9894-07e80e72bff0

**Note about Nix module: **
I can't test it on Nix as I don't use it. If it doesn't work on Nix please tell me to remove that part, I'd be glad to do so.

