### PR TITLE
readme: add new line for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ And the development libraries for the following
 - xkbcommon
 - pam
 - hyprlang >= 0.4
+
 Development libraries are usually suffixed with `-devel` or `-dev` in most distro repos.
 
 You also need to install `mesa-libgbm-devel` on some distros like RPM based ones where its not


### PR DESCRIPTION
Fix a little markdown oopsie by splitting a line.