### PR TITLE
input-field: fix missing `fail_text` when `placeholder_text` is empty

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -47,7 +47,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     g_pHyprlock->m_bNumLock = outerColor.invertNum;
 
     std::string placeholderText = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
-    if (!placeholderText.empty()) {
+    if (!placeholderText.empty() || !configFailText.empty()) {
         placeholder.resourceID = "placeholder:" + std::to_string((uintptr_t)this);
         CAsyncResourceGatherer::SPreloadRequest request;
         request.id                   = placeholder.resourceID;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -47,6 +47,9 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     g_pHyprlock->m_bNumLock = outerColor.invertNum;
 
     std::string placeholderText = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
+
+    // Render placeholder if either placeholder_text or fail_text are non-empty
+    // as placeholder must be rendered to show fail_text
     if (!placeholderText.empty() || !configFailText.empty()) {
         placeholder.resourceID = "placeholder:" + std::to_string((uintptr_t)this);
         CAsyncResourceGatherer::SPreloadRequest request;


### PR DESCRIPTION
Closes #178