### PR TITLE
asyncResourceGatherer: add dma frames before starting the asyncLoopThread

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -12,12 +12,6 @@
 #include "../helpers/Webp.hpp"
 
 CAsyncResourceGatherer::CAsyncResourceGatherer() {
-    asyncLoopThread = std::thread([this]() {
-        this->gather(); /* inital gather */
-        this->asyncAssetSpinLock();
-    });
-    asyncLoopThread.detach();
-
     // some things can't be done async :(
     // gather background textures when needed
 
@@ -54,6 +48,12 @@ CAsyncResourceGatherer::CAsyncResourceGatherer() {
 
         dmas.emplace_back(std::make_unique<CDMAFrame>(PMONITOR));
     }
+
+    asyncLoopThread = std::thread([this]() {
+        this->gather(); /* inital gather */
+        this->asyncAssetSpinLock();
+    });
+    asyncLoopThread.detach();
 }
 
 SPreloadedAsset* CAsyncResourceGatherer::getAssetByID(const std::string& id) {


### PR DESCRIPTION
Fixes a race that now shows itself since https://github.com/hyprwm/hyprlock/pull/386, because if the added check to fall back to background color for dynamic backgrounds.

Thats because `gather` waits for all dma frames to be ready, but rarely it was possible that not all dma frames have been added yet in the `asyncResourceGatherer` ctor.