### PR TITLE
lockSurface: fix dynamic output mode and scale updates

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -16,11 +16,12 @@ static const ext_session_lock_surface_v1_listener lockListener = {
 
 static void handlePreferredScale(void* data, wp_fractional_scale_v1* wp_fractional_scale_v1, uint32_t scale) {
     const auto PSURF       = (CSessionLockSurface*)data;
+    const bool SAMESCALE   = PSURF->fractionalScale == scale / 120.0;
     PSURF->fractionalScale = scale / 120.0;
 
     Debug::log(LOG, "Got fractional scale: {}", PSURF->fractionalScale);
 
-    if (PSURF->readyForFrame)
+    if (!SAMESCALE && PSURF->readyForFrame)
         PSURF->onScaleUpdate();
 }
 

--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -57,10 +57,9 @@ CSessionLockSurface::CSessionLockSurface(COutput* output) : output(output) {
     }
 
     const auto PFRACTIONALSCALING = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:fractional_scaling");
-    const auto ENABLE_FSV1        = **PFRACTIONALSCALING == 1 ||
-        /* auto */ (**PFRACTIONALSCALING == 2 && (g_pHyprlock->m_sCurrentDesktop == "Hyprland" || g_pHyprlock->m_sCurrentDesktop == "niri"));
-    const auto PFRACTIONALMGR = g_pHyprlock->getFractionalMgr();
-    const auto PVIEWPORTER    = g_pHyprlock->getViewporter();
+    const auto ENABLE_FSV1        = **PFRACTIONALSCALING == 1 || /* auto enable */ (**PFRACTIONALSCALING == 2);
+    const auto PFRACTIONALMGR     = g_pHyprlock->getFractionalMgr();
+    const auto PVIEWPORTER        = g_pHyprlock->getViewporter();
 
     if (ENABLE_FSV1 && PFRACTIONALMGR && PVIEWPORTER) {
         fractional = wp_fractional_scale_manager_v1_get_fractional_scale(PFRACTIONALMGR, surface);

--- a/src/core/LockSurface.hpp
+++ b/src/core/LockSurface.hpp
@@ -34,6 +34,7 @@ class CSessionLockSurface {
     wl_egl_window*               eglWindow   = nullptr;
     Vector2D                     size;
     Vector2D                     logicalSize;
+    float                        appliedScale;
     EGLSurface                   eglSurface = nullptr;
     wp_fractional_scale_v1*      fractional = nullptr;
     wp_viewport*                 viewport   = nullptr;


### PR DESCRIPTION
Fixes dynamic output updates via programs like kanshi or wdisplays. (Ref #65)

Accidentally fixed fractional scaling on river and sway (hence e34f67a4f9a861bd05fb5a4a237b4539ea45bf70).
Turns out wlroots sends a correct configure event at some point, but we already created widgets with a wrong viewport. So dynamically removing them fixes it.

Now instead of destroying all widgets for the surface, we could also just update the viewport of all widgets.
Did not do that yet, since I did not want to give the IWidget base class a state and did not feel like implementing a viewport setter for all widgets. Let me know which one of the two sounds better, or if removing like this is fine (widgets will just get recreated with `getOrCreatedWidgetsFor`).