### PR TITLE
auth: pam fallback log message and always call pam_end after pam_authenticate

### DIFF
--- a/src/core/Auth.cpp
+++ b/src/core/Auth.cpp
@@ -91,6 +91,8 @@ bool CAuth::auth() {
     }
 
     ret = pam_authenticate(handle, 0);
+    pam_end(handle, ret);
+    handle = nullptr;
 
     m_sConversationState.waitingForPamAuth = false;
 
@@ -100,8 +102,6 @@ bool CAuth::auth() {
         Debug::log(ERR, "auth: {} for {}", m_sConversationState.failText, m_sPamModule);
         return false;
     }
-
-    ret = pam_end(handle, ret);
 
     m_sConversationState.success  = true;
     m_sConversationState.failText = "Successfully authenticated";

--- a/src/core/Auth.cpp
+++ b/src/core/Auth.cpp
@@ -58,7 +58,7 @@ CAuth::CAuth() {
     m_sPamModule                  = *PPAMMODULE;
 
     if (!std::filesystem::exists(std::filesystem::path("/etc/pam.d/") / m_sPamModule)) {
-        Debug::log(ERR, "Pam module \"{}\" not found! Falling back to \"su\"", m_sPamModule);
+        Debug::log(ERR, "Pam module \"/etc/pam.d/{}\" does not exist! Falling back to \"/etc/pam.d/su\"", m_sPamModule);
         m_sPamModule = "su";
     }
 }


### PR DESCRIPTION
Changed the log, because someone used an absolute path for `general:pam_module`.

Also new release maybe?
People that use 0.3.0 are quite a bit behind by now and don't have d9f644125468054d2a237adf4ae676f64c0da918.