### PR TITLE
label: destroy texture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+.cache
+.direnv
+.envrc
 .vscode/
 build/
-protocols/*.h
+compile_commands.json
 protocols/*.c
+protocols/*.h

--- a/src/renderer/Texture.cpp
+++ b/src/renderer/Texture.cpp
@@ -4,6 +4,10 @@ CTexture::CTexture() {
     // naffin'
 }
 
+CTexture::~CTexture() {
+    destroyTexture();
+}
+
 void CTexture::destroyTexture() {
     if (m_bAllocated) {
         glDeleteTextures(1, &m_iTexID);

--- a/src/renderer/Texture.hpp
+++ b/src/renderer/Texture.hpp
@@ -13,6 +13,7 @@ enum TEXTURETYPE {
 class CTexture {
   public:
     CTexture();
+    ~CTexture();
 
     void        destroyTexture();
     void        allocate();


### PR DESCRIPTION
Fixes #223

Tested it a bit. Seems to fix it.
Also sneaked in some `.gitignore` additions.