### PR TITLE
widgets: render frambuffers with alpha 1.0

### DIFF
--- a/src/helpers/Color.cpp
+++ b/src/helpers/Color.cpp
@@ -21,6 +21,6 @@ CColor::CColor(uint64_t hex) {
     this->a = ALPHA(hex);
 }
 
-uint64_t CColor::getAsHex() {
-    return ((int)a) * 0x1000000 + ((int)r) * 0x10000 + ((int)g) * 0x100 + ((int)b) * 0x1;
+uint32_t CColor::getAsHex() const {
+    return (uint32_t)(a * 255.f) * 0x1000000 + (uint32_t)(r * 255.f) * 0x10000 + (uint32_t)(g * 255.f) * 0x100 + (uint32_t)(b * 255.f) * 0x1;
 }

--- a/src/helpers/Color.hpp
+++ b/src/helpers/Color.hpp
@@ -8,9 +8,10 @@ class CColor {
     CColor(float r, float g, float b, float a);
     CColor(uint64_t);
 
-    float    r = 0, g = 0, b = 0, a = 1.f;
+    float r = 0, g = 0, b = 0, a = 1.f;
 
-    uint64_t getAsHex();
+    // AR32
+    uint32_t getAsHex() const;
 
     CColor   operator-(const CColor& c2) const {
         return CColor(r - c2.r, g - c2.g, b - c2.b, a - c2.a);

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -157,7 +157,7 @@ bool CImage::draw(const SRenderData& data) {
 
         if (border > 0)
             g_pRenderer->renderBorder(borderBox, color, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : std::min(borderBox.w, borderBox.h) / 2.0,
-                                      data.opacity);
+                                      1.0);
 
         texbox.round();
         g_pRenderer->renderTexture(texbox, asset->texture, 1.0, ALLOWROUND ? rounding : std::min(texbox.w, texbox.h) / 2.0, HYPRUTILS_TRANSFORM_NORMAL);

--- a/src/renderer/widgets/Shape.cpp
+++ b/src/renderer/widgets/Shape.cpp
@@ -77,7 +77,7 @@ bool CShape::draw(const SRenderData& data) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
-            g_pRenderer->renderBorder(borderBox, borderGrad, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : MINHALFBORDER, data.opacity);
+            g_pRenderer->renderBorder(borderBox, borderGrad, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : MINHALFBORDER, 1.0);
 
         g_pRenderer->renderRect(shapeBox, color, ALLOWROUND ? rounding : MINHALFSHAPE);
         g_pRenderer->popFb();


### PR DESCRIPTION
I broke shape and image borders on accident by using `data.opacity`.
Did not realize it because i don't use fade-in.

CC @alba4k