### PR TITLE
config: don't crash when getenv HOME returns null

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -23,7 +23,12 @@ static std::string getConfigDir() {
     if (xdgConfigHome && std::filesystem::path(xdgConfigHome).is_absolute())
         return xdgConfigHome;
 
-    return getenv("HOME") + std::string("/.config");
+    static const char* home = getenv("HOME");
+
+    if (!home)
+        throw std::runtime_error("Neither HOME nor XDG_CONFIG_HOME is set in the environment. Cannot determine config directory.");
+
+    return home + std::string("/.config");
 }
 
 static std::string getMainConfigPath() {


### PR DESCRIPTION
Do we prefer throwing an error like this, or logging + exit or just returning an empty string?

Same problem in hyprland as well.

Closes #392