### PR TITLE
core: lock m_vTimers for forceUpdateTimers

### DIFF
--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -115,7 +115,6 @@ class CHyprlock {
     std::shared_ptr<CTimer>               m_pKeyRepeatTimer = nullptr;
 
     std::vector<std::unique_ptr<COutput>> m_vOutputs;
-    std::vector<std::shared_ptr<CTimer>>  getTimers();
 
     struct {
         void*                        linuxDmabuf         = nullptr;
@@ -163,7 +162,9 @@ class CHyprlock {
 
         std::condition_variable timerCV;
         std::mutex              timerRequestMutex;
-        bool                    timerEvent = false;
+        bool                    timerEvent        = false;
+        std::atomic<bool>       forceUpdateTimers = false;
+
     } m_sLoopState;
 
     std::vector<std::shared_ptr<CTimer>> m_vTimers;


### PR DESCRIPTION
Previously `m_vTimers` was not locked when calling `handleForceUpdateSinal`. Don't know how but that might be the culprit behind #535.
To avoid problems with async signals, I introduced this atomtic variable and integrated `forceUpdateTimers` into the main loop instead of locking `m_vTimers` via a signal. 