### PR TITLE
asyncResourceGatherer: trace logs and exit behaviour

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -401,8 +401,6 @@ void CAsyncResourceGatherer::asyncAssetSpinLock() {
                 g_pHyprlock->addTimer(std::chrono::milliseconds(0), timerCallback, new STimerCallbackData{r.callback, r.callbackData});
         }
     }
-
-    dmas.clear();
 }
 
 void CAsyncResourceGatherer::requestAsyncAssetPreload(const SPreloadRequest& request) {
@@ -420,13 +418,14 @@ void CAsyncResourceGatherer::unloadAsset(SPreloadedAsset* asset) {
 
 void CAsyncResourceGatherer::notify() {
     std::lock_guard<std::mutex> lg(asyncLoopState.requestsMutex);
+    asyncLoopState.requests.clear();
     asyncLoopState.pending = true;
     asyncLoopState.requestsCV.notify_all();
 }
 
 void CAsyncResourceGatherer::await() {
-    if (asyncLoopThread.joinable())
-        asyncLoopThread.join();
     if (initialGatherThread.joinable())
         initialGatherThread.join();
+    if (asyncLoopThread.joinable())
+        asyncLoopThread.join();
 }

--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -385,6 +385,8 @@ void CAsyncResourceGatherer::asyncAssetSpinLock() {
 
         // process requests
         for (auto& r : requests) {
+            Debug::log(TRACE, "Processing requested resourceID {}", r.id);
+
             if (r.type == TARGET_TEXT) {
                 renderText(r);
             } else if (r.type == TARGET_IMAGE) {
@@ -404,6 +406,8 @@ void CAsyncResourceGatherer::asyncAssetSpinLock() {
 }
 
 void CAsyncResourceGatherer::requestAsyncAssetPreload(const SPreloadRequest& request) {
+    Debug::log(TRACE, "Requesting label resource {}", request.id);
+
     std::lock_guard<std::mutex> lg(asyncLoopState.requestsMutex);
     asyncLoopState.requests.push_back(request);
     asyncLoopState.pending = true;

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -147,11 +147,6 @@ bool CLabel::draw(const SRenderData& data) {
     return false;
 }
 
-static void onAssetCallbackTimer(std::shared_ptr<CTimer> self, void* data) {
-    const auto PLABEL = (CLabel*)data;
-    PLABEL->renderSuper();
-}
-
 void CLabel::renderSuper() {
     g_pHyprlock->renderOutput(outputStringPort);
 }


### PR DESCRIPTION
Trace logs should help debug label update problems.

`dmas.clear` in the asyncLoopThread sometimes caused a crash. So i removed it. Will get destroyed together with the asyncResourceGatherer. Also tought clearing requests would be a good idea when calling `AsyncResourceGatherer::notify`.