### PR TITLE
label: add `text_align` option for multi-line text

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -561,6 +561,12 @@ in {
               default = "Hi there, $USER";
             };
 
+            text_align = mkOption {
+              description = "Horizontal alignment of multi-line text";
+              type = str;
+              default = "";
+            };
+
             color = mkOption {
               description = "Color of the label";
               type = str;
@@ -729,6 +735,7 @@ in {
           label {
             monitor = ${label.monitor}
             text = ${label.text}
+            text_align = ${label.text_align}
             color = ${label.color}
             font_size = ${toString label.font_size}
             font_family = ${label.font_family}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -132,6 +132,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("label", "halign", Hyprlang::STRING{"none"});
     m_config.addSpecialConfigValue("label", "valign", Hyprlang::STRING{"none"});
     m_config.addSpecialConfigValue("label", "rotate", Hyprlang::FLOAT{0});
+    m_config.addSpecialConfigValue("label", "text_align", Hyprlang::STRING{""});
     SHADOWABLE("label");
 
     m_config.registerHandler(&::handleSource, "source", {false});
@@ -288,6 +289,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"halign", m_config.getSpecialConfigValue("label", "halign", k.c_str())},
                 {"valign", m_config.getSpecialConfigValue("label", "valign", k.c_str())},
                 {"rotate", m_config.getSpecialConfigValue("label", "rotate", k.c_str())},
+                {"text_align", m_config.getSpecialConfigValue("label", "text_align", k.c_str())},
                 SHADOWABLE("label"),
             }
         });

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -244,6 +244,17 @@ void CAsyncResourceGatherer::renderText(const SPreloadRequest& rq) {
     pango_layout_set_font_description(layout, fontDesc);
     pango_font_description_free(fontDesc);
 
+    if (rq.props.contains("text_align")) {
+        const std::string TEXTALIGN = std::any_cast<std::string>(rq.props.at("text_align"));
+        PangoAlignment    align     = PANGO_ALIGN_LEFT;
+        if (TEXTALIGN == "center")
+            align = PANGO_ALIGN_CENTER;
+        else if (TEXTALIGN == "right")
+            align = PANGO_ALIGN_RIGHT;
+
+        pango_layout_set_alignment(layout, align);
+    }
+
     PangoAttrList* attrList = nullptr;
     GError*        gError   = nullptr;
     char*          buf      = nullptr;

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -61,6 +61,7 @@ void CLabel::plantTimer() {
 CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
     outputStringPort(output), shadow(this, props, viewport_) {
     labelPreFormat         = std::any_cast<Hyprlang::STRING>(props.at("text"));
+    std::string textAlign  = std::any_cast<Hyprlang::STRING>(props.at("text_align"));
     std::string fontFamily = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
     CColor      labelColor = std::any_cast<Hyprlang::INT>(props.at("color"));
     int         fontSize   = std::any_cast<Hyprlang::INT>(props.at("font_size"));
@@ -75,6 +76,9 @@ CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, 
     request.props["color"]       = labelColor;
     request.props["font_size"]   = fontSize;
     request.props["cmd"]         = label.cmd;
+
+    if (!textAlign.empty())
+        request.props["text_align"] = textAlign;
 
     g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);
 


### PR DESCRIPTION
instead of messing with multiple labels with its' own alignments and shadow FBs, let pango do the job

there are more fancy stuff that could be added, like justify and ellipsize with explicit width and height, but I don't think it is relevant in context of a locker

or is it?