### PR TITLE
renderer: log framebuffer creation as trace

### DIFF
--- a/src/renderer/Framebuffer.cpp
+++ b/src/renderer/Framebuffer.cpp
@@ -61,7 +61,7 @@ bool CFramebuffer::alloc(int w, int h, bool highres) {
             abort();
         }
 
-        Debug::log(LOG, "Framebuffer created, status {}", status);
+        Debug::log(TRACE, "Framebuffer created, status {}", status);
     }
 
     glBindTexture(GL_TEXTURE_2D, 0);


### PR DESCRIPTION
This just spams the logs and doesn't seem to be adding any valuable information.