### PR TITLE
widgets: add Image

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -162,6 +162,77 @@ in {
       ];
     };
 
+    images = mkOption {
+      description = "Image configurations";
+      type = listOf (submodule {
+        options = {
+          monitor = mkOption {
+            description = "The monitor to draw an image";
+            type = str;
+            default = "";
+          };
+
+          path = mkOption {
+            description = "The path to source image";
+            type = str;
+            default = "/home/me/cutie.png"; # only png supported for now
+          };
+
+          size = mkOption {
+            description = "Size of the image. Lesser side is chosen if not 1:1 aspect ratio";
+            type = int;
+            default = 150;
+          };
+
+          rounding = mkOption {
+            description = "The rounding of the image";
+            type = int;
+            default = -1;
+          };
+
+          frame_size = mkOption {
+            description = "Size of the frame around an image";
+            type = int;
+            default = 4;
+          };
+
+          frame_color = mkOption {
+            description = "Color of the frame around an image";
+            type = str;
+            default = "rgb(221, 221, 221)";
+          };
+
+          position = {
+            x = mkOption {
+              description = "X position of the image";
+              type = int;
+              default = 0;
+            };
+            y = mkOption {
+              description = "Y position of the image";
+              type = int;
+              default = 200;
+            };
+          };
+
+          halign = mkOption {
+            description = "Horizontal alignment of the image";
+            type = str;
+            default = "center";
+          };
+
+          valign = mkOption {
+            description = "Vertical alignment of the image";
+            type = str;
+            default = "center";
+          };
+        };
+      });
+      default = [
+        {}
+      ];
+    };
+
     input-fields = mkOption {
       description = "Input field configurations";
       type = listOf (submodule {
@@ -440,6 +511,22 @@ in {
           }
         '')
         cfg.backgrounds)}
+
+      ${builtins.concatStringsSep "\n" (map (image: ''
+          image {
+            monitor = ${image.monitor}
+            path = ${image.path}
+            size = ${toString image.size}
+            rounding = ${toString image.rounding}
+            frame_size = ${toString image.frame_size}
+            frame_color = ${image.frame_color}
+
+            position = ${toString image.position.x}, ${toString image.position.y}
+            halign = ${image.halign}
+            valign = ${image.valign}
+          }
+        '')
+        cfg.images)}
 
       ${builtins.concatStringsSep "\n" (map (input-field: ''
           input-field {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -190,14 +190,14 @@ in {
             default = -1;
           };
 
-          frame_size = mkOption {
-            description = "Size of the frame around an image";
+          border_size = mkOption {
+            description = "Size of image border";
             type = int;
             default = 4;
           };
 
-          frame_color = mkOption {
-            description = "Color of the frame around an image";
+          border_color = mkOption {
+            description = "Color of image border";
             type = str;
             default = "rgb(221, 221, 221)";
           };
@@ -518,8 +518,8 @@ in {
             path = ${image.path}
             size = ${toString image.size}
             rounding = ${toString image.rounding}
-            frame_size = ${toString image.frame_size}
-            frame_color = ${image.frame_color}
+            border_size = ${toString image.border_size}
+            border_color = ${image.border_color}
 
             position = ${toString image.position.x}, ${toString image.position.y}
             halign = ${image.halign}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -61,6 +61,18 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("background", "vibrancy", Hyprlang::FLOAT{0.1686});
     m_config.addSpecialConfigValue("background", "vibrancy_darkness", Hyprlang::FLOAT{0.05});
 
+    m_config.addSpecialCategory("image", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
+    m_config.addSpecialConfigValue("image", "monitor", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("image", "path", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("image", "size", Hyprlang::INT{150});
+    m_config.addSpecialConfigValue("image", "rounding", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("image", "border_size", Hyprlang::INT{4});
+    m_config.addSpecialConfigValue("image", "border_color", Hyprlang::INT{0xFFDDDDDD});
+    m_config.addSpecialConfigValue("image", "position", Hyprlang::VEC2{0, 200});
+    m_config.addSpecialConfigValue("image", "halign", Hyprlang::STRING{"center"});
+    m_config.addSpecialConfigValue("image", "valign", Hyprlang::STRING{"center"});
+    SHADOWABLE("image");
+
     m_config.addSpecialCategory("input-field", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("input-field", "monitor", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "size", Hyprlang::VEC2{400, 90});
@@ -146,6 +158,28 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"vibrancy", m_config.getSpecialConfigValue("background", "vibrancy", k.c_str())},
                 {"brightness", m_config.getSpecialConfigValue("background", "brightness", k.c_str())},
                 {"vibrancy_darkness", m_config.getSpecialConfigValue("background", "vibrancy_darkness", k.c_str())},
+            }
+        });
+        // clang-format on
+    }
+
+    //
+    keys = m_config.listKeysForSpecialCategory("image");
+    for (auto& k : keys) {
+        // clang-format off
+        result.push_back(CConfigManager::SWidgetConfig{
+            "image",
+            std::any_cast<Hyprlang::STRING>(m_config.getSpecialConfigValue("image", "monitor", k.c_str())),
+            {
+                {"path", m_config.getSpecialConfigValue("image", "path", k.c_str())},
+                {"size", m_config.getSpecialConfigValue("image", "size", k.c_str())},
+                {"rounding", m_config.getSpecialConfigValue("image", "rounding", k.c_str())},
+                {"border_size", m_config.getSpecialConfigValue("image", "border_size", k.c_str())},
+                {"border_color", m_config.getSpecialConfigValue("image", "border_color", k.c_str())},
+                {"position", m_config.getSpecialConfigValue("image", "position", k.c_str())},
+                {"halign", m_config.getSpecialConfigValue("image", "halign", k.c_str())},
+                {"valign", m_config.getSpecialConfigValue("image", "valign", k.c_str())},
+                SHADOWABLE("image"),
             }
         });
         // clang-format on

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -112,13 +112,13 @@ void CAsyncResourceGatherer::gather() {
     // gather resources to preload
     // clang-format off
     int preloads = std::count_if(CWIDGETS.begin(), CWIDGETS.end(), [](const auto& w) {
-        return w.type == "background";
+        return w.type == "background" || w.type == "image";
     });
     // clang-format on
 
     progress = 0;
     for (auto& c : CWIDGETS) {
-        if (c.type == "background") {
+        if (c.type == "background" || c.type == "image") {
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 180100
             progress = progress + 1.0 / (preloads + 1.0);
 #else
@@ -130,7 +130,7 @@ void CAsyncResourceGatherer::gather() {
             if (path.empty() || path == "screenshot")
                 continue;
 
-            std::string id           = std::string{"background:"} + path;
+            std::string id           = (c.type == "background" ? std::string{"background:"} : std::string{"image:"}) + path;
             const auto  ABSOLUTEPATH = absolutePath(path, "");
 
             // preload bg img

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -16,6 +16,7 @@
 #include "widgets/PasswordInputField.hpp"
 #include "widgets/Background.hpp"
 #include "widgets/Label.hpp"
+#include "widgets/Image.hpp"
 
 inline const float fullVerts[] = {
     1, 0, // top right
@@ -323,6 +324,14 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
                 widgets[surf].emplace_back(std::make_unique<CPasswordInputField>(surf->size, c.values));
             } else if (c.type == "label") {
                 widgets[surf].emplace_back(std::make_unique<CLabel>(surf->size, c.values, surf->output->stringPort));
+            } else if (c.type == "image") {
+                const std::string PATH = std::any_cast<Hyprlang::STRING>(c.values.at("path"));
+
+                std::string       resourceID = "";
+                if (!PATH.empty())
+                    resourceID = "image:" + PATH;
+
+                widgets[surf].emplace_back(std::make_unique<CImage>(surf->size, surf->output, resourceID, c.values));
             }
         }
     }

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -1,0 +1,68 @@
+#include "Image.hpp"
+#include "../Renderer.hpp"
+#include <cmath>
+
+CImage::CImage(const Vector2D& viewport_, COutput* output_, const std::string& resourceID_, const std::unordered_map<std::string, std::any>& props) :
+    viewport(viewport_), resourceID(resourceID_), output(output_), shadow(this, props, viewport_) {
+
+    size     = std::any_cast<Hyprlang::INT>(props.at("size"));
+    rounding = std::any_cast<Hyprlang::INT>(props.at("rounding"));
+    border   = std::any_cast<Hyprlang::INT>(props.at("border_size"));
+    color    = std::any_cast<Hyprlang::INT>(props.at("border_color"));
+    pos      = std::any_cast<Hyprlang::VEC2>(props.at("position"));
+    halign   = std::any_cast<Hyprlang::STRING>(props.at("halign"));
+    valign   = std::any_cast<Hyprlang::STRING>(props.at("valign"));
+}
+
+bool CImage::draw(const SRenderData& data) {
+
+    if (resourceID.empty())
+        return false;
+
+    if (!asset)
+        asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
+
+    if (!asset)
+        return true;
+
+    if (asset->texture.m_iType == TEXTURE_INVALID) {
+        g_pRenderer->asyncResourceGatherer->unloadAsset(asset);
+        resourceID = "";
+        return false;
+    }
+
+    CTexture* tex    = &asset->texture;
+    CBox      texbox = {{}, tex->m_vSize};
+
+    if (firstRender) {
+        firstRender = false;
+        shadow.markShadowDirty();
+    }
+
+    float scaleX = size / tex->m_vSize.x;
+    float scaleY = size / tex->m_vSize.y;
+
+    texbox.w *= std::max(scaleX, scaleY);
+    texbox.h *= std::max(scaleX, scaleY);
+
+    shadow.draw(data);
+
+    bool       roundingAllowed = rounding > -1 && rounding < std::min(texbox.w, texbox.h) / 2.0;
+    const auto TEXPOS          = posFromHVAlign(viewport, Vector2D{texbox.w, texbox.h}, pos, halign, valign);
+
+    texbox.x = TEXPOS.x;
+    texbox.y = TEXPOS.y;
+
+    if (border > 0) {
+        CBox   borderBox = {TEXPOS - Vector2D{(double)border, (double)border}, texbox.size() + Vector2D{(double)border * 2.0, (double)border * 2.0}};
+        CColor borderCol = color;
+        borderCol.a *= data.opacity;
+        borderBox.round();
+        g_pRenderer->renderRect(borderBox, borderCol, roundingAllowed ? rounding : std::min(borderBox.w, borderBox.h) / 2.0);
+    }
+
+    texbox.round();
+    g_pRenderer->renderTexture(texbox, *tex, data.opacity, roundingAllowed ? rounding : std::min(texbox.w, texbox.h) / 2.0, WL_OUTPUT_TRANSFORM_FLIPPED_180);
+
+    return data.opacity < 1.0;
+}

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -39,16 +39,16 @@ bool CImage::draw(const SRenderData& data) {
         shadow.markShadowDirty();
     }
 
-    float scaleX = size / tex->m_vSize.x;
-    float scaleY = size / tex->m_vSize.y;
+    const float SCALEX = size / tex->m_vSize.x;
+    const float SCALEY = size / tex->m_vSize.y;
 
-    texbox.w *= std::max(scaleX, scaleY);
-    texbox.h *= std::max(scaleX, scaleY);
+    texbox.w *= std::max(SCALEX, SCALEY);
+    texbox.h *= std::max(SCALEX, SCALEY);
 
     shadow.draw(data);
 
-    bool       roundingAllowed = rounding > -1 && rounding < std::min(texbox.w, texbox.h) / 2.0;
-    const auto TEXPOS          = posFromHVAlign(viewport, Vector2D{texbox.w, texbox.h}, pos, halign, valign);
+    const bool ALLOWROUND = rounding > -1 && rounding < std::min(texbox.w, texbox.h) / 2.0;
+    const auto TEXPOS     = posFromHVAlign(viewport, Vector2D{texbox.w, texbox.h}, pos, halign, valign);
 
     texbox.x = TEXPOS.x;
     texbox.y = TEXPOS.y;
@@ -58,11 +58,11 @@ bool CImage::draw(const SRenderData& data) {
         CColor borderCol = color;
         borderCol.a *= data.opacity;
         borderBox.round();
-        g_pRenderer->renderRect(borderBox, borderCol, roundingAllowed ? rounding : std::min(borderBox.w, borderBox.h) / 2.0);
+        g_pRenderer->renderRect(borderBox, borderCol, ALLOWROUND ? rounding : std::min(borderBox.w, borderBox.h) / 2.0);
     }
 
     texbox.round();
-    g_pRenderer->renderTexture(texbox, *tex, data.opacity, roundingAllowed ? rounding : std::min(texbox.w, texbox.h) / 2.0, WL_OUTPUT_TRANSFORM_FLIPPED_180);
+    g_pRenderer->renderTexture(texbox, *tex, data.opacity, ALLOWROUND ? rounding : std::min(texbox.w, texbox.h) / 2.0, WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
     return data.opacity < 1.0;
 }

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "IWidget.hpp"
+#include "../../helpers/Vector2D.hpp"
+#include "../../helpers/Color.hpp"
+#include "Shadowable.hpp"
+#include <string>
+#include <unordered_map>
+#include <any>
+
+struct SPreloadedAsset;
+class COutput;
+
+class CImage : public IWidget {
+  public:
+    CImage(const Vector2D& viewport, COutput* output_, const std::string& resourceID, const std::unordered_map<std::string, std::any>& props);
+
+    virtual bool draw(const SRenderData& data);
+
+  private:
+    int              size;
+    int              rounding;
+    int              border;
+    CColor           color;
+    Vector2D         pos;
+
+    std::string      halign, valign;
+
+    bool             firstRender = true;
+
+    Vector2D         viewport;
+    std::string      resourceID;
+    SPreloadedAsset* asset  = nullptr;
+    COutput*         output = nullptr;
+    CShadowable      shadow;
+};


### PR DESCRIPTION
that's a simple implementation, just to draw a circle with picture
mostly copy-pasted from background widget and input-field :p

close #10

![055708-output- eDP-1](https://github.com/hyprwm/hyprlock/assets/130279855/5325dbad-792d-4f5f-becc-7f58340e9fa7)

![060544-output- eDP-1](https://github.com/hyprwm/hyprlock/assets/130279855/556968eb-32d0-4d90-9358-2921482dbef7)


```ini
avatar {
    border_color = 0xffdddddd
    border_size = 4
    size = 150
    position = 0, 200
    halign = center
    valign = center
}
```

&check; Shadowable
