### PR TITLE
config: add input-field dots_fade_time option

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -105,6 +105,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "dots_center", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "dots_spacing", Hyprlang::FLOAT{0.2});
     m_config.addSpecialConfigValue("input-field", "dots_rounding", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("input-field", "dots_fade_time", Hyprlang::INT{200});
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
@@ -258,6 +259,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"dots_spacing", m_config.getSpecialConfigValue("input-field", "dots_spacing", k.c_str())},
                 {"dots_center", m_config.getSpecialConfigValue("input-field", "dots_center", k.c_str())},
                 {"dots_rounding", m_config.getSpecialConfigValue("input-field", "dots_rounding", k.c_str())},
+                {"dots_fade_time", m_config.getSpecialConfigValue("input-field", "dots_fade_time", k.c_str())},
                 {"fade_on_empty", m_config.getSpecialConfigValue("input-field", "fade_on_empty", k.c_str())},
                 {"fade_timeout", m_config.getSpecialConfigValue("input-field", "fade_timeout", k.c_str())},
                 {"font_color", m_config.getSpecialConfigValue("input-field", "font_color", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -22,6 +22,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     dots.spacing             = std::any_cast<Hyprlang::FLOAT>(props.at("dots_spacing"));
     dots.center              = std::any_cast<Hyprlang::INT>(props.at("dots_center"));
     dots.rounding            = std::any_cast<Hyprlang::INT>(props.at("dots_rounding"));
+    dots.fadeMs              = std::any_cast<Hyprlang::INT>(props.at("dots_fade_time"));
     fadeOnEmpty              = std::any_cast<Hyprlang::INT>(props.at("fade_on_empty"));
     fadeTimeoutMs            = std::any_cast<Hyprlang::INT>(props.at("fade_timeout"));
     hiddenInputState.enabled = std::any_cast<Hyprlang::INT>(props.at("hide_input"));
@@ -138,7 +139,7 @@ void CPasswordInputField::updateDots() {
 
     const auto  DELTA = std::clamp((int)std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - dots.lastFrame).count(), 0, 20000);
 
-    const float TOADD = DELTA / 1000000.0 * dots.speedPerSecond;
+    const float TOADD = dots.fadeMs > 0 ? ((double)DELTA / 1000000.0) * (1000.0 / (double)dots.fadeMs) : 1;
 
     if (passwordLength > dots.currentAmount) {
         dots.currentAmount += TOADD;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -47,7 +47,7 @@ class CPasswordInputField : public IWidget {
 
     struct {
         float                                 currentAmount  = 0;
-        float                                 speedPerSecond = 5; // actually per... something. I am unsure xD
+        int                                   fadeMs         = 0;
         std::chrono::system_clock::time_point lastFrame;
         bool                                  center   = false;
         float                                 size     = 0;


### PR DESCRIPTION
Adds a config option `dots_fade_time` to `input-field` to control how many milliseconds it takes for dots to fade in and out while typing. Anything <= 0 is instant, disabling dots fading. The default is 200ms which is the same as before.

Closes: https://github.com/hyprwm/hyprlock/issues/355