### PR TITLE
add libmagic dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ And the development libraries for the following
 - xkbcommon
 - pam
 - hyprlang >= 0.4
+- libmagic (file-devel on Fedora)
 
 Development libraries are usually suffixed with `-devel` or `-dev` in most distro repos.
 


### PR DESCRIPTION
Dependency added in 415262065fff0a04b229cd00165f346a86a0a73a. It has a weird name in Fedora as well.