### PR TITLE
input-field: fix colorConfig caps, num and both when they are empty

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -83,7 +83,9 @@ class CGradientValueData : public ICustomConfigValueData {
     /* Float corresponding to the angle (rad) */
     float m_fAngle = 0;
 
-    //
+    /* Whether this gradient stores a fallback value (not exlicitly set) */
+    bool m_bIsFallback = false;
+
     bool operator==(const CGradientValueData& other) const {
         if (other.m_vColors.size() != m_vColors.size() || m_fAngle != other.m_fAngle)
             return false;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -80,6 +80,7 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
 
     CVarList   varlist(V, 0, ' ');
     DATA->m_vColors.clear();
+    DATA->m_bIsFallback = false;
 
     std::string parseError = "";
 
@@ -108,6 +109,11 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
             Debug::log(WARN, "Error parsing gradient {}", V);
             parseError = "Error parsing gradient " + V + ": " + e.what();
         }
+    }
+
+    if (V.empty()) {
+        DATA->m_bIsFallback = true;
+        DATA->m_vColors.push_back(0); // transparent
     }
 
     if (DATA->m_vColors.size() == 0) {

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -56,10 +56,9 @@ CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::u
     dots.size                = std::clamp(dots.size, 0.2f, 0.8f);
     dots.spacing             = std::clamp(dots.spacing, -1.f, 1.f);
     colorConfig.transitionMs = std::clamp(colorConfig.transitionMs, 0, 1000);
-
-    colorConfig.both = colorConfig.both->m_vColors.empty() ? colorConfig.outer : colorConfig.both;
-    colorConfig.caps = colorConfig.caps->m_vColors.empty() ? colorConfig.outer : colorConfig.caps;
-    colorConfig.num  = colorConfig.num->m_vColors.empty() ? colorConfig.outer : colorConfig.num;
+    colorConfig.both         = colorConfig.both->m_bIsFallback ? colorConfig.outer : colorConfig.both;
+    colorConfig.caps         = colorConfig.caps->m_bIsFallback ? colorConfig.outer : colorConfig.caps;
+    colorConfig.num          = colorConfig.num->m_bIsFallback ? colorConfig.outer : colorConfig.num;
 
     colorState.inner       = colorConfig.inner;
     colorState.outer       = *colorConfig.outer;


### PR DESCRIPTION
The `m_vColors.empty()` check did not work like i thought it would.

To differentiate between legitimate `CColor(0)` with angle 0, I added this `m_bIsFallback` boolean. Other option would have been to allow `m_vColors` to be empty, but I think that is not a good idea.