### PR TITLE
widget: fix valign bottom

### DIFF
--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -32,7 +32,7 @@ Vector2D IWidget::posFromHVAlign(const Vector2D& viewport, const Vector2D& size,
     else if (valign == "top")
         pos.y += viewport.y - size.y;
     else if (valign == "bottom")
-        pos.y += size.y;
+        pos.y += 0;
     else if (valign != "none")
         Debug::log(ERR, "IWidget: invalid halign {}", halign);
 

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -34,7 +34,7 @@ Vector2D IWidget::posFromHVAlign(const Vector2D& viewport, const Vector2D& size,
     else if (valign == "bottom")
         pos.y += 0;
     else if (valign != "none")
-        Debug::log(ERR, "IWidget: invalid halign {}", halign);
+        Debug::log(ERR, "IWidget: invalid valign {}", valign);
 
     return pos;
 }


### PR DESCRIPTION
no need to correct for the size since bottom is 0

people probably already have some negative values for widgets that at the bottom. they would need to adjust.