### PR TITLE
NVIDIA stutter fix

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -399,7 +399,7 @@ void CHyprlock::run() {
 
     std::thread pollThr([this, &pollfds]() {
         while (!m_bTerminate) {
-            int ret = poll(pollfds, 1, 5000 /* 5 seconds, reasonable. Just in case we need to terminate and the signal fails */);
+            int ret = poll(pollfds, 1, 16 /* 16 ms, or 60 times per second */);
 
             if (ret < 0) {
                 if (errno == EINTR)
@@ -460,7 +460,7 @@ void CHyprlock::run() {
     while (!m_bTerminate) {
         std::unique_lock lk(m_sLoopState.eventRequestMutex);
         if (m_sLoopState.event == false)
-            m_sLoopState.loopCV.wait_for(lk, std::chrono::milliseconds(5000), [this] { return m_sLoopState.event; });
+            m_sLoopState.loopCV.wait_for(lk, std::chrono::milliseconds(16), [this] { return m_sLoopState.event; });
 
         if (!NOFADEOUT && m_bFadeStarted && std::chrono::system_clock::now() > m_tFadeEnds) {
             releaseSessionLock();


### PR DESCRIPTION
Not sure what are the implications of this on the performance, but haven't noticed any slowdown.

Changing the polling rate from 5000 ms to 16 ms (60 times per second) fixes the stutter issues when running hyprlock.

Without this, hyprlock is unusable and updates once every few seconds when not moving the mouse and causing wayland poll events