### PR TITLE
few reported leaks by asan

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -142,6 +142,7 @@ void CSessionLockSurface::render() {
 }
 
 void CSessionLockSurface::onCallback() {
+    wl_callback_destroy(frameCallback);
     frameCallback = nullptr;
 
     if (needsFrame && !g_pHyprlock->m_bTerminate && g_pEGL)

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -39,6 +39,11 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate) {
     }
 }
 
+CHyprlock::~CHyprlock() {
+    if (g_pHyprlock->dma.gbmDevice)
+        gbm_device_destroy(g_pHyprlock->dma.gbmDevice);
+}
+
 // wl_seat
 
 static void                   handleCapabilities(void* data, wl_seat* wl_seat, uint32_t capabilities);
@@ -82,6 +87,7 @@ static void dmabufFeedbackMainDevice(void* data, zwp_linux_dmabuf_feedback_v1* f
     }
 
     g_pHyprlock->dma.gbmDevice = g_pHyprlock->createGBMDevice(drmDev);
+    drmFreeDevice(&drmDev);
 }
 
 static void dmabufFeedbackFormatTable(void* data, zwp_linux_dmabuf_feedback_v1* feedback, int fd, uint32_t size) {

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -42,6 +42,12 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate) {
 CHyprlock::~CHyprlock() {
     if (g_pHyprlock->dma.gbmDevice)
         gbm_device_destroy(g_pHyprlock->dma.gbmDevice);
+
+    if (g_pHyprlock->m_pXKBState)
+        xkb_state_unref(g_pHyprlock->m_pXKBState);
+
+    if (g_pHyprlock->m_pXKBKeymap)
+        xkb_keymap_unref(g_pHyprlock->m_pXKBKeymap);
 }
 
 // wl_seat

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -29,6 +29,7 @@ struct SDMABUFModifier {
 class CHyprlock {
   public:
     CHyprlock(const std::string& wlDisplay, const bool immediate);
+    ~CHyprlock();
 
     void                            run();
 

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -326,6 +326,9 @@ void CAsyncResourceGatherer::renderText(const SPreloadRequest& rq) {
     if (!attrList)
         attrList = pango_attr_list_new();
 
+    if (buf)
+        free(buf);
+
     pango_attr_list_insert(attrList, pango_attr_scale_new(1));
     pango_layout_set_attributes(layout, attrList);
     pango_attr_list_unref(attrList);

--- a/src/renderer/widgets/IWidget.hpp
+++ b/src/renderer/widgets/IWidget.hpp
@@ -8,6 +8,7 @@ class IWidget {
     struct SRenderData {
         float opacity = 1;
     };
+    virtual ~IWidget() = default;
 
     virtual bool     draw(const SRenderData& data) = 0;
 


### PR DESCRIPTION
with all of these commits, hyprlock launches, renders and unlocks without a single complaint from asan.

short run without them `SUMMARY: AddressSanitizer: 223640 byte(s) leaked in 2441 allocation(s).`

short run with them.

```
[LOG]   | got iface: wl_seat v9
[LOG]    > Bound to wl_seat v9
[LOG]   | got iface: wl_data_device_manager v3
[LOG]   | got iface: wp_tearing_control_manager_v1 v1
[LOG]   | got iface: wp_fractional_scale_manager_v1 v1
[LOG]    > Bound to wp_fractional_scale_manager_v1 v1
[LOG]   | got iface: zxdg_output_manager_v1 v3
[LOG]   | got iface: wp_cursor_shape_manager_v1 v1
[LOG]    > Bound to wp_cursor_shape_manager_v1 v1
[LOG]   | got iface: zwp_idle_inhibit_manager_v1 v1
[LOG]   | got iface: zwp_relative_pointer_manager_v1 v1
[LOG]   | got iface: zxdg_decoration_manager_v1 v1
[LOG]   | got iface: wp_alpha_modifier_v1 v1
[LOG]   | got iface: zwlr_gamma_control_manager_v1 v1
[LOG]   | got iface: ext_foreign_toplevel_list_v1 v1
[LOG]   | got iface: zwp_pointer_gestures_v1 v3
[LOG]   | got iface: zwlr_foreign_toplevel_manager_v1 v3
[LOG]   | got iface: zwp_keyboard_shortcuts_inhibit_manager_v1 v1
[LOG]   | got iface: zwp_text_input_manager_v3 v1
[LOG]   | got iface: zwp_pointer_constraints_v1 v1
[LOG]   | got iface: zwlr_output_power_manager_v1 v1
[LOG]   | got iface: xdg_activation_v1 v1
[LOG]   | got iface: ext_idle_notifier_v1 v1
[LOG]   | got iface: ext_session_lock_manager_v1 v1
[LOG]    > Bound to ext_session_lock_manager_v1 v1
[LOG]   | got iface: zwp_input_method_manager_v2 v1
[LOG]   | got iface: zwp_virtual_keyboard_manager_v1 v1
[LOG]   | got iface: zwlr_virtual_pointer_manager_v1 v2
[LOG]   | got iface: zwlr_output_manager_v1 v4
[LOG]   | got iface: org_kde_kwin_server_decoration_manager v1
[LOG]   | got iface: hyprland_focus_grab_manager_v1 v1
[LOG]   | got iface: zwp_tablet_manager_v2 v1
[LOG]   | got iface: zwlr_layer_shell_v1 v5
[LOG]   | got iface: wp_presentation v1
[LOG]   | got iface: xdg_wm_base v6
[LOG]   | got iface: zwlr_data_control_manager_v1 v2
[LOG]   | got iface: zwp_primary_selection_device_manager_v1 v1
[LOG]   | got iface: hyprland_toplevel_export_manager_v1 v2
[LOG]   | got iface: zwp_text_input_manager_v1 v1
[LOG]   | got iface: hyprland_global_shortcuts_manager_v1 v1
[LOG]   | got iface: zwlr_screencopy_manager_v1 v3
[LOG]    > Bound to zwlr_screencopy_manager_v1 v3
[LOG]   | got iface: wl_shm v1
[LOG]   | got iface: wl_drm v2
[LOG]   | got iface: zwp_linux_dmabuf_v1 v4
[LOG]    > Bound to zwp_linux_dmabuf_v1 v4
[LOG]   | got iface: wl_compositor v6
[LOG]    > Bound to wl_compositor v6
[LOG]   | got iface: wl_subcompositor v1
[LOG]   | got iface: wp_viewporter v1
[LOG]    > Bound to wp_viewporter v1
[LOG]   | got iface: wp_drm_lease_device_v1 v1
[LOG]   | got iface: wp_drm_lease_device_v1 v1
[LOG]   | got iface: wp_single_pixel_buffer_manager_v1 v1
[LOG]   | got iface: xwayland_shell_v1 v1
[LOG]   | got iface: wl_output v4
[LOG]    > Bound to wl_output v4
[LOG] [core] dmabufFeedbackMainDevice
[LOG] output 48 make California Institute of Technology model 0x1628
[LOG] output 48 name eDP-1
[LOG] output 48 description California Institute of Technology 0x1628 0x00006000 (eDP-1)
[LOG] output 48 done
[LOG] Running on Hyprland
[LOG] Locking session
[WARN] Extension: .jpg
[LOG] onLockLocked called
[LOG] got fractional 1
[LOG] got fractional 1
[LOG] configure with serial 18470
[LOG] Configuring surface for logical [Vector2D: x: 2560, y: 1600] and pixel [Vector2D: x: 2560, y: 1600]
[LOG] got fractional 1
[LOG] configure with serial 18470
[LOG] Configuring surface for logical [Vector2D: x: 2560, y: 1600] and pixel [Vector2D: x: 2560, y: 1600]
[LOG] PAM_PROMPT: Password: 
[LOG] Framebuffer created, status 36053
[LOG] Framebuffer created, status 36053
[LOG] Framebuffer created, status 36053
[LOG] Authenticating
[LOG] auth: authenticated for hyprlock
[LOG] Unlocking session
[LOG] Unlocked, exiting!
[LOG] Reached the end, exiting
```