### PR TITLE
Use getpwuid(getuid()) instead of getlogin()

### DIFF
--- a/src/core/Password.cpp
+++ b/src/core/Password.cpp
@@ -39,9 +39,9 @@ std::shared_ptr<CPassword::SVerificationResult> CPassword::verify(const std::str
 
     std::thread([this, result, pass]() {
         auto auth = [&](std::string auth) -> bool {
-            const pam_conv localConv = {conv, (void*)pass.c_str()};
-            pam_handle_t*  handle    = NULL;
-            auto uidPassword = getpwuid(getuid());
+            const pam_conv localConv   = {conv, (void*)pass.c_str()};
+            pam_handle_t*  handle      = NULL;
+            auto           uidPassword = getpwuid(getuid());
 
             int            ret = pam_start(auth.c_str(), uidPassword->pw_name, &localConv, &handle);
 

--- a/src/core/Password.cpp
+++ b/src/core/Password.cpp
@@ -41,9 +41,9 @@ std::shared_ptr<CPassword::SVerificationResult> CPassword::verify(const std::str
         auto auth = [&](std::string auth) -> bool {
             const pam_conv localConv = {conv, (void*)pass.c_str()};
             pam_handle_t*  handle    = NULL;
-            struct passwd *passwd = getpwuid(getuid());
+            auto uidPassword = getpwuid(getuid());
 
-            int            ret = pam_start(auth.c_str(), passwd->pw_name, &localConv, &handle);
+            int            ret = pam_start(auth.c_str(), uidPassword->pw_name, &localConv, &handle);
 
             if (ret != PAM_SUCCESS) {
                 result->success    = false;

--- a/src/core/Password.cpp
+++ b/src/core/Password.cpp
@@ -3,6 +3,7 @@
 #include "../helpers/Log.hpp"
 
 #include <unistd.h>
+#include <pwd.h>
 #include <security/pam_appl.h>
 #if __has_include(<security/pam_misc.h>)
 #include <security/pam_misc.h>
@@ -40,8 +41,9 @@ std::shared_ptr<CPassword::SVerificationResult> CPassword::verify(const std::str
         auto auth = [&](std::string auth) -> bool {
             const pam_conv localConv = {conv, (void*)pass.c_str()};
             pam_handle_t*  handle    = NULL;
+            struct passwd *passwd = getpwuid(getuid());
 
-            int            ret = pam_start(auth.c_str(), getlogin(), &localConv, &handle);
+            int            ret = pam_start(auth.c_str(), passwd->pw_name, &localConv, &handle);
 
             if (ret != PAM_SUCCESS) {
                 result->success    = false;

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -84,7 +84,7 @@ static std::string getTime() {
 IWidget::SFormatResult IWidget::formatString(std::string in) {
 
     auto uidPassword = getpwuid(getuid());
-    char* username = uidPassword->pw_name;;
+    char* username = uidPassword->pw_name;
 
     if (!username)
         Debug::log(ERR, "Error in formatString, username null. Errno: ", errno);

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -4,6 +4,7 @@
 #include "../../core/hyprlock.hpp"
 #include <chrono>
 #include <unistd.h>
+#include <pwd.h>
 
 #if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 190100
 #pragma comment(lib, "date-tz")
@@ -82,7 +83,8 @@ static std::string getTime() {
 
 IWidget::SFormatResult IWidget::formatString(std::string in) {
 
-    char* username = getlogin();
+    struct passwd *passwd = getpwuid(getuid());
+    char* username = passwd->pw_name;;
 
     if (!username)
         Debug::log(ERR, "Error in formatString, username null. Errno: ", errno);

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -83,8 +83,8 @@ static std::string getTime() {
 
 IWidget::SFormatResult IWidget::formatString(std::string in) {
 
-    auto uidPassword = getpwuid(getuid());
-    char* username = uidPassword->pw_name;
+    auto  uidPassword = getpwuid(getuid());
+    char* username    = uidPassword->pw_name;
 
     if (!username)
         Debug::log(ERR, "Error in formatString, username null. Errno: ", errno);

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -83,8 +83,8 @@ static std::string getTime() {
 
 IWidget::SFormatResult IWidget::formatString(std::string in) {
 
-    struct passwd *passwd = getpwuid(getuid());
-    char* username = passwd->pw_name;;
+    auto uidPassword = getpwuid(getuid());
+    char* username = uidPassword->pw_name;;
 
     if (!username)
         Debug::log(ERR, "Error in formatString, username null. Errno: ", errno);


### PR DESCRIPTION
This is to fix getlogin() returning (null) under certain systems (e.g. https://github.com/hyprwm/hyprlock/issues/203 and https://github.com/hyprwm/hyprlock/pull/104)