### PR TITLE
core: add border shader and border gradients

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -1,12 +1,19 @@
 #pragma once
 #include "../helpers/Log.hpp"
+#include "../helpers/Color.hpp"
 #include <hyprutils/math/Vector2D.hpp>
+#include <hyprutils/string/VarList.hpp>
 #include <any>
 #include <string>
+#include <vector>
+#include <cmath>
+
+using namespace Hyprutils::String;
 
 enum eConfigValueDataTypes {
-    CVD_TYPE_INVALID = -1,
-    CVD_TYPE_LAYOUT  = 0,
+    CVD_TYPE_INVALID  = -1,
+    CVD_TYPE_LAYOUT   = 0,
+    CVD_TYPE_GRADIENT = 1,
 };
 
 class ICustomConfigValueData {
@@ -50,4 +57,58 @@ class CLayoutValueData : public ICustomConfigValueData {
         bool x = false;
         bool y = false;
     } m_sIsRelative;
+};
+
+class CGradientValueData : public ICustomConfigValueData {
+  public:
+    CGradientValueData() {};
+    CGradientValueData(CColor col) {
+        m_vColors.push_back(col);
+    };
+    virtual ~CGradientValueData() {};
+
+    virtual eConfigValueDataTypes getDataType() {
+        return CVD_TYPE_GRADIENT;
+    }
+
+    void reset(CColor col) {
+        m_vColors.clear();
+        m_vColors.emplace_back(col);
+        m_fAngle = 0;
+    }
+
+    /* Vector containing the colors */
+    std::vector<CColor> m_vColors;
+
+    /* Float corresponding to the angle (rad) */
+    float m_fAngle = 0;
+
+    //
+    bool operator==(const CGradientValueData& other) const {
+        if (other.m_vColors.size() != m_vColors.size() || m_fAngle != other.m_fAngle)
+            return false;
+
+        for (size_t i = 0; i < m_vColors.size(); ++i)
+            if (m_vColors[i] != other.m_vColors[i])
+                return false;
+
+        return true;
+    }
+
+    virtual std::string toString() {
+        std::string result;
+        for (auto& c : m_vColors) {
+            result += std::format("{:x} ", c.getAsHex());
+        }
+
+        result += std::format("{}deg", (int)(m_fAngle * 180.0 / M_PI));
+        return result;
+    }
+
+    static CGradientValueData* fromAnyPv(const std::any& v) {
+        RASSERT(v.type() == typeid(void*), "Invalid config value type");
+        const auto P = (CGradientValueData*)std::any_cast<void*>(v);
+        RASSERT(P, "Empty config value");
+        return P;
+    }
 };

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,5 +1,9 @@
 #include <filesystem>
 #include "MiscFunctions.hpp"
+#include "../helpers/Log.hpp"
+#include <hyprutils/string/String.hpp>
+
+using namespace Hyprutils::String;
 
 std::string absolutePath(const std::string& rawpath, const std::string& currentDir) {
     std::filesystem::path path(rawpath);
@@ -15,4 +19,44 @@ std::string absolutePath(const std::string& rawpath, const std::string& currentD
     } else {
         return std::filesystem::weakly_canonical(path);
     }
+}
+
+int64_t configStringToInt(const std::string& VALUE) {
+    if (VALUE.starts_with("0x")) {
+        // Values with 0x are hex
+        const auto VALUEWITHOUTHEX = VALUE.substr(2);
+        return stol(VALUEWITHOUTHEX, nullptr, 16);
+    } else if (VALUE.starts_with("rgba(") && VALUE.ends_with(')')) {
+        const auto VALUEWITHOUTFUNC = VALUE.substr(5, VALUE.length() - 6);
+
+        if (trim(VALUEWITHOUTFUNC).length() != 8) {
+            Debug::log(WARN, "invalid length {} for rgba", VALUEWITHOUTFUNC.length());
+            throw std::invalid_argument("rgba() expects length of 8 characters (4 bytes)");
+        }
+
+        const auto RGBA = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+
+        // now we need to RGBA -> ARGB. The config holds ARGB only.
+        return (RGBA >> 8) + 0x1000000 * (RGBA & 0xFF);
+    } else if (VALUE.starts_with("rgb(") && VALUE.ends_with(')')) {
+        const auto VALUEWITHOUTFUNC = VALUE.substr(4, VALUE.length() - 5);
+
+        if (trim(VALUEWITHOUTFUNC).length() != 6) {
+            Debug::log(WARN, "invalid length {} for rgb", VALUEWITHOUTFUNC.length());
+            throw std::invalid_argument("rgb() expects length of 6 characters (3 bytes)");
+        }
+
+        const auto RGB = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+
+        return RGB + 0xFF000000; // 0xFF for opaque
+    } else if (VALUE.starts_with("true") || VALUE.starts_with("on") || VALUE.starts_with("yes")) {
+        return 1;
+    } else if (VALUE.starts_with("false") || VALUE.starts_with("off") || VALUE.starts_with("no")) {
+        return 0;
+    }
+
+    if (VALUE.empty() || !isNumber(VALUE))
+        return 0;
+
+    return std::stoll(VALUE);
 }

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -5,3 +5,4 @@
 #include <hyprutils/math/Vector2D.hpp>
 
 std::string absolutePath(const std::string&, const std::string&);
+int64_t     configStringToInt(const std::string& VALUE);

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -6,8 +6,8 @@
 #include "Shader.hpp"
 #include "../core/LockSurface.hpp"
 #include "../helpers/Color.hpp"
-#include "../helpers/Math.hpp"
 #include "AsyncResourceGatherer.hpp"
+#include "../config/ConfigDataValues.hpp"
 #include "widgets/IWidget.hpp"
 #include "Framebuffer.hpp"
 
@@ -31,6 +31,7 @@ class CRenderer {
     SRenderFeedback                         renderLock(const CSessionLockSurface& surface);
 
     void                                    renderRect(const CBox& box, const CColor& col, int rounding = 0);
+    void                                    renderBorder(const CBox& box, const CGradientValueData& gradient, int thickness, int rounding = 0, float alpha = 1.0);
     void                                    renderTexture(const CBox& box, const CTexture& tex, float a = 1.0, int rounding = 0, std::optional<eTransform> tr = {});
     void                                    blurFB(const CFramebuffer& outfb, SBlurParams params);
 
@@ -53,6 +54,7 @@ class CRenderer {
     CShader                                blurShader2;
     CShader                                blurPrepareShader;
     CShader                                blurFinishShader;
+    CShader                                borderShader;
 
     Mat3x3                                 projMatrix = Mat3x3::identity();
     Mat3x3                                 projection;

--- a/src/renderer/Shaders.hpp
+++ b/src/renderer/Shaders.hpp
@@ -362,3 +362,120 @@ void main() {
     gl_FragColor = pixColor;
 }
 )#";
+
+// makes a stencil without corners
+inline const std::string FRAGBORDER = R"#(
+precision highp float;
+varying vec4 v_color;
+varying vec2 v_texcoord;
+
+uniform vec2 topLeft;
+uniform vec2 fullSize;
+uniform vec2 fullSizeUntransformed;
+uniform float radius;
+uniform float radiusOuter;
+uniform float thick;
+
+uniform vec4 gradient[10];
+uniform int gradientLength;
+uniform float angle;
+uniform float alpha;
+
+vec4 getColorForCoord(vec2 normalizedCoord) {
+    if (gradientLength < 2)
+        return gradient[0];
+
+    float finalAng = 0.0;
+
+    if (angle > 4.71 /* 270 deg */) {
+        normalizedCoord[1] = 1.0 - normalizedCoord[1];
+        finalAng = 6.28 - angle;
+    } else if (angle > 3.14 /* 180 deg */) {
+        normalizedCoord[0] = 1.0 - normalizedCoord[0];
+        normalizedCoord[1] = 1.0 - normalizedCoord[1];
+        finalAng = angle - 3.14;
+    } else if (angle > 1.57 /* 90 deg */) {
+        normalizedCoord[0] = 1.0 - normalizedCoord[0];
+        finalAng = 3.14 - angle;
+    } else {
+        finalAng = angle;
+    }
+
+    float sine = sin(finalAng);
+
+    float progress = (normalizedCoord[1] * sine + normalizedCoord[0] * (1.0 - sine)) * float(gradientLength - 1);
+    int bottom = int(floor(progress));
+    int top = bottom + 1;
+
+    return gradient[top] * (progress - float(bottom)) + gradient[bottom] * (float(top) - progress);
+}
+
+void main() {
+
+    highp vec2 pixCoord = vec2(gl_FragCoord);
+    highp vec2 pixCoordOuter = pixCoord;
+    highp vec2 originalPixCoord = v_texcoord;
+    originalPixCoord *= fullSizeUntransformed;
+    float additionalAlpha = 1.0;
+
+    vec4 pixColor = vec4(1.0, 1.0, 1.0, 1.0);
+
+    bool done = false;
+
+    pixCoord -= topLeft + fullSize * 0.5;
+    pixCoord *= vec2(lessThan(pixCoord, vec2(0.0))) * -2.0 + 1.0;
+    pixCoordOuter = pixCoord;
+    pixCoord -= fullSize * 0.5 - radius;
+    pixCoordOuter -= fullSize * 0.5 - radiusOuter;
+
+    // center the pixes dont make it top-left
+    pixCoord += vec2(1.0, 1.0) / fullSize;
+    pixCoordOuter += vec2(1.0, 1.0) / fullSize;
+
+    if (min(pixCoord.x, pixCoord.y) > 0.0 && radius > 0.0) {
+	    float dist = length(pixCoord);
+	    float distOuter = length(pixCoordOuter);
+        float h = (thick / 2.0);
+
+	    if (dist < radius - h) {
+            // lower
+            float normalized = smoothstep(0.0, 1.0, dist - radius + thick + 0.5);
+            additionalAlpha *= normalized;
+            done = true;
+        } else if (min(pixCoordOuter.x, pixCoordOuter.y) > 0.0) {
+            // higher
+            float normalized = 1.0 - smoothstep(0.0, 1.0, distOuter - radiusOuter + 0.5);
+            additionalAlpha *= normalized;
+            done = true;
+        } else if (distOuter < radiusOuter - h) {
+            additionalAlpha = 1.0;
+            done = true;
+        }
+    }
+
+    // now check for other shit
+    if (!done) {
+        // distance to all straight bb borders
+        float distanceT = originalPixCoord[1];
+        float distanceB = fullSizeUntransformed[1] - originalPixCoord[1];
+        float distanceL = originalPixCoord[0];
+        float distanceR = fullSizeUntransformed[0] - originalPixCoord[0];
+
+        // get the smallest
+        float smallest = min(min(distanceT, distanceB), min(distanceL, distanceR));
+
+        if (smallest > thick)
+            discard;
+    }
+
+    if (additionalAlpha == 0.0)
+        discard;
+
+    pixColor = getColorForCoord(v_texcoord);
+    pixColor.rgb *= pixColor[3];
+
+    pixColor *= alpha * additionalAlpha;
+
+    gl_FragColor = pixColor;
+}
+)#";

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -86,7 +86,7 @@ CImage::CImage(const Vector2D& viewport_, COutput* output_, const std::string& r
         size     = std::any_cast<Hyprlang::INT>(props.at("size"));
         rounding = std::any_cast<Hyprlang::INT>(props.at("rounding"));
         border   = std::any_cast<Hyprlang::INT>(props.at("border_size"));
-        color    = std::any_cast<Hyprlang::INT>(props.at("border_color"));
+        color    = *CGradientValueData::fromAnyPv(props.at("border_color"));
         pos      = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
         halign   = std::any_cast<Hyprlang::STRING>(props.at("halign"));
         valign   = std::any_cast<Hyprlang::STRING>(props.at("valign"));
@@ -156,7 +156,8 @@ bool CImage::draw(const SRenderData& data) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
-            g_pRenderer->renderRect(borderBox, color, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : std::min(borderBox.w, borderBox.h) / 2.0);
+            g_pRenderer->renderBorder(borderBox, color, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : std::min(borderBox.w, borderBox.h) / 2.0,
+                                      data.opacity);
 
         texbox.round();
         g_pRenderer->renderTexture(texbox, asset->texture, 1.0, ALLOWROUND ? rounding : std::min(texbox.w, texbox.h) / 2.0, HYPRUTILS_TRANSFORM_NORMAL);

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -3,6 +3,7 @@
 #include "IWidget.hpp"
 #include "../../helpers/Color.hpp"
 #include "../../helpers/Math.hpp"
+#include "../../config/ConfigDataValues.hpp"
 #include "../../core/Timer.hpp"
 #include "../AsyncResourceGatherer.hpp"
 #include "Shadowable.hpp"
@@ -32,7 +33,7 @@ class CImage : public IWidget {
     int                                     rounding;
     double                                  border;
     double                                  angle;
-    CColor                                  color;
+    CGradientValueData                      color;
     Vector2D                                pos;
 
     std::string                             halign, valign, path;

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -5,6 +5,7 @@
 #include "../../helpers/Math.hpp"
 #include "../../core/Timer.hpp"
 #include "Shadowable.hpp"
+#include "src/config/ConfigDataValues.hpp"
 #include <chrono>
 #include <vector>
 #include <any>
@@ -89,31 +90,31 @@ class CPasswordInputField : public IWidget {
     } hiddenInputState;
 
     struct {
-        CColor outer;
-        CColor inner;
-        CColor font;
-        CColor fail;
-        CColor check;
-        CColor caps;
-        CColor num;
-        CColor both;
+        CGradientValueData* outer = nullptr;
+        CColor              inner;
+        CColor              font;
+        CGradientValueData* fail  = nullptr;
+        CGradientValueData* check = nullptr;
+        CGradientValueData* caps  = nullptr;
+        CGradientValueData* num   = nullptr;
+        CGradientValueData* both  = nullptr;
 
-        int    transitionMs = 0;
-        bool   invertNum    = false;
-        bool   swapFont     = false;
+        int                 transitionMs = 0;
+        bool                invertNum    = false;
+        bool                swapFont     = false;
     } colorConfig;
 
     struct {
-        CColor outer;
-        CColor inner;
-        CColor font;
+        CGradientValueData  outer;
+        CColor              inner;
+        CColor              font;
 
-        CColor outerSource;
-        CColor innerSource;
+        CGradientValueData* outerSource = nullptr;
+        CColor              innerSource;
 
-        CColor currentTarget;
+        CGradientValueData* currentTarget = nullptr;
 
-        bool   animated = false;
+        bool                animated = false;
 
         //
         std::chrono::system_clock::time_point lastFrame;

--- a/src/renderer/widgets/Shape.cpp
+++ b/src/renderer/widgets/Shape.cpp
@@ -7,16 +7,16 @@
 CShape::CShape(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props) : shadow(this, props, viewport_) {
 
     try {
-        size        = CLayoutValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
-        rounding    = std::any_cast<Hyprlang::INT>(props.at("rounding"));
-        border      = std::any_cast<Hyprlang::INT>(props.at("border_size"));
-        color       = std::any_cast<Hyprlang::INT>(props.at("color"));
-        borderColor = std::any_cast<Hyprlang::INT>(props.at("border_color"));
-        pos         = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
-        halign      = std::any_cast<Hyprlang::STRING>(props.at("halign"));
-        valign      = std::any_cast<Hyprlang::STRING>(props.at("valign"));
-        angle       = std::any_cast<Hyprlang::FLOAT>(props.at("rotate"));
-        xray        = std::any_cast<Hyprlang::INT>(props.at("xray"));
+        size       = CLayoutValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
+        rounding   = std::any_cast<Hyprlang::INT>(props.at("rounding"));
+        border     = std::any_cast<Hyprlang::INT>(props.at("border_size"));
+        color      = std::any_cast<Hyprlang::INT>(props.at("color"));
+        borderGrad = *CGradientValueData::fromAnyPv(props.at("border_color"));
+        pos        = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
+        halign     = std::any_cast<Hyprlang::STRING>(props.at("halign"));
+        valign     = std::any_cast<Hyprlang::STRING>(props.at("valign"));
+        angle      = std::any_cast<Hyprlang::FLOAT>(props.at("rotate"));
+        xray       = std::any_cast<Hyprlang::INT>(props.at("xray"));
     } catch (const std::bad_any_cast& e) {
         RASSERT(false, "Failed to construct CShape: {}", e.what()); //
     } catch (const std::out_of_range& e) {
@@ -54,10 +54,8 @@ bool CShape::draw(const SRenderData& data) {
 
     if (xray) {
         if (border > 0) {
-            const int PIROUND   = std::min(MINHALFBORDER, std::round(border * M_PI));
-            CColor    borderCol = borderColor;
-            borderCol.a *= data.opacity;
-            g_pRenderer->renderRect(borderBox, borderCol, rounding == -1 ? PIROUND : std::clamp(rounding, 0, PIROUND));
+            const int PIROUND = std::min(MINHALFBORDER, std::round(border * M_PI));
+            g_pRenderer->renderBorder(borderBox, borderGrad, border, rounding == -1 ? PIROUND : std::clamp(rounding, 0, PIROUND), data.opacity);
         }
 
         glEnable(GL_SCISSOR_TEST);
@@ -79,7 +77,7 @@ bool CShape::draw(const SRenderData& data) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
-            g_pRenderer->renderRect(borderBox, borderColor, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : MINHALFBORDER);
+            g_pRenderer->renderBorder(borderBox, borderGrad, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : MINHALFBORDER, data.opacity);
 
         g_pRenderer->renderRect(shapeBox, color, ALLOWROUND ? rounding : MINHALFSHAPE);
         g_pRenderer->popFb();

--- a/src/renderer/widgets/Shape.hpp
+++ b/src/renderer/widgets/Shape.hpp
@@ -2,6 +2,7 @@
 
 #include "IWidget.hpp"
 #include "../../helpers/Color.hpp"
+#include "../../config/ConfigDataValues.hpp"
 #include "Shadowable.hpp"
 #include <hyprutils/math/Box.hpp>
 #include <string>
@@ -15,23 +16,23 @@ class CShape : public IWidget {
     virtual bool draw(const SRenderData& data);
 
   private:
-    CFramebuffer shapeFB;
+    CFramebuffer       shapeFB;
 
-    int          rounding;
-    double       border;
-    double       angle;
-    CColor       color;
-    CColor       borderColor;
-    Vector2D     size;
-    Vector2D     pos;
-    CBox         shapeBox;
-    CBox         borderBox;
-    bool         xray;
+    int                rounding;
+    double             border;
+    double             angle;
+    CColor             color;
+    CGradientValueData borderGrad;
+    Vector2D           size;
+    Vector2D           pos;
+    CBox               shapeBox;
+    CBox               borderBox;
+    bool               xray;
 
-    std::string  halign, valign;
+    std::string        halign, valign;
 
-    bool         firstRender = true;
+    bool               firstRender = true;
 
-    Vector2D     viewport;
-    CShadowable  shadow;
+    Vector2D           viewport;
+    CShadowable        shadow;
 };


### PR DESCRIPTION
Allows all sorts of nice theming stuff.
`changeGrad` also looks pretty cool when used with gradients.

Also thought about some kind of rotate option to let the gradient rotate, when auth is checking. Maybe in the future.

Closes #458