### PR TITLE
core: support desc: prefix for widget monitor options

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -311,7 +311,8 @@ std::vector<std::unique_ptr<IWidget>>* CRenderer::getOrCreateWidgetsFor(const CS
         });
 
         for (auto& c : CWIDGETS) {
-            if (!c.monitor.empty() && c.monitor != surf->output->stringPort && !surf->output->stringDesc.starts_with(c.monitor))
+            if (!c.monitor.empty() && c.monitor != surf->output->stringPort && !surf->output->stringDesc.starts_with(c.monitor) &&
+                !surf->output->stringDesc.starts_with("desc:" + c.monitor))
                 continue;
 
             // by type


### PR DESCRIPTION
Just adds the possibility to use `desc:` in widgets monitor options.
As mentioned in https://github.com/hyprwm/hyprland-wiki/pull/746.