### PR TITLE
label: add `$LAYOUT` variable

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -675,6 +675,11 @@ static void handleKeyboardModifiers(void* data, wl_keyboard* wl_keyboard, uint s
     if (!g_pHyprlock->m_pXKBState)
         return;
 
+    if (group != g_pHyprlock->m_uiActiveLayout) {
+        g_pHyprlock->m_uiActiveLayout = group;
+        forceUpdateTimers();
+    }
+
     xkb_state_update_mask(g_pHyprlock->m_pXKBState, mods_depressed, mods_latched, mods_locked, 0, 0, group);
 }
 

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -79,6 +79,8 @@ class CHyprlock {
     xkb_keymap*                     m_pXKBKeymap  = nullptr;
     xkb_state*                      m_pXKBState   = nullptr;
 
+    xkb_layout_index_t              m_uiActiveLayout = 0;
+
     bool                            m_bTerminate = false;
 
     bool                            m_bLocked = false;

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -72,6 +72,27 @@ static void replaceAllAttempts(std::string& str) {
     }
 }
 
+static void replaceAllLayout(std::string& str) {
+
+    const auto        LAYOUTIDX  = g_pHyprlock->m_uiActiveLayout;
+    const auto        LAYOUTNAME = xkb_keymap_layout_get_name(g_pHyprlock->m_pXKBKeymap, LAYOUTIDX);
+    const std::string STR        = LAYOUTNAME ? LAYOUTNAME : "error";
+    size_t            pos        = 0;
+
+    while ((pos = str.find("$LAYOUT", pos)) != std::string::npos) {
+        if (str.substr(pos, 8).ends_with('[') && str.substr(pos).contains(']')) {
+            const std::string REPL = str.substr(pos + 8, str.find_first_of(']', pos) - 8 - pos);
+            const CVarList    LANGS(REPL);
+            const std::string LANG = LANGS[LAYOUTIDX].empty() ? STR : LANGS[LAYOUTIDX];
+            str.replace(pos, 9 + REPL.length(), LANG);
+            pos += LANG.length();
+        } else {
+            str.replace(pos, 7, STR);
+            pos += STR.length();
+        }
+    }
+}
+
 static std::string getTime() {
     const auto current_zone = std::chrono::current_zone();
     const auto HHMMSS       = std::chrono::hh_mm_ss{current_zone->to_local(std::chrono::system_clock::now()) -
@@ -106,6 +127,11 @@ IWidget::SFormatResult IWidget::formatString(std::string in) {
 
     if (in.contains("$ATTEMPTS")) {
         replaceAllAttempts(in);
+        result.allowForceUpdate = true;
+    }
+
+    if (in.contains("$LAYOUT")) {
+        replaceAllLayout(in);
         result.allowForceUpdate = true;
     }
 

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -83,7 +83,7 @@ static void replaceAllLayout(std::string& str) {
         if (str.substr(pos, 8).ends_with('[') && str.substr(pos).contains(']')) {
             const std::string REPL = str.substr(pos + 8, str.find_first_of(']', pos) - 8 - pos);
             const CVarList    LANGS(REPL);
-            const std::string LANG = LANGS[LAYOUTIDX].empty() ? STR : LANGS[LAYOUTIDX];
+            const std::string LANG = LANGS[LAYOUTIDX].empty() ? STR : LANGS[LAYOUTIDX] == "!" ? "" : LANGS[LAYOUTIDX];
             str.replace(pos, 9 + REPL.length(), LANG);
             pos += LANG.length();
         } else {


### PR DESCRIPTION
supports format `$LAYOUT[en,РУС,anystring]`, basically same as in `hyprland.conf` or swayconfig can be used for short names

closes #162


https://github.com/hyprwm/hyprlock/assets/130279855/3baecb0e-8679-4fa2-9c9b-58117bd262c3



not `$LANG` because currently normal env vars are expanded, and LANG is a common one

if (i hope when) #205 get merged, this could be added also as placeholder var

one minor issue, when `XDG_CURRENT_DESKTOP` is not Hyprland, if shadows are enabled for the label and hyprlock launched not with default (0) layout, it seems like shadows applied multiple times for first time, when layout switched - all ok