### PR TITLE
label: do not error when using cmd[] for a static label cmd

### DIFF
--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -156,7 +156,7 @@ IWidget::SFormatResult IWidget::formatString(std::string in) {
 
     if (in.starts_with("cmd[") && in.contains("]")) {
         // this is a command
-        CVarList vars(in.substr(4, in.find_first_of(']') - 4));
+        CVarList vars(in.substr(4, in.find_first_of(']') - 4), 0, ',', true);
 
         for (const auto& v : vars) {
             if (v.starts_with("update:")) {


### PR DESCRIPTION
Currently `cmd[]` will cause the following error `[ERR] Unknown prop in string format`.

Since I think it makes sense to use it like that for a static label command, I set `removeEmpty` for the `CVarList` ctor.
Then I noticed `removeEmpty` does not affect empty inputs, so I figured It would make sense if it did. Thus https://github.com/hyprwm/hyprutils/pull/7.