### PR TITLE
core: improve dynamic output handling

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -27,6 +27,8 @@ static const wp_fractional_scale_v1_listener fsListener = {
 };
 
 CSessionLockSurface::~CSessionLockSurface() {
+    g_pRenderer->removeWidgetsFor(this);
+
     if (fractional) {
         wp_viewport_destroy(viewport);
         wp_fractional_scale_v1_destroy(fractional);

--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -27,8 +27,6 @@ static const wp_fractional_scale_v1_listener fsListener = {
 };
 
 CSessionLockSurface::~CSessionLockSurface() {
-    g_pRenderer->removeWidgetsFor(this);
-
     if (fractional) {
         wp_viewport_destroy(viewport);
         wp_fractional_scale_v1_destroy(fractional);

--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -25,11 +25,9 @@ static void handleDone(void* data, wl_output* output) {
     const auto POUTPUT = (COutput*)data;
     Debug::log(LOG, "output {} done", POUTPUT->name);
     if (g_pHyprlock->m_bLocked && !POUTPUT->sessionLockSurface) {
-        // if we are already locked, create a surface dynamically after a small timeout
-        // we also need to request a dma frame for screenshots
+        // if we are already locked, create a surface dynamically
         Debug::log(LOG, "Creating a surface dynamically for output as we are already locked");
         POUTPUT->sessionLockSurface = std::make_unique<CSessionLockSurface>(POUTPUT);
-        g_pRenderer->asyncResourceGatherer->recheckDMAFramesFor(POUTPUT);
     }
 }
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -300,7 +300,11 @@ void CHyprlock::onGlobal(void* data, struct wl_registry* registry, uint32_t name
 
 void CHyprlock::onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name) {
     Debug::log(LOG, "  | removed iface {}", name);
-    std::erase_if(m_vOutputs, [name](const auto& other) { return other->name == name; });
+    auto outputIt = std::find_if(m_vOutputs.begin(), m_vOutputs.end(), [name](const auto& other) { return other->name == name; });
+    if (outputIt != m_vOutputs.end()) {
+        g_pRenderer->removeWidgetsFor(outputIt->get()->sessionLockSurface.get());
+        m_vOutputs.erase(outputIt);
+    }
 }
 
 // end wl_registry

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -300,11 +300,7 @@ void CHyprlock::onGlobal(void* data, struct wl_registry* registry, uint32_t name
 
 void CHyprlock::onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name) {
     Debug::log(LOG, "  | removed iface {}", name);
-    auto outputIt = std::find_if(m_vOutputs.begin(), m_vOutputs.end(), [name](const auto& other) { return other->name == name; });
-    if (outputIt != m_vOutputs.end()) {
-        g_pRenderer->removeWidgetsFor(outputIt->get()->sessionLockSurface.get());
-        m_vOutputs.erase(outputIt);
-    }
+    std::erase_if(m_vOutputs, [name](const auto& other) { return other->name == name; });
 }
 
 // end wl_registry

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -64,6 +64,7 @@ class CHyprlock {
     std::optional<std::string>      passwordLastFailReason();
 
     void                            renderOutput(const std::string& stringPort);
+    void                            renderAllOutputs();
 
     size_t                          getPasswordBufferLen();
     size_t                          getPasswordBufferDisplayLen();

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -70,7 +70,7 @@ SPreloadedAsset* CAsyncResourceGatherer::getAssetByID(const std::string& id) {
     };
 
     for (auto& dma : dmas) {
-        if (id == "dma:" + dma->name)
+        if (id == dma->resourceID)
             return dma->asset.ready ? &dma->asset : nullptr;
     }
 

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -74,6 +74,12 @@ void CAsyncResourceGatherer::recheckDMAFramesFor(COutput* output) {
         }
     }
 
+    for (auto& dma : dmas) {
+        if (dma->name == output->stringPort) {
+            shouldMake = false;
+        }
+    }
+
     if (!shouldMake)
         return;
 

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -56,36 +56,6 @@ CAsyncResourceGatherer::CAsyncResourceGatherer() {
     }
 }
 
-void CAsyncResourceGatherer::recheckDMAFramesFor(COutput* output) {
-    const auto CWIDGETS = g_pConfigManager->getWidgetConfigs();
-
-    bool       shouldMake = false;
-
-    for (auto& c : CWIDGETS) {
-        if (c.type != "background")
-            continue;
-
-        if (std::string{std::any_cast<Hyprlang::STRING>(c.values.at("path"))} != "screenshot")
-            continue;
-
-        if (c.monitor.empty() || c.monitor == output->stringPort || output->stringDesc.starts_with(c.monitor)) {
-            shouldMake = true;
-            break;
-        }
-    }
-
-    for (auto& dma : dmas) {
-        if (dma->name == output->stringPort) {
-            shouldMake = false;
-        }
-    }
-
-    if (!shouldMake)
-        return;
-
-    dmas.emplace_back(std::make_unique<CDMAFrame>(output));
-}
-
 SPreloadedAsset* CAsyncResourceGatherer::getAssetByID(const std::string& id) {
     for (auto& a : assets) {
         if (a.first == id)

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -49,7 +49,6 @@ class CAsyncResourceGatherer {
     void unloadAsset(SPreloadedAsset* asset);
     void notify();
     void await();
-    void recheckDMAFramesFor(COutput* output);
 
   private:
     std::thread asyncLoopThread;

--- a/src/renderer/DMAFrame.cpp
+++ b/src/renderer/DMAFrame.cpp
@@ -86,7 +86,12 @@ static const zwlr_screencopy_frame_v1_listener wlrFrameListener = {
     .buffer_done  = wlrOnBufferDone,
 };
 
-CDMAFrame::CDMAFrame(COutput* output_) : output(output_) {
+std::string CDMAFrame::getResourceId(COutput* output) {
+    return std::format("dma:{}-{}x{}", output->stringPort, output->size.x, output->size.y);
+}
+
+CDMAFrame::CDMAFrame(COutput* output_) {
+    resourceID = getResourceId(output_);
 
     if (!glEGLImageTargetTexture2DOES) {
         glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
@@ -105,8 +110,6 @@ CDMAFrame::CDMAFrame(COutput* output_) : output(output_) {
     scdata.frame = this;
 
     zwlr_screencopy_frame_v1_add_listener(frameCb, &wlrFrameListener, &scdata);
-
-    name = output->stringPort;
 }
 
 CDMAFrame::~CDMAFrame() {

--- a/src/renderer/DMAFrame.cpp
+++ b/src/renderer/DMAFrame.cpp
@@ -105,7 +105,7 @@ CDMAFrame::CDMAFrame(COutput* output_) {
         eglQueryDmaBufModifiersEXT = (PFNEGLQUERYDMABUFMODIFIERSEXTPROC)eglGetProcAddress("eglQueryDmaBufModifiersEXT");
 
     // firstly, plant a listener for the frame
-    frameCb = zwlr_screencopy_manager_v1_capture_output(g_pHyprlock->getScreencopy(), false, output->output);
+    frameCb = zwlr_screencopy_manager_v1_capture_output(g_pHyprlock->getScreencopy(), false, output_->output);
 
     scdata.frame = this;
 

--- a/src/renderer/DMAFrame.hpp
+++ b/src/renderer/DMAFrame.hpp
@@ -44,7 +44,5 @@ class CDMAFrame {
     zwlr_screencopy_frame_v1* frameCb = nullptr;
     SScreencopyData           scdata;
 
-    COutput*                  output = nullptr;
-
     EGLImage                  image = nullptr;
 };

--- a/src/renderer/DMAFrame.hpp
+++ b/src/renderer/DMAFrame.hpp
@@ -19,6 +19,8 @@ struct SScreencopyData {
 
 class CDMAFrame {
   public:
+    static std::string getResourceId(COutput* output);
+
     CDMAFrame(COutput* mon);
     ~CDMAFrame();
 
@@ -27,7 +29,7 @@ class CDMAFrame {
 
     wl_buffer*      wlBuffer = nullptr;
 
-    std::string     name;
+    std::string     resourceID;
 
     SPreloadedAsset asset;
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -323,6 +323,12 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
                 std::string       resourceID = "";
                 if (PATH == "screenshot") {
                     resourceID = CDMAFrame::getResourceId(surf->output);
+                    // When the initial gather of the asyncResourceGatherer is completed (ready), all DMAFrames are available.
+                    // Dynamic ones are tricky, because a screencopy would copy hyprlock itself.
+                    if (asyncResourceGatherer->ready) {
+                        if (!asyncResourceGatherer->getAssetByID(resourceID))
+                            resourceID = ""; // Fallback to solid color (background:color)
+                    }
                 } else if (!PATH.empty())
                     resourceID = "background:" + PATH;
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -4,6 +4,7 @@
 #include "../helpers/Color.hpp"
 #include "../core/Output.hpp"
 #include "../core/hyprlock.hpp"
+#include "../renderer/DMAFrame.hpp"
 #include "mtx.hpp"
 
 #include <GLES3/gl32.h>
@@ -320,9 +321,9 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
                 const std::string PATH = std::any_cast<Hyprlang::STRING>(c.values.at("path"));
 
                 std::string       resourceID = "";
-                if (PATH == "screenshot")
-                    resourceID = "dma:" + surf->output->stringPort;
-                else if (!PATH.empty())
+                if (PATH == "screenshot") {
+                    resourceID = CDMAFrame::getResourceId(surf->output);
+                } else if (!PATH.empty())
                     resourceID = "background:" + PATH;
 
                 widgets[surf].emplace_back(std::make_unique<CBackground>(surf->size, surf->output, resourceID, c.values, PATH == "screenshot"));

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -512,3 +512,7 @@ void CRenderer::popFb() {
     boundFBs.pop_back();
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, boundFBs.empty() ? 0 : boundFBs.back());
 }
+
+void CRenderer::removeWidgetsFor(const CSessionLockSurface* surf) {
+    widgets.erase(surf);
+}

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -41,6 +41,8 @@ class CRenderer {
     void                                    pushFb(GLint fb);
     void                                    popFb();
 
+    void                                    removeWidgetsFor(const CSessionLockSurface* surf);
+
   private:
     widgetMap_t                            widgets;
 


### PR DESCRIPTION
I reproduced some crashes with the lid switching the internal monitor on and off.
That is because the session lock surface is getting created via `handleDone` for a new output.
Even if a full display roundtrip is done, some events might arrive earlier than the output `done` event causing a crash because the `sessionLockSurface` pointer is null. Checking for the `sessionLockSurface` pointer fixes that. Other option would be to only add dynamic outputs to the `m_vOutputs` vector when the sessionLockSurface already exists

Then I noticed that the widgets for a surface are not removed, when it is destroyed (I think that caused #337). Sometimes the new `sessionLockSurface` happens to be the same pointer as the original one. And because the widgets map is keyed by those pointers it will reuse the widgets leading to some weird stuff.
```
[LOG]   | removed iface 60
[LOG] output 905814070 done
[LOG]   | got iface: wl_output v4
[LOG]    > Bound to wl_output v4
[LOG] output 61 done
[LOG] Creating a surface dynamically for output as we are already locked
[LOG] sessionLockSurface 0x36054330
[LOG] output 61 make null model null
[LOG] output 61 name HEADLESS-1
[LOG] output 61 description Headless output 1
[LOG] output 61 done
...
[LOG]   | got iface: wl_output v4
[LOG]    > Bound to wl_output v4
[LOG]   | removed iface 61
[LOG] output 62 make Najing CEC Panda FPD Technology CO. ltd model 0x002B
[LOG] output 62 name eDP-1
[LOG] output 62 description Najing CEC Panda FPD Technology CO. ltd 0x002B (eDP-1)
[LOG] output 62 done
[LOG] Creating a surface dynamically for output as we are already locked
[LOG] sessionLockSurface 0x36054330
```

Stuff that is still to be investigated:
- DMA Frames are identified by output stringPorts, so when someone would unplug one monitor and plug another one in with different dimensions, that would cause weirdness probably. Should we identify them by description or something instead so that we don't need to remove them, or just remove existing ones when an output is removed?
- (Hyprland) My active workspace switches when I deactivate and reactivate my only output. I can imagine that is kind of supposed to happen, but I will need to check what is actually going on.
- (Hyprland) There is a red screen flashing, when reactivating a monitor. Also happens with swaylock. But not when replugging and external monitor.

Closes #337
Probably Closes #117