### PR TITLE
image: add reload options

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -225,6 +225,18 @@ in {
             default = 0.0;
           };
 
+          reload_time = mkOption {
+            description = "Interval in seconds between reloading the image";
+            type = int;
+            default = -1;
+          };
+
+          reload_cmd = mkOption {
+            description = "Command to obtain new path";
+            type = str;
+            default = "";
+          };
+
           position = {
             x = mkOption {
               description = "X position of the image";
@@ -557,6 +569,8 @@ in {
             border_size = ${toString image.border_size}
             border_color = ${image.border_color}
             rotate = ${toString image.rotate}
+            reload_time = ${toString image.reload_time}
+            reload_cmd = ${image.reload_cmd}
 
             position = ${toString image.position.x}, ${toString image.position.y}
             halign = ${image.halign}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -73,6 +73,8 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("image", "halign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("image", "valign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("image", "rotate", Hyprlang::FLOAT{0});
+    m_config.addSpecialConfigValue("image", "reload_time", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("image", "reload_cmd", Hyprlang::STRING{""});
     SHADOWABLE("image");
 
     m_config.addSpecialCategory("input-field", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
@@ -184,6 +186,8 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"halign", m_config.getSpecialConfigValue("image", "halign", k.c_str())},
                 {"valign", m_config.getSpecialConfigValue("image", "valign", k.c_str())},
                 {"rotate", m_config.getSpecialConfigValue("image", "rotate", k.c_str())},
+                {"reload_time", m_config.getSpecialConfigValue("image", "reload_time", k.c_str())},
+                {"reload_cmd", m_config.getSpecialConfigValue("image", "reload_cmd", k.c_str())},
                 SHADOWABLE("image"),
             }
         });

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -56,6 +56,7 @@ class CAsyncResourceGatherer {
 
     void        asyncAssetSpinLock();
     void        renderText(const SPreloadRequest& rq);
+    void        renderImage(const SPreloadRequest& rq);
 
     struct {
         std::condition_variable      loopGuard;

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -1,6 +1,63 @@
 #include "Image.hpp"
 #include "../Renderer.hpp"
+#include "../../core/hyprlock.hpp"
 #include <cmath>
+
+CImage::~CImage() {
+    imageTimer->cancel();
+    imageTimer.reset();
+}
+
+static void onTimer(std::shared_ptr<CTimer> self, void* data) {
+    const auto PIMAGE = (CImage*)data;
+
+    PIMAGE->onTimerUpdate();
+    PIMAGE->plantTimer();
+}
+
+static void onAssetCallback(void* data) {
+    const auto PIMAGE = (CImage*)data;
+    PIMAGE->renderSuper();
+}
+
+std::string CImage::getUniqueResourceId() {
+    return std::string{"image:"} + std::to_string((uintptr_t)this) + ",path:" + path + ",time:" + std::to_string(std::chrono::system_clock::now().time_since_epoch().count());
+}
+
+void CImage::onTimerUpdate() {
+
+    if (!pendingResourceID.empty())
+        return;
+
+    if (!reloadCommand.empty()) {
+        path = g_pHyprlock->spawnSync(reloadCommand);
+
+        if (path.ends_with('\n'))
+            path.pop_back();
+
+        if (path.empty())
+            return;
+    }
+
+    // request new
+    request.id        = getUniqueResourceId();
+    pendingResourceID = request.id;
+    request.asset     = path;
+    request.type      = CAsyncResourceGatherer::eTargetType::TARGET_IMAGE;
+
+    request.callback     = onAssetCallback;
+    request.callbackData = this;
+
+    g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);
+}
+
+void CImage::plantTimer() {
+
+    if (reloadTime == 0) {
+        imageTimer = g_pHyprlock->addTimer(std::chrono::hours(1), onTimer, this, true);
+    } else if (reloadTime > 0)
+        imageTimer = g_pHyprlock->addTimer(std::chrono::seconds(reloadTime), onTimer, this, false);
+}
 
 CImage::CImage(const Vector2D& viewport_, COutput* output_, const std::string& resourceID_, const std::unordered_map<std::string, std::any>& props) :
     viewport(viewport_), resourceID(resourceID_), output(output_), shadow(this, props, viewport_) {
@@ -14,13 +71,41 @@ CImage::CImage(const Vector2D& viewport_, COutput* output_, const std::string& r
     valign   = std::any_cast<Hyprlang::STRING>(props.at("valign"));
     angle    = std::any_cast<Hyprlang::FLOAT>(props.at("rotate"));
 
+    path          = std::any_cast<Hyprlang::STRING>(props.at("path"));
+    reloadTime    = std::any_cast<Hyprlang::INT>(props.at("reload_time"));
+    reloadCommand = std::any_cast<Hyprlang::STRING>(props.at("reload_cmd"));
+
     angle = angle * M_PI / 180.0;
+
+    plantTimer();
 }
 
 bool CImage::draw(const SRenderData& data) {
 
-    if (resourceID.empty())
+    if (resourceID.empty() && pendingResourceID.empty())
         return false;
+
+    if (!pendingResourceID.empty()) {
+        auto newAsset = g_pRenderer->asyncResourceGatherer->getAssetByID(pendingResourceID);
+        if (newAsset) {
+            if (newAsset->texture.m_iType == TEXTURE_INVALID) {
+                g_pRenderer->asyncResourceGatherer->unloadAsset(newAsset);
+                pendingResourceID = "";
+
+                if (!imageFB.isAllocated())
+                    return true;
+
+            } else {
+                g_pRenderer->asyncResourceGatherer->unloadAsset(asset);
+                imageFB.release();
+
+                asset             = newAsset;
+                resourceID        = pendingResourceID;
+                pendingResourceID = "";
+                firstRender       = true;
+            }
+        }
+    }
 
     if (!asset)
         asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
@@ -54,6 +139,8 @@ bool CImage::draw(const SRenderData& data) {
         borderBox.round();
         imageFB.alloc(borderBox.w, borderBox.h, true);
         g_pRenderer->pushFb(imageFB.m_iFb);
+        glClearColor(0.0, 0.0, 0.0, 0.0);
+        glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
             g_pRenderer->renderRect(borderBox, color, ALLOWROUND ? rounding : std::min(borderBox.w, borderBox.h) / 2.0);
@@ -83,4 +170,16 @@ bool CImage::draw(const SRenderData& data) {
     g_pRenderer->renderTexture(texbox, *tex, data.opacity, 0, WL_OUTPUT_TRANSFORM_FLIPPED_180);
 
     return data.opacity < 1.0;
+}
+
+static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {
+    const auto PIMAGE = (CImage*)data;
+    PIMAGE->renderSuper();
+}
+
+void CImage::renderSuper() {
+    g_pHyprlock->renderOutput(output->stringPort);
+
+    if (!pendingResourceID.empty()) /* did not consume the pending resource */
+        g_pHyprlock->addTimer(std::chrono::milliseconds(100), onAssetCallbackTimer, this);
 }

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -22,6 +22,7 @@ static void onAssetCallback(void* data) {
 }
 
 void CImage::onTimerUpdate() {
+    const std::string OLDPATH = path;
 
     if (!reloadCommand.empty()) {
         path = g_pHyprlock->spawnSync(reloadCommand);
@@ -29,17 +30,21 @@ void CImage::onTimerUpdate() {
         if (path.ends_with('\n'))
             path.pop_back();
 
+        if (path.starts_with("file://"))
+            path = path.substr(7);
+
         if (path.empty())
             return;
     }
 
     try {
         const auto MTIME = std::filesystem::last_write_time(path);
-        if (MTIME == modificationTime)
+        if (OLDPATH == path && MTIME == modificationTime)
             return;
 
         modificationTime = MTIME;
     } catch (std::exception& e) {
+        path = OLDPATH;
         Debug::log(ERR, "{}", e.what());
         return;
     }

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -3,6 +3,8 @@
 #include "IWidget.hpp"
 #include "../../helpers/Vector2D.hpp"
 #include "../../helpers/Color.hpp"
+#include "../../core/Timer.hpp"
+#include "../AsyncResourceGatherer.hpp"
 #include "Shadowable.hpp"
 #include <string>
 #include <unordered_map>
@@ -14,26 +16,39 @@ class COutput;
 class CImage : public IWidget {
   public:
     CImage(const Vector2D& viewport, COutput* output_, const std::string& resourceID, const std::unordered_map<std::string, std::any>& props);
+    ~CImage();
 
     virtual bool draw(const SRenderData& data);
 
+    void         renderSuper();
+    void         onTimerUpdate();
+    void         plantTimer();
+
   private:
-    CFramebuffer     imageFB;
+    std::string                             getUniqueResourceId();
 
-    int              size;
-    int              rounding;
-    double           border;
-    double           angle;
-    CColor           color;
-    Vector2D         pos;
+    CFramebuffer                            imageFB;
 
-    std::string      halign, valign;
+    int                                     size;
+    int                                     rounding;
+    double                                  border;
+    double                                  angle;
+    CColor                                  color;
+    Vector2D                                pos;
 
-    bool             firstRender = true;
+    std::string                             halign, valign, path;
 
-    Vector2D         viewport;
-    std::string      resourceID;
-    SPreloadedAsset* asset  = nullptr;
-    COutput*         output = nullptr;
-    CShadowable      shadow;
+    bool                                    firstRender = true;
+
+    int                                     reloadTime;
+    std::string                             reloadCommand;
+    std::shared_ptr<CTimer>                 imageTimer;
+    CAsyncResourceGatherer::SPreloadRequest request;
+
+    Vector2D                                viewport;
+    std::string                             resourceID;
+    std::string                             pendingResourceID; // if reloading image
+    SPreloadedAsset*                        asset  = nullptr;
+    COutput*                                output = nullptr;
+    CShadowable                             shadow;
 };

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -7,6 +7,7 @@
 #include "../AsyncResourceGatherer.hpp"
 #include "Shadowable.hpp"
 #include <string>
+#include <filesystem>
 #include <unordered_map>
 #include <any>
 
@@ -25,9 +26,6 @@ class CImage : public IWidget {
     void         plantTimer();
 
   private:
-    std::uintmax_t                          getFileSize(const std::string& path);
-    std::string                             getUniqueResourceId();
-
     CFramebuffer                            imageFB;
 
     int                                     size;
@@ -41,9 +39,9 @@ class CImage : public IWidget {
 
     bool                                    firstRender = true;
 
-    std::uintmax_t                          fileSize;
     int                                     reloadTime;
     std::string                             reloadCommand;
+    std::filesystem::file_time_type         modificationTime;
     std::shared_ptr<CTimer>                 imageTimer;
     CAsyncResourceGatherer::SPreloadRequest request;
 

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -25,6 +25,7 @@ class CImage : public IWidget {
     void         plantTimer();
 
   private:
+    std::uintmax_t                          getFileSize(const std::string& path);
     std::string                             getUniqueResourceId();
 
     CFramebuffer                            imageFB;
@@ -40,6 +41,7 @@ class CImage : public IWidget {
 
     bool                                    firstRender = true;
 
+    std::uintmax_t                          fileSize;
     int                                     reloadTime;
     std::string                             reloadCommand;
     std::shared_ptr<CTimer>                 imageTimer;


### PR DESCRIPTION
close #225

- `reload_time` -  interval in secs to reload, if 0 can be reloaded with `SIGUSR2`
- `reload_cmd` - command to obtain new path, if empty reuse default one

not sure with option names (as always)

considering that only png is supported, I guess main usecase should be converting and then `killall -USR2` in script, if album arts for example

https://github.com/hyprwm/hyprlock/assets/130279855/5e910e96-ca8a-428f-b27e-4d422a7cab6e

mostly copied from label widget