### PR TITLE
input-field: add font_family

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -113,6 +113,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "valign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("input-field", "position", Hyprlang::VEC2{0, -20});
     m_config.addSpecialConfigValue("input-field", "placeholder_text", Hyprlang::STRING{"<i>Input Password</i>"});
+    m_config.addSpecialConfigValue("input-field", "font_family", Hyprlang::STRING{"Sans"});
     m_config.addSpecialConfigValue("input-field", "hide_input", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "check_color", Hyprlang::INT{0xFFCC8822});
@@ -265,6 +266,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"valign", m_config.getSpecialConfigValue("input-field", "valign", k.c_str())},
                 {"position", m_config.getSpecialConfigValue("input-field", "position", k.c_str())},
                 {"placeholder_text", m_config.getSpecialConfigValue("input-field", "placeholder_text", k.c_str())},
+                {"font_family", m_config.getSpecialConfigValue("input-field", "font_family", k.c_str())},
                 {"hide_input", m_config.getSpecialConfigValue("input-field", "hide_input", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -28,6 +28,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     rounding                 = std::any_cast<Hyprlang::INT>(props.at("rounding"));
     configPlaceholderText    = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
     configFailText           = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
+    configFontFamily         = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
     col.transitionMs         = std::any_cast<Hyprlang::INT>(props.at("fail_transition"));
     col.outer                = std::any_cast<Hyprlang::INT>(props.at("outer_color"));
     col.inner                = std::any_cast<Hyprlang::INT>(props.at("inner_color"));
@@ -72,7 +73,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
         request.id                   = placeholder.resourceID;
         request.asset                = placeholder.currentText;
         request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-        request.props["font_family"] = std::string{"Sans"};
+        request.props["font_family"] = configFontFamily;
         request.props["color"]       = CColor{1.0 - col.font.r, 1.0 - col.font.g, 1.0 - col.font.b, 0.5};
         request.props["font_size"]   = (int)size.y / 4;
         g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);
@@ -347,7 +348,7 @@ void CPasswordInputField::updatePlaceholder() {
     request.id                   = placeholder.resourceID;
     request.asset                = placeholder.currentText;
     request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-    request.props["font_family"] = std::string{"Sans"};
+    request.props["font_family"] = configFontFamily;
     request.props["color"]       = (placeholder.isFailText) ? col.fail : col.font;
     request.props["font_size"]   = (int)size.y / 4;
     g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -38,7 +38,7 @@ class CPasswordInputField : public IWidget {
     Vector2D    configPos;
     Vector2D    configSize;
 
-    std::string halign, valign, configFailText, outputStringPort, configPlaceholderText;
+    std::string halign, valign, configFailText, configFontFamily, outputStringPort, configPlaceholderText;
 
     int         outThick, rounding;
 


### PR DESCRIPTION
added font family customization for the input field, or was it intentional to leave it uncustomizable?