### PR TITLE
Fixed getconf command in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bundled with the mesa package.
 Building:
 ```sh
 cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build
-cmake --build ./build --config Release --target hyprlock -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+cmake --build ./build --config Release --target hyprlock -j`nproc 2>/dev/null || getconf _NPROCESSORS_CONF`
 ```
 
 Installation:


### PR DESCRIPTION
"getconf NPROCESSORS_CONF" isn't a valid command. The correct command is "getconf _NPROCESSORS_CONF"