### PR TITLE
 fix second instance of hyprlock unlocking session

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -365,9 +365,6 @@ void CHyprlock::run() {
         exit(1);
     }
 
-    // gather info about monitors
-    wl_display_roundtrip(m_sWaylandState.display);
-
     g_pRenderer = std::make_unique<CRenderer>();
 
     const auto         CURRENTDESKTOP = getenv("XDG_CURRENT_DESKTOP");
@@ -392,6 +389,9 @@ void CHyprlock::run() {
     }
 
     acquireSessionLock();
+
+    // gather info about monitors
+    wl_display_roundtrip(m_sWaylandState.display);
 
     g_pAuth = std::make_unique<CAuth>();
     g_pAuth->start();
@@ -958,8 +958,7 @@ void CHyprlock::onLockLocked() {
 
 void CHyprlock::onLockFinished() {
     Debug::log(LOG, "onLockFinished called. Seems we got yeeten. Is another lockscreen running?");
-    ext_session_lock_v1_unlock_and_destroy(m_sLockState.lock);
-    m_sLockState.lock = nullptr;
+    exit(1);
 }
 
 ext_session_lock_manager_v1* CHyprlock::getSessionLockMgr() {

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -365,6 +365,9 @@ void CHyprlock::run() {
         exit(1);
     }
 
+    // gather info about monitors
+    wl_display_roundtrip(m_sWaylandState.display);
+
     g_pRenderer = std::make_unique<CRenderer>();
 
     const auto         CURRENTDESKTOP = getenv("XDG_CURRENT_DESKTOP");
@@ -389,9 +392,6 @@ void CHyprlock::run() {
     }
 
     acquireSessionLock();
-
-    // gather info about monitors
-    wl_display_roundtrip(m_sWaylandState.display);
 
     g_pAuth = std::make_unique<CAuth>();
     g_pAuth->start();
@@ -926,6 +926,9 @@ void CHyprlock::acquireSessionLock() {
     Debug::log(LOG, "Locking session");
     m_sLockState.lock = ext_session_lock_manager_v1_lock(m_sWaylandState.sessionLock);
     ext_session_lock_v1_add_listener(m_sLockState.lock, &sessionLockListener, nullptr);
+
+    // wait for wayland to signal whether the session lock has been acquired
+    wl_display_roundtrip(m_sWaylandState.display);
 }
 
 void CHyprlock::releaseSessionLock() {

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -958,6 +958,7 @@ void CHyprlock::onLockLocked() {
 
 void CHyprlock::onLockFinished() {
     Debug::log(LOG, "onLockFinished called. Seems we got yeeten. Is another lockscreen running?");
+    g_pRenderer = nullptr;
     exit(1);
 }
 


### PR DESCRIPTION
Fixes #373

I noticed that the `onLockFinished` function calls `ext_session_lock_v1_unlock_and_destroy`, whereas Swaylock on the other hand directly calls `exit(2)` once it notices that a second lock is already running (see [this line](https://github.com/swaywm/swaylock/blob/b70d85ec145520ba3ebaa4c51921a2761bc0c7f0/main.c#L282)). Implementing this fix alone, however, did not resolve the problem. Thus, I dug further and noticed, that moving the call to `wl_display_roundtrip` after `acquireSessionLock` now seems to resolve the issue.

I have to admit that I have no idea about Wayland and their protocols, so please throw this code out of the window if it makes no sense at all.
