### PR TITLE
core: add option to render solid background immediatly when bg assets are not ready

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -55,6 +55,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:no_fade_in", Hyprlang::INT{0});
     m_config.addConfigValue("general:no_fade_out", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
+    m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:pam_module", Hyprlang::STRING{"hyprlock"});
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -1140,5 +1140,5 @@ void CHyprlock::attemptRestoreOnDeath() {
     ofs.close();
 
     spawnSync("hyprctl keyword misc:allow_session_lock_restore true");
-    spawnAsync("sleep 2 && hyprlock --immediate & disown");
+    spawnAsync("sleep 2 && hyprlock --immediate --immediate-render & disown");
 }

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <algorithm>
 
-CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate) {
+CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender) : m_bImmediateRender(immediateRender) {
     m_sWaylandState.display = wl_display_connect(wlDisplay.empty() ? nullptr : wlDisplay.c_str());
     if (!m_sWaylandState.display) {
         Debug::log(CRIT, "Couldn't connect to a wayland compositor");
@@ -383,7 +383,7 @@ void CHyprlock::run() {
 
     // Hyprland violates the protocol a bit to allow for this.
     if (SZCURRENTD != "Hyprland") {
-        while (!g_pRenderer->asyncResourceGatherer->ready) {
+        while (!g_pRenderer->asyncResourceGatherer->gathered) {
             wl_display_flush(m_sWaylandState.display);
             if (wl_display_prepare_read(m_sWaylandState.display) == 0) {
                 wl_display_read_events(m_sWaylandState.display);

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <algorithm>
 
-CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender) : m_bImmediateRender(immediateRender) {
+CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender) {
     m_sWaylandState.display = wl_display_connect(wlDisplay.empty() ? nullptr : wlDisplay.c_str());
     if (!m_sWaylandState.display) {
         Debug::log(CRIT, "Couldn't connect to a wayland compositor");
@@ -32,11 +32,14 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const b
         Debug::log(ERR, "Failed to create xkb context");
 
     if (!immediate) {
-        const auto GRACE = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:grace");
-        m_tGraceEnds     = **GRACE ? std::chrono::system_clock::now() + std::chrono::seconds(**GRACE) : std::chrono::system_clock::from_time_t(0);
+        const auto PGRACE = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:grace");
+        m_tGraceEnds      = **PGRACE ? std::chrono::system_clock::now() + std::chrono::seconds(**PGRACE) : std::chrono::system_clock::from_time_t(0);
     } else {
         m_tGraceEnds = std::chrono::system_clock::from_time_t(0);
     }
+
+    const auto PIMMEDIATERENDER = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:immediate_render");
+    m_bImmediateRender          = immediateRender || **PIMMEDIATERENDER;
 }
 
 CHyprlock::~CHyprlock() {

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -28,7 +28,7 @@ struct SDMABUFModifier {
 
 class CHyprlock {
   public:
-    CHyprlock(const std::string& wlDisplay, const bool immediate);
+    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender);
     ~CHyprlock();
 
     void                            run();
@@ -100,6 +100,8 @@ class CHyprlock {
     bool                            m_bNumLock     = false;
     bool                            m_bCtrl        = false;
     bool                            m_bFadeStarted = false;
+
+    bool                            m_bImmediateRender = false;
     //
     std::chrono::system_clock::time_point m_tGraceEnds;
     std::chrono::system_clock::time_point m_tFadeEnds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,8 +26,9 @@ std::optional<std::string> parseArg(const std::vector<std::string>& args, const 
 int main(int argc, char** argv, char** envp) {
     std::string              configPath;
     std::string              wlDisplay;
-    bool                     immediate = false;
-    bool                     showHelp  = false;
+    bool                     immediate       = false;
+    bool                     immediateRender = false;
+    bool                     showHelp        = false;
 
     std::vector<std::string> args(argv, argv + argc);
 
@@ -54,6 +55,9 @@ int main(int argc, char** argv, char** envp) {
 
         } else if (arg == "--immediate")
             immediate = true;
+
+        else if (arg == "--immediate-render")
+            immediateRender = true;
 
         else if (arg == "--help" || arg == "-h") {
             showHelp = true;
@@ -83,7 +87,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     try {
-        g_pHyprlock = std::make_unique<CHyprlock>(wlDisplay, immediate);
+        g_pHyprlock = std::make_unique<CHyprlock>(wlDisplay, immediate, immediateRender);
         g_pHyprlock->run();
     } catch (const std::exception& ex) {
         Debug::log(CRIT, "Hyprlock threw: {}", ex.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ void help() {
                  "  -c FILE, --config FILE   - Specify config file to use\n"
                  "  --display (display)      - Specify the Wayland display to connect to\n"
                  "  --immediate              - Lock immediately, ignoring any configured grace period\n"
+                 "  --immediate-render       - Do not wait for resources before drawing the background\n"
                  "  -h, --help               - Show this help message\n";
 }
 

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -178,7 +178,7 @@ void CAsyncResourceGatherer::gather() {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
-    ready = true;
+    gathered = true;
 }
 
 bool CAsyncResourceGatherer::apply() {
@@ -228,7 +228,6 @@ bool CAsyncResourceGatherer::apply() {
         }
     }
 
-    applied = true;
     return true;
 }
 

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -52,6 +52,7 @@ class CAsyncResourceGatherer {
 
   private:
     std::thread asyncLoopThread;
+    std::thread initialGatherThread;
 
     void        asyncAssetSpinLock();
     void        renderText(const SPreloadRequest& rq);

--- a/src/renderer/AsyncResourceGatherer.hpp
+++ b/src/renderer/AsyncResourceGatherer.hpp
@@ -16,8 +16,7 @@
 class CAsyncResourceGatherer {
   public:
     CAsyncResourceGatherer();
-    std::atomic<bool>  ready   = false;
-    std::atomic<bool>  applied = false;
+    std::atomic<bool>  gathered = false;
 
     std::atomic<float> progress = 0;
 

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -36,7 +36,7 @@ class CRenderer {
     void                                    blurFB(const CFramebuffer& outfb, SBlurParams params);
 
     std::unique_ptr<CAsyncResourceGatherer> asyncResourceGatherer;
-    std::chrono::system_clock::time_point   gatheredAt;
+    std::chrono::system_clock::time_point   firstFullFrameTime;
 
     void                                    pushFb(GLint fb);
     void                                    popFb();

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -15,21 +15,29 @@ CBackground::CBackground(const Vector2D& viewport_, COutput* output_, const std:
     contrast          = std::any_cast<Hyprlang::FLOAT>(props.at("contrast"));
 }
 
+void CBackground::renderRect(CColor color) {
+    CBox monbox = {0, 0, viewport.x, viewport.y};
+    g_pRenderer->renderRect(monbox, color, 0);
+}
+
 bool CBackground::draw(const SRenderData& data) {
 
     if (resourceID.empty()) {
-        CBox   monbox = {0, 0, viewport.x, viewport.y};
-        CColor col    = color;
+        CColor col = color;
         col.a *= data.opacity;
-        g_pRenderer->renderRect(monbox, col, 0);
+        renderRect(col);
         return data.opacity < 1.0;
     }
 
     if (!asset)
         asset = g_pRenderer->asyncResourceGatherer->getAssetByID(resourceID);
 
-    if (!asset)
+    if (!asset) {
+        CColor col = color;
+        col.a *= data.opacity;
+        renderRect(col);
         return true;
+    }
 
     if (asset->texture.m_iType == TEXTURE_INVALID) {
         g_pRenderer->asyncResourceGatherer->unloadAsset(asset);

--- a/src/renderer/widgets/Background.hpp
+++ b/src/renderer/widgets/Background.hpp
@@ -16,6 +16,7 @@ class CBackground : public IWidget {
     CBackground(const Vector2D& viewport, COutput* output_, const std::string& resourceID, const std::unordered_map<std::string, std::any>& props, bool ss_);
 
     virtual bool draw(const SRenderData& data);
+    void         renderRect(CColor color);
 
   private:
     // if needed


### PR DESCRIPTION
Closes #389

Option and flag that allows `background:color` to be rendered immediately, when the background assets are not ready yet.
 