### PR TITLE
core: make attemptRestoreOnDeath faster and hyprland exclusive

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -1176,6 +1176,13 @@ void CHyprlock::attemptRestoreOnDeath() {
     ofs << timeNowMs;
     ofs.close();
 
+    if (m_bLocked && m_sLockState.lock) {
+        ext_session_lock_v1_destroy(m_sLockState.lock);
+
+        // Destroy sessionLockSurfaces
+        m_vOutputs.clear();
+    }
+
     spawnSync("hyprctl keyword misc:allow_session_lock_restore true");
     spawnSync("hyprctl dispatch exec \"hyprlock --immediate --immediate-render\"");
 }

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -1138,7 +1138,7 @@ zwlr_screencopy_manager_v1* CHyprlock::getScreencopy() {
 }
 
 void CHyprlock::attemptRestoreOnDeath() {
-    if (m_bTerminate)
+    if (m_bTerminate || m_sCurrentDesktop != "Hyprland")
         return;
 
     const auto XDG_RUNTIME_DIR = getenv("XDG_RUNTIME_DIR");
@@ -1177,5 +1177,5 @@ void CHyprlock::attemptRestoreOnDeath() {
     ofs.close();
 
     spawnSync("hyprctl keyword misc:allow_session_lock_restore true");
-    spawnAsync("sleep 2 && hyprlock --immediate --immediate-render & disown");
+    spawnSync("hyprctl dispatch exec \"hyprlock --immediate --immediate-render\"");
 }


### PR DESCRIPTION
`attemptRestoreOnDeath` only works with hyprland anyways.
This is why we now use `hyprctl dispatch exec` to relaunch hyprlock. Removing the need to `disown` the process.

Destoying the lock and lockSurfaces right away also allowed me to remove the `sleep 2 &&` part of the previous recover command and launch it in sync.

Fixes #504