### PR TITLE
asyncResourceGatherer: do not detach worker threads

### DIFF
--- a/src/renderer/AsyncResourceGatherer.cpp
+++ b/src/renderer/AsyncResourceGatherer.cpp
@@ -18,10 +18,7 @@ CAsyncResourceGatherer::CAsyncResourceGatherer() {
         enqueueDMAFrames();
 
     initialGatherThread = std::thread([this]() { this->gather(); });
-    initialGatherThread.detach();
-
-    asyncLoopThread = std::thread([this]() { this->asyncAssetSpinLock(); });
-    asyncLoopThread.detach();
+    asyncLoopThread     = std::thread([this]() { this->asyncAssetSpinLock(); });
 }
 
 void CAsyncResourceGatherer::enqueueDMAFrames() {


### PR DESCRIPTION
Worker threads become non-joinable once they are detached, and `await()` will not wait for them to finish. This can lead to a crash when `asyncResourceGatherer` is destroyed in the main thread while it is still being used in worker threads.

It crashes several times daily in my case without this patch.