### PR TITLE
hyprlock: ensure members are accessed direct

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -40,14 +40,14 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate) {
 }
 
 CHyprlock::~CHyprlock() {
-    if (g_pHyprlock->dma.gbmDevice)
-        gbm_device_destroy(g_pHyprlock->dma.gbmDevice);
+    if (dma.gbmDevice)
+        gbm_device_destroy(dma.gbmDevice);
 
-    if (g_pHyprlock->m_pXKBState)
-        xkb_state_unref(g_pHyprlock->m_pXKBState);
+    if (m_pXKBState)
+        xkb_state_unref(m_pXKBState);
 
-    if (g_pHyprlock->m_pXKBKeymap)
-        xkb_keymap_unref(g_pHyprlock->m_pXKBKeymap);
+    if (m_pXKBKeymap)
+        xkb_keymap_unref(m_pXKBKeymap);
 }
 
 // wl_seat


### PR DESCRIPTION
if the unique_ptr is reset directly accessing it from the destructor causes crashes on Clang/libc++, just access the members directly.

fixes #403 