### PR TITLE
core: add key repeat for backspace and make del clear the input

### DIFF
--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -54,13 +54,13 @@ class CHyprlock {
     std::string                     spawnSync(const std::string& cmd);
 
     void                            onKey(uint32_t key, bool down);
+    void                            handleKeySym(xkb_keysym_t sym);
     void                            startKeyRepeat(xkb_keysym_t sym);
     void                            repeatKey(xkb_keysym_t sym);
     void                            onPasswordCheckTimer();
     void                            clearPasswordBuffer();
     bool                            passwordCheckWaiting();
     std::optional<std::string>      passwordLastFailReason();
-    void                            doBackspace();
 
     void                            renderOutput(const std::string& stringPort);
 

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -54,10 +54,13 @@ class CHyprlock {
     std::string                     spawnSync(const std::string& cmd);
 
     void                            onKey(uint32_t key, bool down);
+    void                            startKeyRepeat(xkb_keysym_t sym);
+    void                            repeatKey(xkb_keysym_t sym);
     void                            onPasswordCheckTimer();
     void                            clearPasswordBuffer();
     bool                            passwordCheckWaiting();
     std::optional<std::string>      passwordLastFailReason();
+    void                            doBackspace();
 
     void                            renderOutput(const std::string& stringPort);
 
@@ -96,6 +99,8 @@ class CHyprlock {
     std::chrono::system_clock::time_point m_tGraceEnds;
     std::chrono::system_clock::time_point m_tFadeEnds;
     Vector2D                              m_vLastEnterCoords = {};
+
+    std::shared_ptr<CTimer>               m_pKeyRepeatTimer = nullptr;
 
     std::vector<std::unique_ptr<COutput>> m_vOutputs;
     std::vector<std::shared_ptr<CTimer>>  getTimers();

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -85,8 +85,8 @@ class CHyprlock {
     xkb_keymap*                     m_pXKBKeymap  = nullptr;
     xkb_state*                      m_pXKBState   = nullptr;
 
-    int32_t                         m_iKeebRepeatRate  = 0;
-    int32_t                         m_iKeebRepeatDelay = 0;
+    int32_t                         m_iKeebRepeatRate  = 25;
+    int32_t                         m_iKeebRepeatDelay = 600;
 
     xkb_layout_index_t              m_uiActiveLayout = 0;
 

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -85,6 +85,9 @@ class CHyprlock {
     xkb_keymap*                     m_pXKBKeymap  = nullptr;
     xkb_state*                      m_pXKBState   = nullptr;
 
+    int32_t                         m_iKeebRepeatRate  = 0;
+    int32_t                         m_iKeebRepeatDelay = 0;
+
     xkb_layout_index_t              m_uiActiveLayout = 0;
 
     bool                            m_bTerminate = false;


### PR DESCRIPTION
Allows users to hold backspace to delete the password buffer.
I feel like using a shortcut to clear the entire buffer is superior, but oh well.

A minor thing to consider:
If you press down a key, press&hold backspace after that and then release the first key, that will cancel the timer. Idk if we want to make sure that the key we are releasing is a repeatable one or not and only cancel if it is. That would fix that.

Also we don't necessarily need to move sym into a separate function, but it made more sense to me like that.

Closes #263