### PR TITLE
fix crash caused by exiting without joining running thread

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -405,8 +405,14 @@ void CHyprlock::run() {
 
     acquireSessionLock();
 
-    if (m_bTerminate) // Recieved finished
+    // Recieved finished
+    if (m_bTerminate) {
+        m_sLoopState.timerEvent = true;
+        m_sLoopState.timerCV.notify_all();
+        g_pRenderer->asyncResourceGatherer->notify();
+        g_pRenderer->asyncResourceGatherer->await();
         exit(1);
+    }
 
     g_pAuth = std::make_unique<CAuth>();
     g_pAuth->start();


### PR DESCRIPTION

Hyprlock crashes frequently in my case. When a crash occurs, GDB shows:

1. The main thread is trying to exit, and `CAsyncResourceGatherer` has already been destroyed.
2. `initialGatherThread` is still running, walking through `dmas` of the destroyed `CAsyncResourceGatherer` instance.

Calling await for `initialGatherThread` should fix this specific crash.
