### PR TITLE
label: add `font_features` support

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -579,6 +579,12 @@ in {
               default = "Noto Sans";
             };
 
+            font_features = mkOption {
+              description = "Font features to apply on the label";
+              type = str;
+              default = "";
+            };
+
             rotate = mkOption {
               description = "Label rotation angle";
               type = float;
@@ -732,6 +738,7 @@ in {
             color = ${label.color}
             font_size = ${toString label.font_size}
             font_family = ${label.font_family}
+            font_features = ${label.font_features}
             rotate = ${toString label.rotate}
             shadow_passes = ${toString label.shadow_passes}
             shadow_size = ${toString label.shadow_size}

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -129,6 +129,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("label", "font_size", Hyprlang::INT{16});
     m_config.addSpecialConfigValue("label", "text", Hyprlang::STRING{"Sample Text"});
     m_config.addSpecialConfigValue("label", "font_family", Hyprlang::STRING{"Sans"});
+    m_config.addSpecialConfigValue("label", "font_features", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("label", "halign", Hyprlang::STRING{"none"});
     m_config.addSpecialConfigValue("label", "valign", Hyprlang::STRING{"none"});
     m_config.addSpecialConfigValue("label", "rotate", Hyprlang::FLOAT{0});
@@ -284,6 +285,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"color", m_config.getSpecialConfigValue("label", "color", k.c_str())},
                 {"font_size", m_config.getSpecialConfigValue("label", "font_size", k.c_str())},
                 {"font_family", m_config.getSpecialConfigValue("label", "font_family", k.c_str())},
+                {"font_features", m_config.getSpecialConfigValue("label", "font_features", k.c_str())},
                 {"text", m_config.getSpecialConfigValue("label", "text", k.c_str())},
                 {"halign", m_config.getSpecialConfigValue("label", "halign", k.c_str())},
                 {"valign", m_config.getSpecialConfigValue("label", "valign", k.c_str())},

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -227,11 +227,12 @@ void CAsyncResourceGatherer::renderText(const SPreloadRequest& rq) {
     target.type = TARGET_IMAGE; /* text is just an image lol */
     target.id   = rq.id;
 
-    const int         FONTSIZE   = rq.props.contains("font_size") ? std::any_cast<int>(rq.props.at("font_size")) : 16;
-    const CColor      FONTCOLOR  = rq.props.contains("color") ? std::any_cast<CColor>(rq.props.at("color")) : CColor(1.0, 1.0, 1.0, 1.0);
-    const std::string FONTFAMILY = rq.props.contains("font_family") ? std::any_cast<std::string>(rq.props.at("font_family")) : "Sans";
-    const bool        ISCMD      = rq.props.contains("cmd") ? std::any_cast<bool>(rq.props.at("cmd")) : false;
-    const std::string TEXT       = ISCMD ? g_pHyprlock->spawnSync(rq.asset) : rq.asset;
+    const int         FONTSIZE     = rq.props.contains("font_size") ? std::any_cast<int>(rq.props.at("font_size")) : 16;
+    const CColor      FONTCOLOR    = rq.props.contains("color") ? std::any_cast<CColor>(rq.props.at("color")) : CColor(1.0, 1.0, 1.0, 1.0);
+    const std::string FONTFAMILY   = rq.props.contains("font_family") ? std::any_cast<std::string>(rq.props.at("font_family")) : "Sans";
+    const std::string FONTFEATURES = rq.props.contains("font_features") ? std::any_cast<std::string>(rq.props.at("font_features")) : "";
+    const bool        ISCMD        = rq.props.contains("cmd") ? std::any_cast<bool>(rq.props.at("cmd")) : false;
+    const std::string TEXT         = ISCMD ? g_pHyprlock->spawnSync(rq.asset) : rq.asset;
 
     auto              CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 1920, 1080 /* dummy value */);
     auto              CAIRO        = cairo_create(CAIROSURFACE);
@@ -259,6 +260,7 @@ void CAsyncResourceGatherer::renderText(const SPreloadRequest& rq) {
         attrList = pango_attr_list_new();
 
     pango_attr_list_insert(attrList, pango_attr_scale_new(1));
+    pango_attr_list_insert(attrList, pango_attr_font_features_new(FONTFEATURES.c_str()));
     pango_layout_set_attributes(layout, attrList);
     pango_attr_list_unref(attrList);
 

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -60,21 +60,23 @@ void CLabel::plantTimer() {
 
 CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
     outputStringPort(output), shadow(this, props, viewport_) {
-    labelPreFormat         = std::any_cast<Hyprlang::STRING>(props.at("text"));
-    std::string fontFamily = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
-    CColor      labelColor = std::any_cast<Hyprlang::INT>(props.at("color"));
-    int         fontSize   = std::any_cast<Hyprlang::INT>(props.at("font_size"));
+    labelPreFormat           = std::any_cast<Hyprlang::STRING>(props.at("text"));
+    std::string fontFamily   = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
+    std::string fontFeatures = std::any_cast<Hyprlang::STRING>(props.at("font_features"));
+    CColor      labelColor   = std::any_cast<Hyprlang::INT>(props.at("color"));
+    int         fontSize     = std::any_cast<Hyprlang::INT>(props.at("font_size"));
 
     label = formatString(labelPreFormat);
 
-    request.id                   = getUniqueResourceId();
-    resourceID                   = request.id;
-    request.asset                = label.formatted;
-    request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-    request.props["font_family"] = fontFamily;
-    request.props["color"]       = labelColor;
-    request.props["font_size"]   = fontSize;
-    request.props["cmd"]         = label.cmd;
+    request.id                     = getUniqueResourceId();
+    resourceID                     = request.id;
+    request.asset                  = label.formatted;
+    request.type                   = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
+    request.props["font_family"]   = fontFamily;
+    request.props["font_features"] = fontFeatures;
+    request.props["color"]         = labelColor;
+    request.props["font_size"]     = fontSize;
+    request.props["cmd"]           = label.cmd;
 
     g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);
 


### PR DESCRIPTION
add a config option to apply stylistic sets to the `font_family`

config has a css sytax. eg `font_features = ss01, ss03` or `font_features = ss01 1, ss02 0, ss03 1`