### PR TITLE
auth: use pam_faillock log as $FAIL

### DIFF
--- a/src/core/Auth.hpp
+++ b/src/core/Auth.hpp
@@ -18,6 +18,7 @@ class CAuth {
 
         bool                    waitingForPamAuth = false;
         bool                    inputRequested    = false;
+        bool                    failTextFromPam   = false;
     };
 
     CAuth();


### PR DESCRIPTION
Allows us to show "(x minutes left to unlock)" directly in the input-field fail text.

I thought about how to best include the faillock message from pam_faillock. I considered the following options:
- Create a separate variable like `$PAM_LOG` that includes the entire pam log.
  Problem is that there are multiple lines and that does not work nicely in the input's placeholder text.
- Just look for the specific message and set it as `$FAIL` (This MR).
  Does not work if the message is translated.

Picked the second option, because I think it is more useful and works with the default value for `input:fail_text`
But it feels a bit hacky, so if anyone has a better idea, let me know.
