### PR TITLE
renderer: add `--no-fade-in`

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <algorithm>
 
-CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender) {
+CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender, const bool noFadeIn) {
     m_sWaylandState.display = wl_display_connect(wlDisplay.empty() ? nullptr : wlDisplay.c_str());
     if (!m_sWaylandState.display) {
         Debug::log(CRIT, "Couldn't connect to a wayland compositor");
@@ -40,6 +40,9 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediate, const b
 
     const auto PIMMEDIATERENDER = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:immediate_render");
     m_bImmediateRender          = immediateRender || **PIMMEDIATERENDER;
+
+    const auto* const PNOFADEIN   = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:no_fade_in");
+    m_bNoFadeIn = noFadeIn || **PNOFADEIN;
 }
 
 CHyprlock::~CHyprlock() {

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -25,7 +25,7 @@ struct SDMABUFModifier {
 
 class CHyprlock {
   public:
-    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender);
+    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender, const bool noFadeIn);
     ~CHyprlock();
 
     void                            run();
@@ -102,6 +102,9 @@ class CHyprlock {
     bool                            m_bFadeStarted = false;
 
     bool                            m_bImmediateRender = false;
+
+    bool                            m_bNoFadeIn = false;
+
     //
     std::chrono::system_clock::time_point m_tGraceEnds;
     std::chrono::system_clock::time_point m_tFadeEnds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@ void help() {
                  "  --display NAME           - Specify the Wayland display to connect to\n"
                  "  --immediate              - Lock immediately, ignoring any configured grace period\n"
                  "  --immediate-render       - Do not wait for resources before drawing the background\n"
+                 "  --no-fade-in              - Disable the fade-in animation when the lock screen appears\n"
                  "  -V, --version            - Show version information\n"
                  "  -h, --help               - Show this help message\n";
 }
@@ -32,6 +33,7 @@ int main(int argc, char** argv, char** envp) {
     std::string              wlDisplay;
     bool                     immediate       = false;
     bool                     immediateRender = false;
+    bool                     noFadeIn        = false;
 
     std::vector<std::string> args(argv, argv + argc);
 
@@ -72,6 +74,9 @@ int main(int argc, char** argv, char** envp) {
         else if (arg == "--immediate-render")
             immediateRender = true;
 
+        else if (arg == "--no-fade-in")
+            noFadeIn = true;
+
         else {
             std::cerr << "Unknown option: " << arg << "\n";
             help();
@@ -91,7 +96,7 @@ int main(int argc, char** argv, char** envp) {
     }
 
     try {
-        g_pHyprlock = std::make_unique<CHyprlock>(wlDisplay, immediate, immediateRender);
+        g_pHyprlock = std::make_unique<CHyprlock>(wlDisplay, immediate, immediateRender, noFadeIn);
         g_pHyprlock->run();
     } catch (const std::exception& ex) {
         Debug::log(CRIT, "Hyprlock threw: {}", ex.what());

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -162,7 +162,6 @@ static bool firstFullFrame = false;
 //
 CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf) {
     static auto* const PDISABLEBAR = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:disable_loading_bar");
-    static auto* const PNOFADEIN   = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:no_fade_in");
     static auto* const PNOFADEOUT  = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:no_fade_out");
 
     matrixProjection(projection.data(), surf.size.x, surf.size.y, WL_OUTPUT_TRANSFORM_NORMAL);
@@ -200,7 +199,7 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
 
         bga = std::clamp(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - firstFullFrameTime).count() / 500000.0, 0.0, 1.0);
 
-        if (**PNOFADEIN)
+        if (g_pHyprlock->m_bNoFadeIn)
             bga = 1.0;
 
         if (g_pHyprlock->m_bFadeStarted && !**PNOFADEOUT) {


### PR DESCRIPTION
This PR implements what I wished for in https://github.com/hyprwm/hyprlock/issues/452

It simply adds a `--no-fade-in` flag that disables the fade in animation when used, overwriting the use of no_fade_in (as if it was always set to true).

For the implementation, I mainly looked at the way `--immediate-render` was implemented.

LMK if there are any changes I should make, the main doubts I have are:
* is the internal `m_bNoFafeIn` name correct? not sure what the m and the b stand for.
* the commit name, should it start with `renderer:`? Would something else like `core:` be better?

