### PR TITLE
handle null timers in destructors

### DIFF
--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -5,8 +5,10 @@
 #include <cmath>
 
 CImage::~CImage() {
-    imageTimer->cancel();
-    imageTimer.reset();
+    if (imageTimer) {
+        imageTimer->cancel();
+        imageTimer.reset();
+    }
 }
 
 static void onTimer(std::shared_ptr<CTimer> self, void* data) {

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -6,8 +6,10 @@
 #include "../../core/hyprlock.hpp"
 
 CLabel::~CLabel() {
-    labelTimer->cancel();
-    labelTimer.reset();
+    if (labelTimer) {
+        labelTimer->cancel();
+        labelTimer.reset();
+    }
 }
 
 static void onTimer(std::shared_ptr<CTimer> self, void* data) {


### PR DESCRIPTION
Fixes crash on unlock:

```
Stack trace of thread 28180:
#0  0x00007f90566a2efc __pthread_kill_implementation (libc.so.6 + 0x8fefc)
#1  0x00007f9056652e86 raise (libc.so.6 + 0x3fe86)
#2  0x00007f905663b9bf abort (libc.so.6 + 0x289bf)
#3  0x00000000004412cb _ZL20handleCriticalSignali (hyprlock + 0x412cb)
#4  0x00007f9056652f30 __restore_rt (libc.so.6 + 0x3ff30)
#5  0x0000000000439e60 _ZN6CTimer6cancelEv (hyprlock + 0x39e60)
#6  0x0000000000470d81 _ZN6CLabelD1Ev (hyprlock + 0x70d81)
#7  0x00000000004710e9 _ZN6CLabelD0Ev (hyprlock + 0x710e9)
#8  0x0000000000444562 _ZN9CRendererD1Ev (hyprlock + 0x44562)
#9  0x00000000004430ac _ZN9CHyprlock3runEv (hyprlock + 0x430ac)
#10 0x0000000000416529 main (hyprlock + 0x16529)
#11 0x00007f905663d10e __libc_start_call_main (libc.so.6 + 0x2a10e)
#12 0x00007f905663d1c9 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a1c9)
#13 0x00000000004172e5 _start (hyprlock + 0x172e5)
```