### PR TITLE
config: add option to ignore empty input

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -30,7 +30,8 @@ static std::string getMainConfigPath() {
     return getConfigDir() + "/hypr/hyprlock.conf";
 }
 
-CConfigManager::CConfigManager(std::string configPath) : m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = configPath.empty()}) {
+CConfigManager::CConfigManager(std::string configPath) :
+    m_config(configPath.empty() ? getMainConfigPath().c_str() : configPath.c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = configPath.empty()}) {
     configCurrentPath = configPath.empty() ? getMainConfigPath() : configPath;
 }
 
@@ -47,7 +48,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:grace", Hyprlang::INT{0});
     m_config.addConfigValue("general:no_fade_in", Hyprlang::INT{0});
     m_config.addConfigValue("general:no_fade_out", Hyprlang::INT{0});
-
+    m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("background", "monitor", Hyprlang::STRING{""});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -814,6 +814,14 @@ void CHyprlock::onKey(uint32_t key, bool down) {
             }
         } else if (SYM == XKB_KEY_Return || SYM == XKB_KEY_KP_Enter) {
             Debug::log(LOG, "Authenticating");
+
+            static auto* const PIGNOREEMPTY = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:ignore_empty_input");
+
+            if (m_sPasswordState.passBuffer.empty() && **PIGNOREEMPTY) {
+                Debug::log(LOG, "Ignoring empty input");
+                return;
+            }
+
             m_sPasswordState.result = g_pPassword->verify(m_sPasswordState.passBuffer);
         } else if (SYM == XKB_KEY_Escape) {
             Debug::log(LOG, "Clearing password buffer");


### PR DESCRIPTION
Added an `ignore_empty_input` configuration option, for users like myself who often use the enter key to wake the screen.