### PR TITLE
core: mmap keymap buffer with MAP_PRIVATE

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -611,7 +611,7 @@ static void handleKeyboardKeymap(void* data, wl_keyboard* wl_keyboard, uint form
         return;
     }
 
-    const char* buf = (const char*)mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+    const char* buf = (const char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (buf == MAP_FAILED) {
         Debug::log(ERR, "Failed to mmap xkb keymap: {}", errno);
         return;


### PR DESCRIPTION
Opened my laptop and had no input. Attached and everything looked ok but no key events and a lot of calls to `handleKeyboardKeymap`.

So I don't know if that fixes it but according to [here](https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard) the region should be mapped with MAP_PRIVATE.

The debugger also showed `fd: 0xf (/dev/shm/wlroots-kgkhkA (deleted))`. when stepping through `handleKeyboardKeymap`. But the "(deleted)" part could also be fine. don't know.
 
Could address #101