### PR TITLE
core: use --immediate for attemptRestoreOnDeath

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -1049,5 +1049,5 @@ void CHyprlock::attemptRestoreOnDeath() {
     ofs.close();
 
     spawnSync("hyprctl keyword misc:allow_session_lock_restore true");
-    spawnAsync("sleep 2 && hyprlock & disown");
+    spawnAsync("sleep 2 && hyprlock --immediate & disown");
 }


### PR DESCRIPTION
Probably fixes the "unlocks" part of #269 

Kind of an important fix so I will tag @vaxerski.