### PR TITLE
input-field: only render the current output on fade out callback

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -754,6 +754,17 @@ std::optional<std::string> CHyprlock::passwordLastFailReason() {
     return m_sPasswordState.lastFailReason;
 }
 
+void CHyprlock::renderOutput(const std::string& stringPort) {
+    const auto MON = std::find_if(m_vOutputs.begin(), m_vOutputs.end(), [stringPort](const auto& other) { return other->stringPort == stringPort; });
+
+    if (MON == m_vOutputs.end() || !MON->get())
+        return;
+
+    const auto PMONITOR = MON->get();
+
+    PMONITOR->sessionLockSurface->render();
+}
+
 void CHyprlock::onKey(uint32_t key, bool down) {
     if (m_bFadeStarted)
         return;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -56,6 +56,8 @@ class CHyprlock {
     bool                            passwordCheckWaiting();
     std::optional<std::string>      passwordLastFailReason();
 
+    void                            renderOutput(const std::string& stringPort);
+
     size_t                          getPasswordBufferLen();
     size_t                          getPasswordBufferDisplayLen();
     size_t                          getPasswordFailedAttempts();

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -321,7 +321,7 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
 
                 widgets[surf].emplace_back(std::make_unique<CBackground>(surf->size, surf->output, resourceID, c.values, PATH == "screenshot"));
             } else if (c.type == "input-field") {
-                widgets[surf].emplace_back(std::make_unique<CPasswordInputField>(surf->size, c.values));
+                widgets[surf].emplace_back(std::make_unique<CPasswordInputField>(surf->size, c.values, surf->output->stringPort));
             } else if (c.type == "label") {
                 widgets[surf].emplace_back(std::make_unique<CLabel>(surf->size, c.values, surf->output->stringPort));
             } else if (c.type == "image") {

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -129,15 +129,7 @@ static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {
 }
 
 void CLabel::renderSuper() {
-    const auto MON =
-        std::find_if(g_pHyprlock->m_vOutputs.begin(), g_pHyprlock->m_vOutputs.end(), [this](const auto& other) { return other->stringPort == this->outputStringPort; });
-
-    if (MON == g_pHyprlock->m_vOutputs.end() || !MON->get())
-        return;
-
-    const auto PMONITOR = MON->get();
-
-    PMONITOR->sessionLockSurface->render();
+    g_pHyprlock->renderOutput(outputStringPort);
 
     if (!pendingResourceID.empty()) /* did not consume the pending resource */
         g_pHyprlock->addTimer(std::chrono::milliseconds(100), onAssetCallbackTimer, this);

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -3,7 +3,8 @@
 #include "../../core/hyprlock.hpp"
 #include <algorithm>
 
-CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props) : shadow(this, props, viewport_) {
+CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
+    outputStringPort(output), shadow(this, props, viewport_) {
     size                     = std::any_cast<Hyprlang::VEC2>(props.at("size"));
     inner                    = std::any_cast<Hyprlang::INT>(props.at("inner_color"));
     outThick                 = std::any_cast<Hyprlang::INT>(props.at("outline_thickness"));
@@ -77,15 +78,13 @@ static void fadeOutCallback(std::shared_ptr<CTimer> self, void* data) {
     CPasswordInputField* p = (CPasswordInputField*)data;
 
     p->onFadeOutTimer();
-
-    for (auto& o : g_pHyprlock->m_vOutputs) {
-        o->sessionLockSurface->render();
-    }
 }
 
 void CPasswordInputField::onFadeOutTimer() {
     fade.allowFadeOut = true;
     fade.fadeOutTimer.reset();
+
+    g_pHyprlock->renderOutput(outputStringPort);
 }
 
 void CPasswordInputField::updateFade() {

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -14,7 +14,7 @@ struct SPreloadedAsset;
 
 class CPasswordInputField : public IWidget {
   public:
-    CPasswordInputField(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props);
+    CPasswordInputField(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props, const std::string& output);
 
     virtual bool draw(const SRenderData& data);
     void         onFadeOutTimer();
@@ -38,7 +38,7 @@ class CPasswordInputField : public IWidget {
     Vector2D    configPos;
     Vector2D    configSize;
 
-    std::string halign, valign, configFailText;
+    std::string halign, valign, configFailText, outputStringPort;
 
     int         outThick, rounding;
 


### PR DESCRIPTION
Avoids rendering multiple times on all monitors when having multiple input fields.