### PR TITLE
widgets: move asset updates out of the draw function

### DIFF
--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -21,7 +21,7 @@ class CImage : public IWidget {
 
     virtual bool draw(const SRenderData& data);
 
-    void         renderSuper();
+    void         renderUpdate();
     void         onTimerUpdate();
     void         plantTimer();
 

--- a/src/renderer/widgets/Label.hpp
+++ b/src/renderer/widgets/Label.hpp
@@ -19,7 +19,7 @@ class CLabel : public IWidget {
 
     virtual bool draw(const SRenderData& data);
 
-    void         renderSuper();
+    void         renderUpdate();
     void         onTimerUpdate();
     void         plantTimer();
 


### PR DESCRIPTION
This allows us to check if the label has actually updated after the
callback from the asyncResourceGatherer. If it isn't we can requeue the
renderUpdate() function.

Probably fixes #390