### PR TITLE
readme: Add Arch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Hyprland's simple, yet multi-threaded and GPU-accelerated screen locking utility
 ## Docs / Configuration
 [See the wiki](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock/)
 
+## Arch install
+```sh
+yay -S hyprlock-git
+```
+
 ## Building
 
 ### Deps


### PR DESCRIPTION
I'm installing Hyprland, and in the Hyprland Wiki -> [Ecosystem](https://wiki.hyprland.org/Useful-Utilities/Hypr-Ecosystem/), `hyprlock` is in the same list as [`hyprpicker`](https://github.com/hyprwm/hyprpicker); this lib has the Arch AUR installation in its README, so it might be helpful to have it here. Feel free to close this if it is not relevant.