### PR TITLE
input-field: refactor updateColors and other improvements

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -402,8 +402,8 @@ void CPasswordInputField::updateColors() {
     const bool NUMLOCK    = g_pHyprlock->m_bNumLock || (colorConfig.invertNum && !g_pHyprlock->m_bNumLock);
     const auto MULTI      = colorConfig.transitionMs == 0 ?
              1.0 :
-             std::clamp(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - colorState.lastFrame).count() / (double)colorConfig.transitionMs, 0.016,
-                        0.5);
+             std::clamp(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - colorState.lastFrame).count() / (double)colorConfig.transitionMs,
+                        0.0016, 0.5);
 
     CColor     targetColor;
 

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -63,23 +63,8 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     colorState.outer = colorConfig.outer;
     colorState.font  = colorConfig.font;
 
-    // Render placeholder if either placeholder_text or fail_text are non-empty
-    // as placeholder must be rendered to show fail_text
-    if (!configPlaceholderText.empty() || !configFailText.empty()) {
-        placeholder.currentText = configPlaceholderText;
-
-        replaceAll(placeholder.currentText, "$PROMPT", "");
-
-        placeholder.resourceID = "placeholder:" + placeholder.currentText + std::to_string((uintptr_t)this);
-        CAsyncResourceGatherer::SPreloadRequest request;
-        request.id                   = placeholder.resourceID;
-        request.asset                = placeholder.currentText;
-        request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-        request.props["font_family"] = std::string{"Sans"};
-        request.props["color"]       = CColor{1.0 - colorState.font.r, 1.0 - colorState.font.g, 1.0 - colorState.font.b, 0.5};
-        request.props["font_size"]   = (int)size.y / 4;
-        g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);
-    }
+    // request the inital placeholder asset
+    updatePlaceholder();
 }
 
 static void fadeOutCallback(std::shared_ptr<CTimer> self, void* data) {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -63,8 +63,6 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     colorState.outer = colorConfig.outer;
     colorState.font  = colorConfig.font;
 
-    g_pHyprlock->m_bNumLock = colorConfig.invertNum;
-
     // Render placeholder if either placeholder_text or fail_text are non-empty
     // as placeholder must be rendered to show fail_text
     if (!configPlaceholderText.empty() || !configFailText.empty()) {
@@ -416,6 +414,7 @@ static void changeColor(const CColor& source, const CColor& target, CColor& subj
 
 void CPasswordInputField::updateColors() {
     const bool BORDERLESS = outThick == 0;
+    const bool NUMLOCK    = g_pHyprlock->m_bNumLock || (colorConfig.invertNum && !g_pHyprlock->m_bNumLock);
     const auto MULTI      = colorConfig.transitionMs == 0 ?
              1.0 :
              std::clamp(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - colorState.lastFrame).count() / (double)colorConfig.transitionMs, 0.016,
@@ -429,11 +428,11 @@ void CPasswordInputField::updateColors() {
         targetColor = colorConfig.fail;
     }
 
-    if (g_pHyprlock->m_bCapsLock && g_pHyprlock->m_bNumLock) {
+    if (g_pHyprlock->m_bCapsLock && NUMLOCK) {
         targetColor = colorConfig.both;
     } else if (g_pHyprlock->m_bCapsLock) {
         targetColor = colorConfig.caps;
-    } else if (g_pHyprlock->m_bNumLock || !g_pHyprlock->m_bNumLock) {
+    } else if (NUMLOCK) {
         targetColor = colorConfig.num;
     }
 
@@ -441,12 +440,12 @@ void CPasswordInputField::updateColors() {
     CColor innerTarget = colorConfig.inner;
     CColor fontTarget  = (displayFail) ? colorConfig.fail : colorConfig.font;
 
-    if (checkWaiting || displayFail || g_pHyprlock->m_bCapsLock || g_pHyprlock->m_bNumLock) {
+    if (checkWaiting || displayFail || g_pHyprlock->m_bCapsLock || NUMLOCK) {
         if (BORDERLESS && colorConfig.swapFont) {
             fontTarget = targetColor;
         } else if (BORDERLESS && !colorConfig.swapFont) {
             innerTarget = targetColor;
-            // When changing the inne color the font cannot be fail_color
+            // When changing the inner color the font cannot be fail_color
             fontTarget = colorConfig.font;
         } else {
             outerTarget = targetColor;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -310,9 +310,10 @@ void CPasswordInputField::updatePlaceholder() {
         return;
     }
 
-    const auto AUTHFEEDBACK = g_pAuth->m_bDisplayFailText ? g_pAuth->getLastFailText().value_or("Ups, no fail text?") : g_pAuth->getLastPrompt().value_or("Ups, no prompt?");
+    const auto AUTHFEEDBACK   = g_pAuth->m_bDisplayFailText ? g_pAuth->getLastFailText().value_or("Ups, no fail text?") : g_pAuth->getLastPrompt().value_or("Ups, no prompt?");
+    const auto ALLOWCOLORSWAP = outThick == 0 && colorConfig.swapFont;
 
-    if (placeholder.lastAuthFeedback == AUTHFEEDBACK && g_pHyprlock->getPasswordFailedAttempts() == placeholder.failedAttempts)
+    if (!ALLOWCOLORSWAP && placeholder.lastAuthFeedback == AUTHFEEDBACK && g_pHyprlock->getPasswordFailedAttempts() == placeholder.failedAttempts)
         return;
 
     placeholder.failedAttempts   = g_pHyprlock->getPasswordFailedAttempts();

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -24,11 +24,13 @@ class CPasswordInputField : public IWidget {
     void        updateFade();
     void        updatePlaceholder();
     void        updateHiddenInputState();
+    void        updateInputState();
     void        updateColors();
 
     bool        firstRender  = true;
     bool        redrawShadow = false;
     bool        checkWaiting = false;
+    bool        displayFail  = false;
 
     size_t      passwordLength = 0;
 
@@ -69,7 +71,6 @@ class CPasswordInputField : public IWidget {
         std::string              currentText    = "";
         size_t                   failedAttempts = 0;
         bool                     canGetNewText  = true;
-        bool                     isFailText     = false;
 
         std::string              lastAuthFeedback;
 
@@ -96,15 +97,24 @@ class CPasswordInputField : public IWidget {
 
         int    transitionMs = 0;
         bool   invertNum    = false;
-        bool   animated     = false;
-        bool   stateNum     = false;
-        bool   stateCaps    = false;
         bool   swapFont     = false;
-        bool   shouldStart;
+    } colorConfig;
+
+    struct {
+        CColor outer;
+        CColor inner;
+        CColor font;
+
+        CColor outerSource;
+        CColor innerSource;
+
+        CColor currentTarget;
+
+        bool   animated = false;
 
         //
         std::chrono::system_clock::time_point lastFrame;
-    } col;
+    } colorState;
 
     bool        fadeOnEmpty;
     uint64_t    fadeTimeoutMs;


### PR DESCRIPTION
Looked into the `updateColor` code for the input field because of #468.
I did not understand what was going on, so I rewrote the function.

I think it behaves as it did before with all the different options, but now `swap_font_color` and `invert_numlock` work as expected.

Notable is that there are no animations for font color changes (which happen when `outline_thickness=0` and `swap_font_color=1`). As reported in #468 those options are currently broken.
I implemented animations for the font, but making subsequent requests to the asyncResourceGatherer with changing colors is not nice and lead to some problems. So the `updateColors` function just sets the font color without animating it.

I did quite a bit of testing but if someone can double check if everything works that would be appreciated.

Closes #468