### PR TITLE
input-field: add dots_text_format to support setting arbitrary chars as the input indicator

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -110,6 +110,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
+    m_config.addSpecialConfigValue("input-field", "font_family", Hyprlang::STRING{"Sans"});
     m_config.addSpecialConfigValue("input-field", "halign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("input-field", "valign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("input-field", "position", Hyprlang::VEC2{0, -20});
@@ -265,6 +266,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"fade_on_empty", m_config.getSpecialConfigValue("input-field", "fade_on_empty", k.c_str())},
                 {"fade_timeout", m_config.getSpecialConfigValue("input-field", "fade_timeout", k.c_str())},
                 {"font_color", m_config.getSpecialConfigValue("input-field", "font_color", k.c_str())},
+                {"font_family", m_config.getSpecialConfigValue("input-field", "font_family", k.c_str())},
                 {"halign", m_config.getSpecialConfigValue("input-field", "halign", k.c_str())},
                 {"valign", m_config.getSpecialConfigValue("input-field", "valign", k.c_str())},
                 {"position", m_config.getSpecialConfigValue("input-field", "position", k.c_str())},

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -106,6 +106,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "dots_spacing", Hyprlang::FLOAT{0.2});
     m_config.addSpecialConfigValue("input-field", "dots_rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "dots_fade_time", Hyprlang::INT{200});
+    m_config.addSpecialConfigValue("input-field", "dots_text_format", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
@@ -260,6 +261,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"dots_center", m_config.getSpecialConfigValue("input-field", "dots_center", k.c_str())},
                 {"dots_rounding", m_config.getSpecialConfigValue("input-field", "dots_rounding", k.c_str())},
                 {"dots_fade_time", m_config.getSpecialConfigValue("input-field", "dots_fade_time", k.c_str())},
+                {"dots_text_format", m_config.getSpecialConfigValue("input-field", "dots_text_format", k.c_str())},
                 {"fade_on_empty", m_config.getSpecialConfigValue("input-field", "fade_on_empty", k.c_str())},
                 {"fade_timeout", m_config.getSpecialConfigValue("input-field", "fade_timeout", k.c_str())},
                 {"font_color", m_config.getSpecialConfigValue("input-field", "font_color", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -31,6 +31,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     configPlaceholderText    = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
     configFailText           = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
     configFailTimeoutMs      = std::any_cast<Hyprlang::INT>(props.at("fail_timeout"));
+    fontFamily               = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
     colorConfig.transitionMs = std::any_cast<Hyprlang::INT>(props.at("fail_transition"));
     colorConfig.outer        = std::any_cast<Hyprlang::INT>(props.at("outer_color"));
     colorConfig.inner        = std::any_cast<Hyprlang::INT>(props.at("inner_color"));
@@ -71,7 +72,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
         request.id                   = dots.textResourceID;
         request.asset                = dots.textFormat;
         request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-        request.props["font_family"] = std::string{"Sans"};
+        request.props["font_family"] = fontFamily;
         request.props["color"]       = colorState.font;
         request.props["font_size"]   = (int)(std::nearbyint(size.y * dots.size * 0.5f) * 2.f);
 
@@ -380,7 +381,7 @@ void CPasswordInputField::updatePlaceholder() {
     request.id                   = placeholder.resourceID;
     request.asset                = placeholder.currentText;
     request.type                 = CAsyncResourceGatherer::eTargetType::TARGET_TEXT;
-    request.props["font_family"] = std::string{"Sans"};
+    request.props["font_family"] = fontFamily;
     request.props["color"]       = colorState.font;
     request.props["font_size"]   = (int)size.y / 4;
     g_pRenderer->asyncResourceGatherer->requestAsyncAssetPreload(request);

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -55,7 +55,7 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
 
     pos                      = posFromHVAlign(viewport, size, pos, halign, valign);
     dots.size                = std::clamp(dots.size, 0.2f, 0.8f);
-    dots.spacing             = std::clamp(dots.spacing, 0.f, 1.f);
+    dots.spacing             = std::clamp(dots.spacing, -1.f, 1.f);
     colorConfig.transitionMs = std::clamp(colorConfig.transitionMs, 0, 1000);
 
     colorConfig.both = colorConfig.both == -1 ? colorConfig.outer : colorConfig.both;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -49,10 +49,13 @@ class CPasswordInputField : public IWidget {
         float                                 currentAmount  = 0;
         int                                   fadeMs         = 0;
         std::chrono::system_clock::time_point lastFrame;
-        bool                                  center   = false;
-        float                                 size     = 0;
-        float                                 spacing  = 0;
-        int                                   rounding = 0;
+        bool                                  center     = false;
+        float                                 size       = 0;
+        float                                 spacing    = 0;
+        int                                   rounding   = 0;
+        std::string                           textFormat = "";
+        SPreloadedAsset*                      textAsset  = nullptr;
+        std::string                           textResourceID;
     } dots;
 
     struct {

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -40,14 +40,14 @@ class CPasswordInputField : public IWidget {
     Vector2D    configPos;
     Vector2D    configSize;
 
-    std::string halign, valign, configFailText, outputStringPort, configPlaceholderText;
+    std::string halign, valign, configFailText, outputStringPort, configPlaceholderText, fontFamily;
     uint64_t    configFailTimeoutMs = 2000;
 
     int         outThick, rounding;
 
     struct {
-        float                                 currentAmount  = 0;
-        int                                   fadeMs         = 0;
+        float                                 currentAmount = 0;
+        int                                   fadeMs        = 0;
         std::chrono::system_clock::time_point lastFrame;
         bool                                  center     = false;
         float                                 size       = 0;


### PR DESCRIPTION
This adds an option, that allows setting an arbitrary char to be rendered instead of a rectangle for the input fields dots.

Closes #316
Closes #482

Let me know if you think we should name the option something else.
Guy in #316 suggested `dots_mask_character`. Maybe just `dots_char`?
Currently the option does support multiple chars as well, so I chose `dots_text`. But in that case `dots_text_format` is a bit more clear I think.

I also added the `font_familiy` option to the input-field, in order for users to be able to use a nerd font for example.