### PR TITLE
input-field: various fixes

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -789,8 +789,12 @@ void CHyprlock::onKey(uint32_t key, bool down) {
     m_bNumLock  = xkb_state_mod_name_is_active(g_pHyprlock->m_pXKBState, XKB_MOD_NAME_NUM, XKB_STATE_MODS_LOCKED);
 
     if (SYM == XKB_KEY_BackSpace) {
-        if (m_sPasswordState.passBuffer.length() > 0)
+        if (m_sPasswordState.passBuffer.length() > 0) {
+            // handle utf-8
+            while ((m_sPasswordState.passBuffer.back() & 0xc0) == 0x80)
+                m_sPasswordState.passBuffer.pop_back();
             m_sPasswordState.passBuffer = m_sPasswordState.passBuffer.substr(0, m_sPasswordState.passBuffer.length() - 1);
+        }
     } else if (SYM == XKB_KEY_Return || SYM == XKB_KEY_KP_Enter) {
         Debug::log(LOG, "Authenticating");
         m_sPasswordState.result = g_pPassword->verify(m_sPasswordState.passBuffer);

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -89,22 +89,20 @@ void CPasswordInputField::onFadeOutTimer() {
 }
 
 void CPasswordInputField::updateFade() {
-    const auto PASSLEN = g_pHyprlock->getPasswordBufferLen();
-
     if (!fadeOnEmpty) {
         fade.a = 1.0;
         return;
     }
 
-    if (PASSLEN > 0 && fade.allowFadeOut)
+    if (passwordLength > 0 && fade.allowFadeOut)
         fade.allowFadeOut = false;
 
-    if (PASSLEN > 0 && fade.fadeOutTimer.get()) {
+    if (passwordLength > 0 && fade.fadeOutTimer.get()) {
         fade.fadeOutTimer->cancel();
         fade.fadeOutTimer.reset();
     }
 
-    if (PASSLEN == 0 && fade.a != 0.0 && (!fade.animated || fade.appearing)) {
+    if (passwordLength == 0 && fade.a != 0.0 && (!fade.animated || fade.appearing)) {
         if (fade.allowFadeOut || fadeTimeoutMs == 0) {
             fade.a            = 1.0;
             fade.animated     = true;
@@ -115,7 +113,7 @@ void CPasswordInputField::updateFade() {
             fade.fadeOutTimer = g_pHyprlock->addTimer(std::chrono::milliseconds(fadeTimeoutMs), fadeOutCallback, this);
     }
 
-    if (PASSLEN > 0 && fade.a != 1.0 && (!fade.animated || !fade.appearing)) {
+    if (passwordLength > 0 && fade.a != 1.0 && (!fade.animated || !fade.appearing)) {
         fade.a         = 0.0;
         fade.animated  = true;
         fade.appearing = true;
@@ -136,13 +134,11 @@ void CPasswordInputField::updateFade() {
 }
 
 void CPasswordInputField::updateDots() {
-    const auto PASSLEN = g_pHyprlock->getPasswordBufferDisplayLen();
-
-    if (PASSLEN == dots.currentAmount)
+    if (passwordLength == dots.currentAmount)
         return;
 
-    if (std::abs(PASSLEN - dots.currentAmount) > 1) {
-        dots.currentAmount = std::clamp(dots.currentAmount, PASSLEN - 1.f, PASSLEN + 1.f);
+    if (std::abs(passwordLength - dots.currentAmount) > 1) {
+        dots.currentAmount = std::clamp(dots.currentAmount, passwordLength - 1.f, passwordLength + 1.f);
         dots.lastFrame     = std::chrono::system_clock::now();
     }
 
@@ -150,14 +146,14 @@ void CPasswordInputField::updateDots() {
 
     const float TOADD = DELTA / 1000000.0 * dots.speedPerSecond;
 
-    if (PASSLEN > dots.currentAmount) {
+    if (passwordLength > dots.currentAmount) {
         dots.currentAmount += TOADD;
-        if (dots.currentAmount > PASSLEN)
-            dots.currentAmount = PASSLEN;
-    } else if (PASSLEN < dots.currentAmount) {
+        if (dots.currentAmount > passwordLength)
+            dots.currentAmount = passwordLength;
+    } else if (passwordLength < dots.currentAmount) {
         dots.currentAmount -= TOADD;
-        if (dots.currentAmount < PASSLEN)
-            dots.currentAmount = PASSLEN;
+        if (dots.currentAmount < passwordLength)
+            dots.currentAmount = passwordLength;
     }
 
     dots.lastFrame = std::chrono::system_clock::now();
@@ -174,6 +170,9 @@ bool CPasswordInputField::draw(const SRenderData& data) {
     }
 
     bool forceReload = false;
+
+    passwordLength = g_pHyprlock->getPasswordBufferDisplayLen();
+    checkWaiting   = g_pHyprlock->passwordCheckWaiting();
 
     updateFade();
     updateDots();
@@ -209,7 +208,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
     shadowData.opacity *= fade.a;
     shadow.draw(shadowData);
 
-    float  passAlpha = g_pHyprlock->passwordCheckWaiting() ? 0.5 : 1.0;
+    float  passAlpha = checkWaiting ? 0.5 : 1.0;
 
     CColor outerCol = outerColor.main;
     outerCol.a *= fade.a * data.opacity;
@@ -218,12 +217,10 @@ bool CPasswordInputField::draw(const SRenderData& data) {
     CColor fontCol = font;
     fontCol.a *= fade.a * data.opacity * passAlpha;
 
-    const auto PASSLEN = g_pHyprlock->getPasswordBufferLen();
-
     if (outThick > 0) {
         g_pRenderer->renderRect(outerBox, outerCol, rounding == -1 ? outerBox.h / 2.0 : rounding);
 
-        if (PASSLEN != 0 && hiddenInputState.enabled && !fade.animated && data.opacity == 1.0) {
+        if (passwordLength != 0 && hiddenInputState.enabled && !fade.animated && data.opacity == 1.0) {
             CBox     outerBoxScaled = outerBox;
             Vector2D p              = outerBox.pos();
             outerBoxScaled.translate(-p).scale(0.5).translate(p);
@@ -283,7 +280,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
         }
     }
 
-    if (PASSLEN == 0 && !placeholder.resourceID.empty()) {
+    if (passwordLength == 0 && !placeholder.resourceID.empty()) {
         SPreloadedAsset* currAsset = nullptr;
 
         if (!placeholder.failID.empty()) {
@@ -307,18 +304,16 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
-    return dots.currentAmount != PASSLEN || fade.animated || outerColor.animated || redrawShadow || data.opacity < 1.0 || forceReload;
+    return dots.currentAmount != passwordLength || fade.animated || outerColor.animated || redrawShadow || data.opacity < 1.0 || forceReload;
 }
 
 void CPasswordInputField::updateFailTex() {
-    const auto FAIL    = g_pHyprlock->passwordLastFailReason();
-    const auto WAITING = g_pHyprlock->passwordCheckWaiting();
-    const auto PASSLEN = g_pHyprlock->getPasswordBufferLen();
+    const auto FAIL = g_pHyprlock->passwordLastFailReason();
 
-    if (WAITING)
+    if (checkWaiting)
         placeholder.canGetNewFail = true;
 
-    if (PASSLEN != 0 || (WAITING && PASSLEN == 0)) {
+    if (passwordLength != 0 || (checkWaiting && passwordLength == 0)) {
         if (placeholder.failAsset) {
             g_pRenderer->asyncResourceGatherer->unloadAsset(placeholder.failAsset);
             placeholder.failAsset = nullptr;
@@ -350,11 +345,11 @@ void CPasswordInputField::updateFailTex() {
 }
 
 void CPasswordInputField::updateHiddenInputState() {
-    if (!hiddenInputState.enabled || (size_t)hiddenInputState.lastPasswordLength == g_pHyprlock->getPasswordBufferDisplayLen())
+    if (!hiddenInputState.enabled || (size_t)hiddenInputState.lastPasswordLength == passwordLength)
         return;
 
     // randomize new thang
-    hiddenInputState.lastPasswordLength = g_pHyprlock->getPasswordBufferDisplayLen();
+    hiddenInputState.lastPasswordLength = passwordLength;
 
     srand(std::chrono::system_clock::now().time_since_epoch().count());
     float r1 = (rand() % 100) / 255.0;
@@ -398,8 +393,8 @@ void CPasswordInputField::updateOuter() {
             if (TARGET == outerColor.check)
                 SOURCE = outerColor.main;
             outerColor.transitionMs = 100;
-            TARGET = OUTER;
-        } else if (g_pHyprlock->passwordCheckWaiting())
+            TARGET                  = OUTER;
+        } else if (checkWaiting)
             TARGET = outerColor.check;
         else if (outerColor.both != OUTER && outerColor.stateCaps && outerColor.stateNum)
             TARGET = outerColor.both;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -379,7 +379,7 @@ void CPasswordInputField::updateOuter() {
     static auto TIMER = std::chrono::system_clock::now();
 
     if (outerColor.animated) {
-        if (outerColor.stateNum != outerColor.invertNum ? !g_pHyprlock->m_bNumLock : g_pHyprlock->m_bNumLock || outerColor.stateCaps != g_pHyprlock->m_bCapsLock)
+        if (outerColor.stateNum != (outerColor.invertNum ? !g_pHyprlock->m_bNumLock : g_pHyprlock->m_bNumLock) || outerColor.stateCaps != g_pHyprlock->m_bCapsLock)
             SOURCE = outerColor.main;
     } else
         SOURCE = outerColor.main;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -122,9 +122,9 @@ void CPasswordInputField::updateFade() {
 
     if (fade.animated) {
         if (fade.appearing)
-            fade.a = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - fade.start).count() / 150000.0, 0.0, 1.0);
+            fade.a = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - fade.start).count() / 100000.0, 0.0, 1.0);
         else
-            fade.a = std::clamp(1.0 - std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - fade.start).count() / 150000.0, 0.0, 1.0);
+            fade.a = std::clamp(1.0 - std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - fade.start).count() / 100000.0, 0.0, 1.0);
 
         if ((fade.appearing && fade.a == 1.0) || (!fade.appearing && fade.a == 0.0))
             fade.animated = false;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -28,6 +28,9 @@ class CPasswordInputField : public IWidget {
 
     bool        firstRender  = true;
     bool        redrawShadow = false;
+    bool        checkWaiting = false;
+
+    size_t      passwordLength = 0;
 
     Vector2D    size;
     Vector2D    pos;


### PR DESCRIPTION
- correctly erase utf8 chars on backspace
- don't draw outer at all if `outline_thickness = 0`
- don't draw hidden input quadrants on fades. even if respecting `fade.a` and `data.opacity`, it's colored and still visible like quadrant (ugly)
- don't draw dots on unlock fadeout (they are flashing now)
- don't stuck on `check_color` on unlock fadeout
- now correctly checks `dots.currentAmount` against utf8 in draw return

I also made input-field fades to be a bit longer