### PR TITLE
asyncResourceGatherer: skip processing screenshot paths and remove initThread

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -10,12 +10,11 @@
 std::mutex cvmtx;
 
 CAsyncResourceGatherer::CAsyncResourceGatherer() {
-    initThread = std::thread([this]() {
-        this->gather();
-        this->asyncLoopThread = std::thread([this]() { this->asyncAssetSpinLock(); });
-        this->asyncLoopThread.detach();
+    asyncLoopThread = std::thread([this]() {
+        this->gather(); /* inital gather */
+        this->asyncAssetSpinLock();
     });
-    initThread.detach();
+    asyncLoopThread.detach();
 
     // some things can't be done async :(
     // gather background textures when needed

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -128,7 +128,7 @@ void CAsyncResourceGatherer::gather() {
 
             std::string path = std::any_cast<Hyprlang::STRING>(c.values.at("path"));
 
-            if (path.empty())
+            if (path.empty() || path == "screenshot")
                 continue;
 
             std::string id           = std::string{"background:"} + path;

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -52,7 +52,6 @@ class CAsyncResourceGatherer {
     void recheckDMAFramesFor(COutput* output);
 
   private:
-    std::thread initThread;
     std::thread asyncLoopThread;
 
     void        asyncAssetSpinLock();


### PR DESCRIPTION
Just some misc things I noticed.