### PR TITLE
core: stabilize label updates and revision locking in the asyncResourceGatherer

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -129,8 +129,10 @@ static const wl_callback_listener callbackListener = {
 void CSessionLockSurface::render() {
     Debug::log(TRACE, "render lock");
 
-    if (frameCallback || !readyForFrame)
+    if (frameCallback || !readyForFrame) {
+        needsFrame = true;
         return;
+    }
 
     const auto FEEDBACK = g_pRenderer->renderLock(*this);
     frameCallback       = wl_surface_frame(surface);

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -3,7 +3,6 @@
 #include "../core/Egl.hpp"
 #include <cairo/cairo.h>
 #include <magic.h>
-#include <mutex>
 #include <pango/pangocairo.h>
 #include <algorithm>
 #include <filesystem>
@@ -383,7 +382,7 @@ static void timerCallback(std::shared_ptr<CTimer> self, void* data_) {
 void CAsyncResourceGatherer::asyncAssetSpinLock() {
     while (!g_pHyprlock->m_bTerminate) {
 
-        std::unique_lock<std::mutex> lk(asyncLoopState.requestsMutex);
+        std::unique_lock lk(asyncLoopState.requestsMutex);
         if (asyncLoopState.pending == false) // avoid a lock if a thread managed to request something already since we .unlock()ed
             asyncLoopState.requestsCV.wait_for(lk, std::chrono::seconds(5), [this] { return asyncLoopState.pending; }); // wait for events
 

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -24,7 +24,7 @@ class CAsyncResourceGatherer {
     /* only call from ogl thread */
     SPreloadedAsset* getAssetByID(const std::string& id);
 
-    void             apply();
+    bool             apply();
 
     enum eTargetType {
         TARGET_IMAGE = 0,
@@ -59,12 +59,8 @@ class CAsyncResourceGatherer {
     void        renderImage(const SPreloadRequest& rq);
 
     struct {
-        std::condition_variable      loopGuard;
-        std::mutex                   loopMutex;
-
-        std::mutex                   requestMutex;
-
-        std::mutex                   assetsMutex;
+        std::condition_variable      requestsCV;
+        std::mutex                   requestsMutex;
 
         std::vector<SPreloadRequest> requests;
         bool                         pending = false;
@@ -86,6 +82,8 @@ class CAsyncResourceGatherer {
     std::vector<std::unique_ptr<CDMAFrame>>          dmas;
 
     std::vector<SPreloadTarget>                      preloadTargets;
+    std::mutex                                       preloadTargetsMutex;
+
     std::unordered_map<std::string, SPreloadedAsset> assets;
 
     void                                             gather();

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -39,8 +39,10 @@ void CLabel::onTimerUpdate() {
     if (label.formatted == oldFormatted && !label.alwaysUpdate)
         return;
 
-    if (!pendingResourceID.empty())
-        return; // too many updates, we'll miss some. Shouldn't happen tbh
+    if (!pendingResourceID.empty()) {
+        Debug::log(WARN, "Trying to update label, but resource {} is still pending! Skipping update.", pendingResourceID);
+        return;
+    }
 
     // request new
     request.id        = getUniqueResourceId();

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -141,7 +141,4 @@ static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {
 
 void CLabel::renderSuper() {
     g_pHyprlock->renderOutput(outputStringPort);
-
-    if (!pendingResourceID.empty()) /* did not consume the pending resource */
-        g_pHyprlock->addTimer(std::chrono::milliseconds(100), onAssetCallbackTimer, this);
 }


### PR DESCRIPTION
Was able to repro #357 (multiple monitors required i think).
Fixes it on my end.

[4509552](https://github.com/hyprwm/hyprlock/pull/384/commits/450955217f860554384549f461cf0c080d86a957) reverts the previous approach of adding a timer to re-render, when the resource was not available (#152). It also sets `needsFrame=true`, when render is called but `frameCallback` is present (I think not 100% needed but still makes sense)

The other 3 commits make sure that `getAssetById` fails less often by removing the `busy` flag and revisioning the locking in the resource gatherer.

`-fsanitize=thread` is a bit happier regarding the asyncResourceGatherer now. Besides some races with `dmas` on startup I think.

Closes #367