### PR TITLE
helpers: fix jpeg and webp OOM error

### DIFF
--- a/src/helpers/Jpeg.cpp
+++ b/src/helpers/Jpeg.cpp
@@ -66,6 +66,7 @@ cairo_surface_t* JPEG::createSurfaceFromJPEG(const std::filesystem::path& path) 
         jpeg_read_scanlines(&decompressStruct, &rowRead, 1);
     }
 
+    cairo_surface_flush(cairoSurface);
     cairo_surface_mark_dirty(cairoSurface);
     cairo_surface_set_mime_data(cairoSurface, CAIRO_MIME_TYPE_JPEG, (const unsigned char*)imageRawData, fileInfo.st_size, free, imageRawData);
     jpeg_finish_decompress(&decompressStruct);

--- a/src/helpers/Webp.cpp
+++ b/src/helpers/Webp.cpp
@@ -74,6 +74,7 @@ cairo_surface_t* WEBP::createSurfaceFromWEBP(const std::filesystem::path& path) 
         return nullptr;
     }
 
+    cairo_surface_flush(cairoSurface);
     cairo_surface_mark_dirty(cairoSurface);
     cairo_surface_set_mime_data(cairoSurface, CAIRO_MIME_TYPE_PNG, (const unsigned char*)imageRawData, fileInfo.st_size, free, imageRawData);
 


### PR DESCRIPTION
Following the cairo docs on [cairo_surface_mark_dirty](https://www.cairographics.org/manual/cairo-cairo-surface-t.html#cairo-surface-mark-dirty), the cairo surface flush call had been left out and was leading to OOM errors on non-png images. This should fix that issue.

Resolves #315.