### PR TITLE
Add missing destructors causing segfaults

### DIFF
--- a/src/core/Egl.cpp
+++ b/src/core/Egl.cpp
@@ -69,6 +69,12 @@ CEGL::CEGL(wl_display* display) {
 
 error:
     eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+}
+
+CEGL::~CEGL() {
+    if (eglContext != EGL_NO_CONTEXT)
+        eglDestroyContext(eglDisplay, eglContext);
+
     if (eglDisplay)
         eglTerminate(eglDisplay);
 

--- a/src/core/Egl.hpp
+++ b/src/core/Egl.hpp
@@ -9,6 +9,7 @@
 class CEGL {
   public:
     CEGL(wl_display*);
+    ~CEGL();
 
     EGLDisplay                               eglDisplay;
     EGLConfig                                eglConfig;

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -519,6 +519,9 @@ void CHyprlock::run() {
 
     m_vOutputs.clear();
     g_pEGL.reset();
+    g_pRenderer = nullptr;
+
+    xkb_context_unref(m_pXKBContext);
 
     wl_display_disconnect(m_sWaylandState.display);
 


### PR DESCRIPTION
Hello!
I was running into a couple of segfaults caused because of the lack of de-initialization of certain components. I thought I would track it down and send in a fix!

The segfault I was really concerned by was caused by the lack of call to `eglTerminate` as it caused a segfault to get thrown from deep within `libnvidia-egl-wayland.so`.