### PR TITLE
core: immediately create session lock surfaces

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -941,6 +941,12 @@ void CHyprlock::releaseSessionLock() {
         return;
     }
 
+    if (!m_bLocked) {
+        // Would be a protocol error to allow this
+        Debug::log(ERR, "Trying to unlock the session, but never recieved the locked event!");
+        return;
+    }
+
     ext_session_lock_v1_unlock_and_destroy(m_sLockState.lock);
     m_sLockState.lock = nullptr;
 

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -46,6 +46,8 @@ class CHyprlock {
     void                            acquireSessionLock();
     void                            releaseSessionLock();
 
+    void                            createSessionLockSurfaces();
+
     void                            attemptRestoreOnDeath();
 
     void                            spawnAsync(const std::string& cmd);


### PR DESCRIPTION
Instead of waiting for the `locked` event, create session lock surfaces right away.

Closes #420