### PR TITLE
input-field: increase default fade_timeout

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -437,7 +437,7 @@ in {
             fade_timeout = mkOption {
               description = "Milliseconds before the input field should be faded (0 to fade immediately)";
               type = int;
-              default = 1000;
+              default = 2000;
             };
 
             placeholder_text = mkOption {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -103,7 +103,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "dots_spacing", Hyprlang::FLOAT{0.2});
     m_config.addSpecialConfigValue("input-field", "dots_rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
-    m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{1000});
+    m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
     m_config.addSpecialConfigValue("input-field", "halign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("input-field", "valign", Hyprlang::STRING{"center"});


### PR DESCRIPTION
Duration of the fail text getting displayed is 1 sec as well. So now switching back to the normal placeholder text and fading out does not happen at the same time.