### PR TITLE
core: grace unlock improvements and auth fixes for grace/SIGUSR1 unlocks

### DIFF
--- a/src/core/Auth.hpp
+++ b/src/core/Auth.hpp
@@ -18,15 +18,13 @@ class CAuth {
 
         bool                    waitingForPamAuth = false;
         bool                    inputRequested    = false;
-
-        bool                    success = false;
     };
 
     CAuth();
 
     void                       start();
     bool                       auth();
-    bool                       didAuthSucceed();
+    bool                       isAuthenticated();
 
     void                       waitForInput();
     void                       submitInput(std::string input);
@@ -44,7 +42,8 @@ class CAuth {
   private:
     SPamConversationState m_sConversationState;
 
-    bool                  m_bBlockInput = true;
+    bool                  m_bBlockInput    = true;
+    bool                  m_bAuthenticated = false;
 
     std::string           m_sPamModule;
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -585,6 +585,10 @@ void CHyprlock::unlock() {
     renderAllOutputs();
 }
 
+bool CHyprlock::isUnlocked() {
+    return m_bFadeStarted || m_bTerminate;
+}
+
 // wl_seat
 
 static void handlePointerEnter(void* data, struct wl_pointer* wl_pointer, uint32_t serial, struct wl_surface* surface, wl_fixed_t surface_x, wl_fixed_t surface_y) {
@@ -613,9 +617,7 @@ static void handlePointerMotion(void* data, struct wl_pointer* wl_pointer, uint3
     if (std::chrono::system_clock::now() > g_pHyprlock->m_tGraceEnds)
         return;
 
-    const auto UNLOCKED = g_pHyprlock->m_bTerminate || g_pHyprlock->m_bFadeStarted;
-    if (!UNLOCKED && g_pHyprlock->m_vLastEnterCoords.distance({wl_fixed_to_double(surface_x), wl_fixed_to_double(surface_y)}) > 5) {
-
+    if (!g_pHyprlock->isUnlocked() && g_pHyprlock->m_vLastEnterCoords.distance({wl_fixed_to_double(surface_x), wl_fixed_to_double(surface_y)}) > 5) {
         Debug::log(LOG, "In grace and cursor moved more than 5px, unlocking!");
         g_pHyprlock->unlock();
     }

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -772,13 +772,13 @@ static const ext_session_lock_v1_listener sessionLockListener = {
 
 void CHyprlock::onPasswordCheckTimer() {
     // check result
-    if (g_pAuth->didAuthSucceed()) {
+    if (g_pAuth->isAuthenticated()) {
         unlock();
     } else {
-        Debug::log(LOG, "Failed attempts: {}", m_sPasswordState.failedAttempts);
-
         m_sPasswordState.passBuffer = "";
         m_sPasswordState.failedAttempts += 1;
+        Debug::log(LOG, "Failed attempts: {}", m_sPasswordState.failedAttempts);
+
         g_pAuth->m_bDisplayFailText = true;
         forceUpdateTimers();
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -983,7 +983,8 @@ void CHyprlock::onLockFinished() {
     else
         ext_session_lock_v1_destroy(m_sLockState.lock);
 
-    m_bTerminate = true;
+    m_sLockState.lock = nullptr;
+    m_bTerminate      = true;
 }
 
 ext_session_lock_manager_v1* CHyprlock::getSessionLockMgr() {

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -31,6 +31,7 @@ class CHyprlock {
     void                            run();
 
     void                            unlock();
+    bool                            isUnlocked();
 
     void                            onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
     void                            onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);


### PR DESCRIPTION
Closes #423

Grace code previously respected the case when `m_bFadeStarted` was already set, but not `m_bTerminate` in case `gerneral:no_fade_out` is used.

Auth needs to check for `isUnlocked` to not cause a failed authentication attempt. Also we don't need to enqueue `passwordCheckTimerCallback` if we are already unlocked.

I didn't like `success` being part of `m_sConversationState`. So I moved it outside of it, used the return value of `auth` to set it and renamed it to `m_bAuthenticated`.

https://github.com/hyprwm/hyprlock/pull/424/commits/b6d2be62184dc3e06ed73f16d1ef4211d1433617 is just in there because i noticed it.

