### PR TITLE
Nix/HM module: empty defaults for images and labels

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -228,9 +228,7 @@ in {
           };
         };
       });
-      default = [
-        {}
-      ];
+      default = [];
     };
 
     input-fields = mkOption {
@@ -484,9 +482,7 @@ in {
           }
           // shadow;
       });
-      default = [
-        {}
-      ];
+      default = [];
     };
   };
 


### PR DESCRIPTION
Defaults for backgrounds and input-fields make sense.
Don't want it to generate a config with an image that does not exist. It is reasonable to use hyprlock without labels and images I think.