### PR TITLE
input-field: fade in when checkWaiting is true

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -94,15 +94,17 @@ void CPasswordInputField::updateFade() {
         return;
     }
 
-    if (passwordLength > 0 && fade.allowFadeOut)
+    const bool INPUTUSED = passwordLength > 0 || checkWaiting;
+
+    if (INPUTUSED && fade.allowFadeOut)
         fade.allowFadeOut = false;
 
-    if (passwordLength > 0 && fade.fadeOutTimer.get()) {
+    if (INPUTUSED && fade.fadeOutTimer.get()) {
         fade.fadeOutTimer->cancel();
         fade.fadeOutTimer.reset();
     }
 
-    if (passwordLength == 0 && fade.a != 0.0 && (!fade.animated || fade.appearing)) {
+    if (!INPUTUSED && fade.a != 0.0 && (!fade.animated || fade.appearing)) {
         if (fade.allowFadeOut || fadeTimeoutMs == 0) {
             fade.a            = 1.0;
             fade.animated     = true;
@@ -113,7 +115,7 @@ void CPasswordInputField::updateFade() {
             fade.fadeOutTimer = g_pHyprlock->addTimer(std::chrono::milliseconds(fadeTimeoutMs), fadeOutCallback, this);
     }
 
-    if (passwordLength > 0 && fade.a != 1.0 && (!fade.animated || !fade.appearing)) {
+    if (INPUTUSED && fade.a != 1.0 && (!fade.animated || !fade.appearing)) {
         fade.a         = 0.0;
         fade.animated  = true;
         fade.appearing = true;


### PR DESCRIPTION
This makes it so that pressing enter with an empty input field makes the input field fade in and it will only start to fade out when `checkWaiting` is false.

Checked and it does not conflict with #205

Closes #250