### PR TITLE
Add support for JPEG and WEBP background images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 compile_commands.json
 protocols/*.c
 protocols/*.h
+*.kdev4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ message(STATUS "Checking deps...")
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(OpenGL REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols wayland-egl hyprlang>=0.4.0 egl opengl xkbcommon cairo pangocairo libdrm gbm)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols wayland-egl hyprlang>=0.4.0 egl opengl xkbcommon libjpeg libwebp libmagic cairo pangocairo libdrm gbm)
 
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 add_executable(hyprlock ${SRCFILES})

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,8 +4,11 @@
   cmake,
   pkg-config,
   cairo,
+  file,
   libdrm,
   libGL,
+  libjpeg,
+  libwebp,
   libxkbcommon,
   mesa,
   hyprlang,
@@ -28,8 +31,11 @@ stdenv.mkDerivation {
 
   buildInputs = [
     cairo
+    file
     libdrm
     libGL
+    libjpeg
+    libwebp
     libxkbcommon
     mesa
     hyprlang

--- a/src/helpers/Jpeg.cpp
+++ b/src/helpers/Jpeg.cpp
@@ -1,0 +1,75 @@
+#include "Jpeg.hpp"
+#include "Log.hpp"
+
+#include <jpeglib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+cairo_surface_t* JPEG::createSurfaceFromJPEG(const std::filesystem::path& path) {
+
+    if (!std::filesystem::exists(path)) {
+        Debug::log(ERR, "createSurfaceFromJPEG: file doesn't exist??");
+        return nullptr;
+    }
+
+    if (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__) {
+        Debug::log(CRIT, "tried to load a jpeg on a big endian system! ping vaxry he is lazy.");
+        return nullptr;
+    }
+
+    void*       imageRawData;
+    struct stat fileInfo = {};
+    const auto  FD       = open(path.c_str(), O_RDONLY);
+
+    fstat(FD, &fileInfo);
+
+    imageRawData = malloc(fileInfo.st_size);
+
+    read(FD, imageRawData, fileInfo.st_size);
+    close(FD);
+
+    // now the JPEG is in the memory
+
+    jpeg_decompress_struct decompressStruct = {};
+    jpeg_error_mgr         errorManager     = {};
+
+    decompressStruct.err = jpeg_std_error(&errorManager);
+    jpeg_create_decompress(&decompressStruct);
+    jpeg_mem_src(&decompressStruct, (const unsigned char*)imageRawData, fileInfo.st_size);
+    jpeg_read_header(&decompressStruct, true);
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    decompressStruct.out_color_space = JCS_EXT_BGRA;
+#else
+    decompressStruct.out_color_space = JCS_EXT_ARGB;
+#endif
+
+    // decompress
+    jpeg_start_decompress(&decompressStruct);
+
+    auto cairoSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, decompressStruct.output_width, decompressStruct.output_height);
+
+    if (cairo_surface_status(cairoSurface) != CAIRO_STATUS_SUCCESS) {
+        Debug::log(ERR, "createSurfaceFromJPEG: Cairo Failed (?)");
+        return nullptr;
+    }
+
+    const auto CAIRODATA   = cairo_image_surface_get_data(cairoSurface);
+    const auto CAIROSTRIDE = cairo_image_surface_get_stride(cairoSurface);
+    JSAMPROW   rowRead;
+
+    while (decompressStruct.output_scanline < decompressStruct.output_height) {
+        const auto PROW = CAIRODATA + (decompressStruct.output_scanline * CAIROSTRIDE);
+        rowRead         = PROW;
+        jpeg_read_scanlines(&decompressStruct, &rowRead, 1);
+    }
+
+    cairo_surface_mark_dirty(cairoSurface);
+    cairo_surface_set_mime_data(cairoSurface, CAIRO_MIME_TYPE_JPEG, (const unsigned char*)imageRawData, fileInfo.st_size, free, imageRawData);
+    jpeg_finish_decompress(&decompressStruct);
+    jpeg_destroy_decompress(&decompressStruct);
+
+    return cairoSurface;
+}

--- a/src/helpers/Jpeg.hpp
+++ b/src/helpers/Jpeg.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <filesystem>
+#include <cairo/cairo.h>
+
+namespace JPEG {
+    cairo_surface_t* createSurfaceFromJPEG(const std::filesystem::path&);
+};

--- a/src/helpers/Webp.cpp
+++ b/src/helpers/Webp.cpp
@@ -1,0 +1,85 @@
+#include "Webp.hpp"
+#include "Log.hpp"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <webp/decode.h>
+
+cairo_surface_t* WEBP::createSurfaceFromWEBP(const std::filesystem::path& path) {
+
+    if (!std::filesystem::exists(path)) {
+        Debug::log(ERR, "createSurfaceFromWEBP: file doesn't exist??");
+        return nullptr;
+    }
+
+    void* imageRawData;
+
+    struct stat fileInfo = {};
+
+    const auto FD = open(path.c_str(), O_RDONLY);
+
+    fstat(FD, &fileInfo);
+
+    imageRawData = malloc(fileInfo.st_size);
+
+    read(FD, imageRawData, fileInfo.st_size);
+    close(FD);
+
+    // now the WebP is in the memory
+
+    WebPDecoderConfig config;
+    if (!WebPInitDecoderConfig(&config)) {
+        Debug::log(CRIT, "WebPInitDecoderConfig Failed");
+        return nullptr;
+    }
+
+    if (WebPGetFeatures((const unsigned char*)imageRawData, fileInfo.st_size, &config.input) != VP8_STATUS_OK) {
+        Debug::log(ERR, "createSurfaceFromWEBP: file is not webp format");
+        free(imageRawData);
+        return nullptr;
+    }
+
+    const auto HEIGHT = config.input.height;
+    const auto WIDTH = config.input.width;
+
+    auto cairoSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, WIDTH, HEIGHT);
+    if (cairo_surface_status(cairoSurface) != CAIRO_STATUS_SUCCESS) {
+        Debug::log(CRIT, "createSurfaceFromWEBP: Cairo Failed (?)");
+        cairo_surface_destroy(cairoSurface);
+        return nullptr;
+    }
+
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    config.output.colorspace = MODE_bgrA;
+#else
+    config.output.colorspace = MODE_Argb;
+#endif
+
+    const auto CAIRODATA = cairo_image_surface_get_data(cairoSurface);
+    const auto CAIROSTRIDE = cairo_image_surface_get_stride(cairoSurface);
+
+    config.options.no_fancy_upsampling = 1;
+    config.output.u.RGBA.rgba = CAIRODATA;
+    config.output.u.RGBA.stride = CAIROSTRIDE;
+    config.output.u.RGBA.size = CAIROSTRIDE * HEIGHT;
+    config.output.is_external_memory = 1;
+    config.output.width = WIDTH;
+    config.output.height = HEIGHT;
+
+    if (WebPDecode((const unsigned char*)imageRawData, fileInfo.st_size, &config) != VP8_STATUS_OK) {
+        Debug::log(CRIT, "createSurfaceFromWEBP: WebP Decode Failed (?)");
+        return nullptr;
+    }
+
+    cairo_surface_mark_dirty(cairoSurface);
+    cairo_surface_set_mime_data(cairoSurface, CAIRO_MIME_TYPE_PNG, (const unsigned char*)imageRawData, fileInfo.st_size, free, imageRawData);
+
+    WebPFreeDecBuffer(&config.output);
+
+    return cairoSurface;
+
+}

--- a/src/helpers/Webp.hpp
+++ b/src/helpers/Webp.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <filesystem>
+#include <cairo/cairo.h>
+
+namespace WEBP {
+    cairo_surface_t* createSurfaceFromWEBP(const std::filesystem::path&);
+};

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -152,13 +152,13 @@ void CAsyncResourceGatherer::gather() {
 
             FileType ft = FileType::UNKNOWN;
             Debug::log(WARN, "Extension: {}", ext);
-            if (ext == ".png") {
+            if (ext == ".png")
                 ft = FileType::PNG;
-            } else if (ext == ".jpg" || ext == ".jpeg") {
+            else if (ext == ".jpg" || ext == ".jpeg")
                 ft = FileType::JPEG;
-            } else if (ext == ".webp") {
+            else if (ext == ".webp")
                 ft = FileType::WEBP;
-            } else {
+            else {
                 // magic is slow, so only use it when no recognized extension is found
                 auto handle = magic_open(MAGIC_NONE | MAGIC_COMPRESS);
                 magic_load(handle, nullptr);
@@ -167,13 +167,12 @@ void CAsyncResourceGatherer::gather() {
                 const auto first_word = type_str.substr(0, type_str.find(" "));
                 magic_close(handle);
 
-                if (first_word == "PNG") {
+                if (first_word == "PNG")
                     ft = FileType::PNG;
-                } else if (first_word == "JPEG") {
+                else if (first_word == "JPEG")
                     ft = FileType::JPEG;
-                } else if (first_word == "RIFF" && type_str.find("Web/P image") != std::string::npos) {
+                else if (first_word == "RIFF" && type_str.find("Web/P image") != std::string::npos)
                     ft = FileType::WEBP;
-                }
             }
 
             // preload bg img
@@ -185,9 +184,8 @@ void CAsyncResourceGatherer::gather() {
                 default: Debug::log(ERR, "unrecognized image format of {}", path.c_str()); continue;
             }
 
-            if (CAIROISURFACE == nullptr) {
+            if (CAIROISURFACE == nullptr)
                 continue;
-            }
 
             const auto CAIRO = cairo_create(CAIROISURFACE);
             cairo_scale(CAIRO, 1, 1);


### PR DESCRIPTION
Most of the code is copy-pasted from [hyperpaper](https://github.com/hyprwm/hyprpaper) (with some changes).

Ideally, the jpeg / webp loading code would be shared in some common library. However, I couldn't find a fitting candidate in [hyprwm](https://github.com/hyprwm).

fixes #221