### PR TITLE
input-field: new color features

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -407,6 +407,12 @@ in {
               type = bool;
               default = false;
             };
+
+            swap_font = mkOption {
+              description = "Whether to swap font color with inner color on some events";
+              type = bool;
+              default = false;
+            };
           }
           // shadow;
       });
@@ -557,6 +563,7 @@ in {
             numlock_color = ${input-field.numlock_color}
             bothlock_color = ${input-field.bothlock_color}
             invert_numlock = ${boolToString input-field.invert_numlock}
+            swap_font = ${boolToString input-field.swap_font}
 
             position = ${toString input-field.position.x}, ${toString input-field.position.y}
             halign = ${input-field.halign}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -408,7 +408,7 @@ in {
               default = false;
             };
 
-            swap_font = mkOption {
+            swap_font_color = mkOption {
               description = "Whether to swap font color with inner color on some events";
               type = bool;
               default = false;
@@ -563,7 +563,7 @@ in {
             numlock_color = ${input-field.numlock_color}
             bothlock_color = ${input-field.bothlock_color}
             invert_numlock = ${boolToString input-field.invert_numlock}
-            swap_font = ${boolToString input-field.swap_font}
+            swap_font_color = ${boolToString input-field.swap_font_color}
 
             position = ${toString input-field.position.x}, ${toString input-field.position.y}
             halign = ${input-field.halign}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -100,7 +100,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "numlock_color", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "bothlock_color", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "invert_numlock", Hyprlang::INT{0});
-    m_config.addSpecialConfigValue("input-field", "swap_font", Hyprlang::INT{0});
+    m_config.addSpecialConfigValue("input-field", "swap_font_color", Hyprlang::INT{0});
     SHADOWABLE("input-field");
 
     m_config.addSpecialCategory("label", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
@@ -219,7 +219,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"numlock_color", m_config.getSpecialConfigValue("input-field", "numlock_color", k.c_str())},
                 {"bothlock_color", m_config.getSpecialConfigValue("input-field", "bothlock_color", k.c_str())},
                 {"invert_numlock", m_config.getSpecialConfigValue("input-field", "invert_numlock", k.c_str())},
-                {"swap_font", m_config.getSpecialConfigValue("input-field", "swap_font", k.c_str())},
+                {"swap_font_color", m_config.getSpecialConfigValue("input-field", "swap_font_color", k.c_str())},
                 SHADOWABLE("input-field"),
             }
         });

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -100,6 +100,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "numlock_color", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "bothlock_color", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "invert_numlock", Hyprlang::INT{0});
+    m_config.addSpecialConfigValue("input-field", "swap_font", Hyprlang::INT{0});
     SHADOWABLE("input-field");
 
     m_config.addSpecialCategory("label", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
@@ -218,6 +219,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"numlock_color", m_config.getSpecialConfigValue("input-field", "numlock_color", k.c_str())},
                 {"bothlock_color", m_config.getSpecialConfigValue("input-field", "bothlock_color", k.c_str())},
                 {"invert_numlock", m_config.getSpecialConfigValue("input-field", "invert_numlock", k.c_str())},
+                {"swap_font", m_config.getSpecialConfigValue("input-field", "swap_font", k.c_str())},
                 SHADOWABLE("input-field"),
             }
         });

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -172,6 +172,10 @@ bool CPasswordInputField::draw(const SRenderData& data) {
 
     bool forceReload = false;
 
+    if (passwordLength == 0 && g_pHyprlock->getPasswordFailedAttempts() > failedAttempts)
+        forceReload = true;
+
+    failedAttempts = g_pHyprlock->getPasswordFailedAttempts();
     passwordLength = g_pHyprlock->getPasswordBufferDisplayLen();
     checkWaiting   = g_pHyprlock->passwordCheckWaiting();
 
@@ -303,12 +307,6 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
-    // TODO: find out why failAsset not shown on empty input
-    if (passwordLength == 0 && g_pHyprlock->getPasswordFailedAttempts() > failedAttempts)
-        forceReload = true;
-
-    failedAttempts = g_pHyprlock->getPasswordFailedAttempts();
-
     return dots.currentAmount != passwordLength || fade.animated || col.animated || redrawShadow || data.opacity < 1.0 || forceReload;
 }
 
@@ -424,7 +422,7 @@ void CPasswordInputField::updateColors() {
         // some cases when events happen too quick (within transitionMs)
         // TODO: find more?
         const bool LOCKCHANGED = col.stateNum != (col.invertNum ? !g_pHyprlock->m_bNumLock : g_pHyprlock->m_bNumLock) || col.stateCaps != g_pHyprlock->m_bCapsLock;
-        const bool ANIMONCHECK = checkWaiting && TARGET == (BORDERLESS ? INNER : OUTER);
+        const bool ANIMONCHECK = checkWaiting && (TARGET == (BORDERLESS ? INNER : OUTER) || TARGET == col.fail);
 
         if (LOCKCHANGED || ANIMONCHECK) {
             SOURCE = BORDERLESS ? col.inner : col.outer;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -303,6 +303,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
+    // TODO: find out why failAsset not shown on empty input
     if (passwordLength == 0 && g_pHyprlock->getPasswordFailedAttempts() > failedAttempts)
         forceReload = true;
 

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -374,41 +374,25 @@ void CPasswordInputField::updateHiddenInputState() {
     hiddenInputState.lastQuadrant = (hiddenInputState.lastQuadrant + rand() % 3 + 1) % 4;
 }
 
+static void changeChannel(const float& source, const float& target, float& subject, const double& multi, bool& animated, const float& delta) {
+
+    if (subject != target) {
+        subject += delta * multi;
+        animated = true;
+
+        if ((source < target && subject > target) || (source > target && subject < target))
+            subject = target;
+    }
+}
+
 static void changeColor(const CColor& source, const CColor& target, CColor& subject, const double& multi, bool& animated) {
 
     const auto DELTA = target - source;
 
-    if (subject.r != target.r) {
-        subject.r += DELTA.r * multi;
-        animated = true;
-
-        if ((source.r < target.r && subject.r > target.r) || (source.r > target.r && subject.r < target.r))
-            subject.r = target.r;
-    }
-
-    if (subject.g != target.g) {
-        subject.g += DELTA.g * multi;
-        animated = true;
-
-        if ((source.g < target.g && subject.g > target.g) || (source.g > target.g && subject.g < target.g))
-            subject.g = target.g;
-    }
-
-    if (subject.b != target.b) {
-        subject.b += DELTA.b * multi;
-        animated = true;
-
-        if ((source.b < target.b && subject.b > target.b) || (source.b > target.b && subject.b < target.b))
-            subject.b = target.b;
-    }
-
-    if (subject.a != target.a) {
-        subject.a += DELTA.a * multi;
-        animated = true;
-
-        if ((source.a < target.a && subject.a > target.a) || (source.a > target.a && subject.a < target.a))
-            subject.a = target.a;
-    }
+    changeChannel(source.r, target.r, subject.r, multi, animated, DELTA.r);
+    changeChannel(source.g, target.g, subject.g, multi, animated, DELTA.g);
+    changeChannel(source.b, target.b, subject.b, multi, animated, DELTA.b);
+    changeChannel(source.a, target.a, subject.a, multi, animated, DELTA.a);
 }
 
 void CPasswordInputField::updateColors() {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -25,7 +25,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     col.caps                 = std::any_cast<Hyprlang::INT>(props.at("capslock_color"));
     col.num                  = std::any_cast<Hyprlang::INT>(props.at("numlock_color"));
     col.invertNum            = std::any_cast<Hyprlang::INT>(props.at("invert_numlock"));
-    col.swapFont             = std::any_cast<Hyprlang::INT>(props.at("swap_font"));
+    col.swapFont             = std::any_cast<Hyprlang::INT>(props.at("swap_font_color"));
     viewport                 = viewport_;
 
     auto POS__ = std::any_cast<Hyprlang::VEC2>(props.at("position"));

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -463,8 +463,8 @@ void CPasswordInputField::updateColors() {
             FTARGET = col.swapFont && BORDERLESS ? INNER : FONT;
         } else {
             // if quickly pressed after failure
-            if (BORDERLESS && col.animated && TARGET == col.fail)
-                SOURCE = col.inner;
+            if (col.animated && TARGET == col.fail)
+                SOURCE = BORDERLESS ? col.inner : col.outer;
 
             TARGET  = BORDERLESS ? INNER : OUTER;
             FTARGET = FONT;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -374,10 +374,12 @@ void CPasswordInputField::updateHiddenInputState() {
     hiddenInputState.lastQuadrant = (hiddenInputState.lastQuadrant + rand() % 3 + 1) % 4;
 }
 
-static void changeChannel(const float& source, const float& target, float& subject, const double& multi, bool& animated, const float& delta) {
+static void changeChannel(const float& source, const float& target, float& subject, const double& multi, bool& animated) {
+
+    const float DELTA = target - source;
 
     if (subject != target) {
-        subject += delta * multi;
+        subject += DELTA * multi;
         animated = true;
 
         if ((source < target && subject > target) || (source > target && subject < target))
@@ -387,12 +389,10 @@ static void changeChannel(const float& source, const float& target, float& subje
 
 static void changeColor(const CColor& source, const CColor& target, CColor& subject, const double& multi, bool& animated) {
 
-    const auto DELTA = target - source;
-
-    changeChannel(source.r, target.r, subject.r, multi, animated, DELTA.r);
-    changeChannel(source.g, target.g, subject.g, multi, animated, DELTA.g);
-    changeChannel(source.b, target.b, subject.b, multi, animated, DELTA.b);
-    changeChannel(source.a, target.a, subject.a, multi, animated, DELTA.a);
+    changeChannel(source.r, target.r, subject.r, multi, animated);
+    changeChannel(source.g, target.g, subject.g, multi, animated);
+    changeChannel(source.b, target.b, subject.b, multi, animated);
+    changeChannel(source.a, target.a, subject.a, multi, animated);
 }
 
 void CPasswordInputField::updateColors() {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -303,6 +303,11 @@ bool CPasswordInputField::draw(const SRenderData& data) {
             forceReload = true;
     }
 
+    if (passwordLength == 0 && g_pHyprlock->getPasswordFailedAttempts() > failedAttempts)
+        forceReload = true;
+
+    failedAttempts = g_pHyprlock->getPasswordFailedAttempts();
+
     return dots.currentAmount != passwordLength || fade.animated || col.animated || redrawShadow || data.opacity < 1.0 || forceReload;
 }
 
@@ -327,7 +332,7 @@ void CPasswordInputField::updateFailTex() {
 
     placeholder.failText = configFailText;
     replaceAllFail(placeholder.failText, "$FAIL", FAIL.value());
-    replaceAllFail(placeholder.failText, "$ATTEMPTS", std::to_string(g_pHyprlock->getPasswordFailedAttempts()));
+    replaceAllFail(placeholder.failText, "$ATTEMPTS", std::to_string(failedAttempts));
 
     // query
     CAsyncResourceGatherer::SPreloadRequest request;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -425,10 +425,11 @@ void CPasswordInputField::updateColors() {
         const bool ANIMONCHECK = checkWaiting && (TARGET == (BORDERLESS ? INNER : OUTER) || TARGET == col.fail);
 
         if (LOCKCHANGED || ANIMONCHECK) {
-            SOURCE = BORDERLESS ? col.inner : col.outer;
-            // to avoid an edge case when check_color set to the same as outer.
-            FSOURCE = ANIMONCHECK && OUTER == col.check ? FONT : col.font;
-            ISOURCE = ANIMONCHECK && OUTER == col.check ? INNER : col.inner;
+            const bool EQUALCOLORS = ANIMONCHECK && OUTER == col.check;
+            // to avoid throttle when check_color set to the same as outer.
+            SOURCE  = BORDERLESS ? (EQUALCOLORS ? INNER : col.inner) : col.outer;
+            FSOURCE = EQUALCOLORS ? FONT : col.font;
+            ISOURCE = EQUALCOLORS ? INNER : col.inner;
         }
     } else {
         SOURCE  = BORDERLESS ? col.inner : col.outer;
@@ -452,13 +453,13 @@ void CPasswordInputField::updateColors() {
 
             TARGET  = col.check;
             ITARGET = col.swapFont ? FONT : INNER;
-        } else if (col.both != OUTER && col.stateCaps && col.stateNum) {
+        } else if (col.stateCaps && col.stateNum && col.both != OUTER) {
             TARGET  = col.both;
             FTARGET = col.swapFont && BORDERLESS ? INNER : FONT;
-        } else if (col.caps != OUTER && col.stateCaps) {
+        } else if (col.stateCaps && col.caps != OUTER) {
             TARGET  = col.caps;
             FTARGET = col.swapFont && BORDERLESS ? INNER : FONT;
-        } else if (col.num != OUTER && col.stateNum) {
+        } else if (col.stateNum && col.num != OUTER) {
             TARGET  = col.num;
             FTARGET = col.swapFont && BORDERLESS ? INNER : FONT;
         } else {

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -31,6 +31,7 @@ class CPasswordInputField : public IWidget {
     bool        checkWaiting = false;
 
     size_t      passwordLength = 0;
+    size_t      failedAttempts = 0;
 
     Vector2D    size;
     Vector2D    pos;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -24,7 +24,7 @@ class CPasswordInputField : public IWidget {
     void        updateFade();
     void        updateFailTex();
     void        updateHiddenInputState();
-    void        updateOuter();
+    void        updateColors();
 
     bool        firstRender  = true;
     bool        redrawShadow = false;
@@ -41,8 +41,6 @@ class CPasswordInputField : public IWidget {
     std::string halign, valign, configFailText;
 
     int         outThick, rounding;
-
-    CColor      inner, font;
 
     struct {
         float                                 currentAmount  = 0;
@@ -81,18 +79,26 @@ class CPasswordInputField : public IWidget {
     } hiddenInputState;
 
     struct {
-        CColor main;
+        CColor outer;
+        CColor inner;
+        CColor font;
         CColor fail;
         CColor check;
         CColor caps;
         CColor num;
         CColor both;
+
         int    transitionMs = 0;
         bool   invertNum    = false;
         bool   animated     = false;
         bool   stateNum     = false;
         bool   stateCaps    = false;
-    } outerColor;
+        bool   swapFont     = false;
+        bool   shouldStart;
+
+        //
+        std::chrono::system_clock::time_point lastFrame;
+    } col;
 
     bool        fadeOnEmpty;
     uint64_t    fadeTimeoutMs;


### PR DESCRIPTION
- new `swap_font` option (see on videos)
- now when `outline_thickness = 0` (aka borderless) inner box color will be changed instead

this is how it looks

borderless with `swap_font`:
will change dots color to inner, that's for cases bright font looks ugly on colored box


https://github.com/hyprwm/hyprlock/assets/130279855/19d8b855-b1db-48e6-bcc0-ec33c30f458b


normal with `swap_font`:
will swap inner and font on check and failure


https://github.com/hyprwm/hyprlock/assets/130279855/c3db7b0f-e3d6-47d8-93ca-4bec19f44834


now i think we should deprecate `fail_transition` in favour of `color_transition`
how it is handled correctly?