### PR TITLE
misc: make Debug::log flush stdout

### DIFF
--- a/src/helpers/Log.hpp
+++ b/src/helpers/Log.hpp
@@ -52,6 +52,6 @@ namespace Debug {
             std::cout << "] ";
         }
 
-        std::cout << std::vformat(fmt, std::make_format_args(args...)) << "\n";
+        std::cout << std::vformat(fmt, std::make_format_args(args...)) << std::endl;
     }
 };


### PR DESCRIPTION
Makes it a lot easier to spot a failed RASSERT