### PR TITLE
core: handle ext_session_lock_v1::finished as defined by the protocol

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -959,8 +959,15 @@ void CHyprlock::onLockLocked() {
 
 void CHyprlock::onLockFinished() {
     Debug::log(LOG, "onLockFinished called. Seems we got yeeten. Is another lockscreen running?");
-    g_pRenderer = nullptr;
-    exit(1);
+    if (m_bLocked)
+        // The `finished` event specifies that whenever the `locked` event has been recieved and the compositor sends `finished`,
+        // `unlock_and_destroy` should be called by the client.
+        // This does not mean the session gets unlocked! That is ultimatly the responsiblity of the compositor.
+        ext_session_lock_v1_unlock_and_destroy(m_sLockState.lock);
+    else
+        ext_session_lock_v1_destroy(m_sLockState.lock);
+
+    m_bTerminate = true;
 }
 
 ext_session_lock_manager_v1* CHyprlock::getSessionLockMgr() {


### PR DESCRIPTION
Closes #416

According to [ext_session_lock_v1::finished](https://wayland.app/protocols/ext-session-lock-v1#ext_session_lock_v1:event:finished)

>  Upon receiving this event, the client should make either the destroy request or the unlock_and_destroy request, depending on whether or not the locked event was received on this object.

Also `exit` previously did not terminate hyprlock properly. I think the right thing to do is to set `m_bTerminate`.