### PR TITLE
auth: add an interface for different authentication methods

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -100,14 +100,11 @@ void CAuth::terminate() {
 }
 
 static void passwordCheckTimerCallback(std::shared_ptr<CTimer> self, void* data) {
-    const auto PCLEAR = (bool*)data;
     // check result
     if (g_pAuth->isAuthenticated()) {
         g_pHyprlock->unlock();
     } else {
-        if (*PCLEAR)
-            g_pHyprlock->clearPasswordBuffer();
-
+        g_pHyprlock->clearPasswordBuffer();
         g_pAuth->m_iFailedAttempts += 1;
         Debug::log(LOG, "Failed attempts: {}", g_pAuth->m_iFailedAttempts);
 
@@ -118,8 +115,8 @@ static void passwordCheckTimerCallback(std::shared_ptr<CTimer> self, void* data)
     }
 }
 
-void CAuth::enqueueCheckAuthenticated(bool clearPasswordBuffer) {
-    g_pHyprlock->addTimer(std::chrono::milliseconds(1), passwordCheckTimerCallback, new bool(clearPasswordBuffer));
+void CAuth::enqueueCheckAuthenticated() {
+    g_pHyprlock->addTimer(std::chrono::milliseconds(1), passwordCheckTimerCallback, nullptr);
 }
 
 void CAuth::postActivity(eAuthImplementations implType) {

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -1,0 +1,109 @@
+#include "Auth.hpp"
+#include "Pam.hpp"
+#include "Fingerprint.hpp"
+#include "../config/ConfigManager.hpp"
+#include "../core/hyprlock.hpp"
+#include "src/helpers/Log.hpp"
+
+#include <hyprlang.hpp>
+#include <memory>
+
+CAuth::CAuth() {
+    m_vImpls.push_back(std::make_shared<CPam>());
+    static auto* const PENABLEFINGERPRINT = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:enable_fingerprint");
+    if (**PENABLEFINGERPRINT)
+        m_vImpls.push_back(std::make_shared<CFingerprint>());
+}
+
+void CAuth::start() {
+    for (const auto& i : m_vImpls) {
+        i->init();
+    }
+}
+
+void CAuth::submitInput(const std::string& input) {
+    for (const auto& i : m_vImpls) {
+        i->handleInput(input);
+    }
+}
+
+bool CAuth::isAuthenticated() {
+    for (const auto& i : m_vImpls) {
+        if (i->isAuthenticated())
+            return true;
+    }
+
+    return false;
+}
+
+bool CAuth::checkWaiting() {
+    for (const auto& i : m_vImpls) {
+        if (i->checkWaiting())
+            return true;
+    }
+
+    return false;
+}
+
+std::string CAuth::getInlineFeedback() {
+    for (const auto& i : m_vImpls) {
+        const auto FEEDBACK = (m_bDisplayFailText) ? i->getLastFailText() : i->getLastPrompt();
+        if (FEEDBACK.has_value())
+            return FEEDBACK.value();
+    }
+
+    return "Ups, empty authentication feedack";
+}
+
+std::optional<std::string> CAuth::getFailText(eAuthImplementations implType) {
+    for (const auto& i : m_vImpls) {
+        if (i->getImplType() == implType) {
+            return i->getLastFailText();
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> CAuth::getPrompt(eAuthImplementations implType) {
+    for (const auto& i : m_vImpls) {
+        if (i->getImplType() == implType) {
+            return i->getLastPrompt();
+        }
+    }
+    return std::nullopt;
+}
+
+std::shared_ptr<IAuthImplementation> CAuth::getImpl(eAuthImplementations implType) {
+    for (const auto& i : m_vImpls) {
+        if (i->getImplType() == implType)
+            return i;
+    }
+
+    return nullptr;
+}
+
+void CAuth::terminate() {
+    for (const auto& i : m_vImpls) {
+        i->terminate();
+    }
+}
+
+static void passwordCheckTimerCallback(std::shared_ptr<CTimer> self, void* data) {
+    // check result
+    if (g_pAuth->isAuthenticated()) {
+        g_pHyprlock->unlock();
+    } else {
+        g_pHyprlock->clearPasswordBuffer();
+        g_pAuth->m_iFailedAttempts += 1;
+        Debug::log(LOG, "Failed attempts: {}", g_pAuth->m_iFailedAttempts);
+
+        g_pAuth->m_bDisplayFailText = true;
+        g_pHyprlock->enqueueForceUpdateTimers();
+
+        g_pHyprlock->renderAllOutputs();
+    }
+}
+
+void CAuth::enqueueCheckAuthenticated() {
+    g_pHyprlock->addTimer(std::chrono::milliseconds(1), passwordCheckTimerCallback, nullptr);
+}

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -68,18 +68,16 @@ std::string CAuth::getInlineFeedback() {
 
 std::optional<std::string> CAuth::getFailText(eAuthImplementations implType) {
     for (const auto& i : m_vImpls) {
-        if (i->getImplType() == implType) {
+        if (i->getImplType() == implType)
             return i->getLastFailText();
-        }
     }
     return std::nullopt;
 }
 
 std::optional<std::string> CAuth::getPrompt(eAuthImplementations implType) {
     for (const auto& i : m_vImpls) {
-        if (i->getImplType() == implType) {
+        if (i->getImplType() == implType)
             return i->getLastPrompt();
-        }
     }
     return std::nullopt;
 }
@@ -101,11 +99,11 @@ void CAuth::terminate() {
 
 static void passwordCheckTimerCallback(std::shared_ptr<CTimer> self, void* data) {
     // check result
-    if (g_pAuth->isAuthenticated()) {
+    if (g_pAuth->isAuthenticated())
         g_pHyprlock->unlock();
-    } else {
+    else {
         g_pHyprlock->clearPasswordBuffer();
-        g_pAuth->m_iFailedAttempts += 1;
+        g_pAuth->m_iFailedAttempts++;
         Debug::log(LOG, "Failed attempts: {}", g_pAuth->m_iFailedAttempts);
 
         g_pAuth->m_bDisplayFailText = true;

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -7,12 +7,17 @@
 
 #include <hyprlang.hpp>
 #include <memory>
+#include <optional>
 
 CAuth::CAuth() {
-    m_vImpls.push_back(std::make_shared<CPam>());
-    static auto* const PENABLEFINGERPRINT = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:enable_fingerprint");
+    static auto* const PENABLEPAM = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("auth:pam:enabled");
+    if (**PENABLEPAM)
+        m_vImpls.push_back(std::make_shared<CPam>());
+    static auto* const PENABLEFINGERPRINT = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("auth:fingerprint:enabled");
     if (**PENABLEFINGERPRINT)
         m_vImpls.push_back(std::make_shared<CFingerprint>());
+
+    RASSERT(!m_vImpls.empty(), "At least one authentication method must be enabled!");
 }
 
 void CAuth::start() {

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -36,7 +36,8 @@ class CAuth {
     bool checkWaiting();
 
     // Used by the PasswordInput field. We are constraint to a single line for the authentication feedback there.
-    // Based on m_bDisplayFailText, this will return either the fail text or the prompt. This result can also be influence by the auth configuration.
+    // Based on m_bDisplayFailText, this will return either the fail text or the prompt.
+    // Based on m_eLastActiveImpl, it will select the implementation.
     std::string                          getInlineFeedback();
 
     std::optional<std::string>           getFailText(eAuthImplementations implType);
@@ -51,9 +52,11 @@ class CAuth {
     size_t m_iFailedAttempts  = 0;
 
     void   enqueueCheckAuthenticated();
+    void   postActivity(eAuthImplementations implType);
 
   private:
     std::vector<std::shared_ptr<IAuthImplementation>> m_vImpls;
+    std::optional<eAuthImplementations>               m_eLastActiveImpl = std::nullopt;
 };
 
 inline std::unique_ptr<CAuth> g_pAuth;

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -51,7 +51,7 @@ class CAuth {
     bool   m_bDisplayFailText = false;
     size_t m_iFailedAttempts  = 0;
 
-    void   enqueueCheckAuthenticated();
+    void   enqueueCheckAuthenticated(bool clearPasswordBuffer = true);
     void   postActivity(eAuthImplementations implType);
 
   private:

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -16,7 +16,6 @@ class IAuthImplementation {
     virtual eAuthImplementations       getImplType()                         = 0;
     virtual void                       init()                                = 0;
     virtual void                       handleInput(const std::string& input) = 0;
-    virtual bool                       isAuthenticated()                     = 0;
     virtual bool                       checkWaiting()                        = 0;
     virtual std::optional<std::string> getLastFailText()                     = 0;
     virtual std::optional<std::string> getLastPrompt()                       = 0;
@@ -32,7 +31,6 @@ class CAuth {
     void start();
 
     void submitInput(const std::string& input);
-    bool isAuthenticated();
     bool checkWaiting();
 
     // Used by the PasswordInput field. We are constraint to a single line for the authentication feedback there.
@@ -51,7 +49,8 @@ class CAuth {
     bool   m_bDisplayFailText = false;
     size_t m_iFailedAttempts  = 0;
 
-    void   enqueueCheckAuthenticated();
+    void   enqueueUnlock();
+    void   enqueueFail();
     void   postActivity(eAuthImplementations implType);
 
   private:

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -51,7 +51,7 @@ class CAuth {
     bool   m_bDisplayFailText = false;
     size_t m_iFailedAttempts  = 0;
 
-    void   enqueueCheckAuthenticated(bool clearPasswordBuffer = true);
+    void   enqueueCheckAuthenticated();
     void   postActivity(eAuthImplementations implType);
 
   private:

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+enum eAuthImplementations {
+    AUTH_IMPL_PAM         = 0,
+    AUTH_IMPL_FINGERPRINT = 1,
+};
+
+class IAuthImplementation {
+  public:
+    virtual ~IAuthImplementation() = default;
+
+    virtual eAuthImplementations       getImplType()                         = 0;
+    virtual void                       init()                                = 0;
+    virtual void                       handleInput(const std::string& input) = 0;
+    virtual bool                       isAuthenticated()                     = 0;
+    virtual bool                       checkWaiting()                        = 0;
+    virtual std::optional<std::string> getLastFailText()                     = 0;
+    virtual std::optional<std::string> getLastPrompt()                       = 0;
+    virtual void                       terminate()                           = 0;
+
+    friend class CAuth;
+};
+
+class CAuth {
+  public:
+    CAuth();
+
+    void start();
+
+    void submitInput(const std::string& input);
+    bool isAuthenticated();
+    bool checkWaiting();
+
+    // Used by the PasswordInput field. We are constraint to a single line for the authentication feedback there.
+    // Based on m_bDisplayFailText, this will return either the fail text or the prompt. This result can also be influence by the auth configuration.
+    std::string                          getInlineFeedback();
+
+    std::optional<std::string>           getFailText(eAuthImplementations implType);
+    std::optional<std::string>           getPrompt(eAuthImplementations implType);
+
+    std::shared_ptr<IAuthImplementation> getImpl(eAuthImplementations implType);
+
+    void                                 terminate();
+
+    // Should only be set via the main thread
+    bool   m_bDisplayFailText = false;
+    size_t m_iFailedAttempts  = 0;
+
+    void   enqueueCheckAuthenticated();
+
+  private:
+    std::vector<std::shared_ptr<IAuthImplementation>> m_vImpls;
+};
+
+inline std::unique_ptr<CAuth> g_pAuth;

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -177,7 +177,7 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
             stopVerify();
             m_sDBUSState.message = "";
             m_bAuthenticated     = true;
-            g_pAuth->enqueueCheckAuthenticated();
+            g_pAuth->enqueueCheckAuthenticated(false);
             break;
         case MATCH_RETRY: m_sDBUSState.message = "Please retry fingerprint scan"; break;
         case MATCH_SWIPE_TOO_SHORT: m_sDBUSState.message = "Swipe too short - try again"; break;

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -163,21 +163,22 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
         case MATCH_NO_MATCH:
             stopVerify();
             if (m_sDBUSState.retries >= 3) {
-                m_sDBUSState.message = "Fingerprint auth disabled: too many failed attempts";
+                m_sDBUSState.message = "Fingerprint auth disabled (too many failed attempts)";
             } else {
                 done = false;
                 startVerify(true);
+                m_sDBUSState.message = "Fingerprint not matched";
             }
             break;
         case MATCH_UNKNOWN_ERROR:
             stopVerify();
-            m_sDBUSState.message = "Unknown fingerprint error, disabling fingerprint auth";
+            m_sDBUSState.message = "Fingerprint auth disabled (unknown error)";
             break;
         case MATCH_MATCHED:
             stopVerify();
             m_sDBUSState.message = "";
             m_bAuthenticated     = true;
-            g_pAuth->enqueueCheckAuthenticated(false);
+            g_pAuth->enqueueCheckAuthenticated();
             break;
         case MATCH_RETRY: m_sDBUSState.message = "Please retry fingerprint scan"; break;
         case MATCH_SWIPE_TOO_SHORT: m_sDBUSState.message = "Swipe too short - try again"; break;
@@ -188,6 +189,7 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
             m_sDBUSState.abort   = true;
             break;
     }
+    g_pAuth->enqueueCheckAuthenticated();
     g_pHyprlock->enqueueForceUpdateTimers();
     if (done || m_sDBUSState.abort)
         m_sDBUSState.done = true;
@@ -218,7 +220,7 @@ void CFingerprint::startVerify(bool isRetry) {
         if (e) {
             Debug::log(WARN, "fprint: could not start verifying, {}", e->what());
             if (isRetry)
-                m_sDBUSState.message = "Fingerprint auth disabled: could not restart verification";
+                m_sDBUSState.message = "Fingerprint auth disabled (failed to restart)";
         } else {
             Debug::log(LOG, "fprint: started verifying");
             if (isRetry) {

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -37,9 +37,9 @@ static std::map<std::string, MatchResult> s_mapStringToTestType = {{"verify-no-m
                                                                    {"verify-unknown-error", MATCH_UNKNOWN_ERROR}};
 
 CFingerprint::CFingerprint() {
-    static auto* const PFINGERPRINTREADY   = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("general:fingerprint_ready_message"));
+    static auto* const PFINGERPRINTREADY   = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("auth:fingerprint:ready_message"));
     m_sFingerprintReady                    = *PFINGERPRINTREADY;
-    static auto* const PFINGERPRINTPRESENT = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("general:fingerprint_present_message"));
+    static auto* const PFINGERPRINTPRESENT = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("auth:fingerprint:present_message"));
     m_sFingerprintPresent                  = *PFINGERPRINTPRESENT;
 }
 

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -153,6 +153,7 @@ bool CFingerprint::createDeviceProxy() {
 }
 
 void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
+    g_pAuth->postActivity(AUTH_IMPL_FINGERPRINT);
     Debug::log(LOG, "fprint: handling status {}", result);
     auto matchResult = s_mapStringToTestType[result];
     if (m_sDBUSState.sleeping && matchResult != MATCH_DISCONNECTED)

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -11,17 +11,17 @@ class CFingerprint : public IAuthImplementation {
   public:
     CFingerprint();
 
-    ~CFingerprint() override;
-    eAuthImplementations getImplType() override {
+    virtual ~CFingerprint();
+    virtual eAuthImplementations getImplType() {
         return AUTH_IMPL_FINGERPRINT;
     }
-    void                                init() override;
-    void                                handleInput(const std::string& input) override;
-    bool                                isAuthenticated() override;
-    bool                                checkWaiting() override;
-    std::optional<std::string>          getLastFailText() override;
-    std::optional<std::string>          getLastPrompt() override;
-    void                                terminate() override;
+    virtual void                        init();
+    virtual void                        handleInput(const std::string& input);
+    virtual bool                        isAuthenticated();
+    virtual bool                        checkWaiting();
+    virtual std::optional<std::string>  getLastFailText();
+    virtual std::optional<std::string>  getLastPrompt();
+    virtual void                        terminate();
 
     std::shared_ptr<sdbus::IConnection> getConnection();
 

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -1,20 +1,29 @@
 #pragma once
 
-#include "hyprlock.hpp"
+#include "Auth.hpp"
 
 #include <memory>
 #include <optional>
 #include <string>
 #include <sdbus-c++/sdbus-c++.h>
 
-class CFingerprint {
+class CFingerprint : public IAuthImplementation {
   public:
     CFingerprint();
 
-    std::shared_ptr<sdbus::IConnection> start();
-    bool                                isAuthenticated();
-    std::optional<std::string>          getLastMessage();
-    void                                terminate();
+    ~CFingerprint() override;
+    eAuthImplementations getImplType() override {
+        return AUTH_IMPL_FINGERPRINT;
+    }
+    void                                init() override;
+    void                                handleInput(const std::string& input) override;
+    bool                                isAuthenticated() override;
+    bool                                checkWaiting() override;
+    std::optional<std::string>          getLastFailText() override;
+    std::optional<std::string>          getLastPrompt() override;
+    void                                terminate() override;
+
+    std::shared_ptr<sdbus::IConnection> getConnection();
 
   private:
     struct SDBUSState {
@@ -34,7 +43,6 @@ class CFingerprint {
     std::string m_sFingerprintReady;
     std::string m_sFingerprintPresent;
     bool        m_bAuthenticated = false;
-    bool        m_bEnabled       = false;
 
     void        handleVerifyStatus(const std::string& result, const bool done);
 
@@ -46,5 +54,3 @@ class CFingerprint {
     bool        stopVerify();
     bool        releaseDevice();
 };
-
-inline std::unique_ptr<CFingerprint> g_pFingerprint;

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -17,7 +17,6 @@ class CFingerprint : public IAuthImplementation {
     }
     virtual void                        init();
     virtual void                        handleInput(const std::string& input);
-    virtual bool                        isAuthenticated();
     virtual bool                        checkWaiting();
     virtual std::optional<std::string>  getLastFailText();
     virtual std::optional<std::string>  getLastPrompt();
@@ -42,7 +41,6 @@ class CFingerprint : public IAuthImplementation {
 
     std::string m_sFingerprintReady;
     std::string m_sFingerprintPresent;
-    bool        m_bAuthenticated = false;
 
     void        handleVerifyStatus(const std::string& result, const bool done);
 

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -119,6 +119,7 @@ bool CPam::auth() {
     handle = nullptr;
 
     m_sConversationState.waitingForPamAuth = false;
+    g_pAuth->postActivity(AUTH_IMPL_PAM);
 
     if (ret != PAM_SUCCESS) {
         if (!m_sConversationState.failTextFromPam)
@@ -154,6 +155,7 @@ void CPam::waitForInput() {
 }
 
 void CPam::handleInput(const std::string& input) {
+    g_pAuth->postActivity(AUTH_IMPL_PAM);
     std::unique_lock<std::mutex> lk(m_sConversationState.inputMutex);
 
     if (!m_sConversationState.inputRequested)

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -77,7 +77,7 @@ CPam::~CPam() {
 }
 
 void CPam::init() {
-    std::thread([this]() {
+    m_thread = std::thread([this]() {
         while (true) {
             resetConversation();
 
@@ -97,8 +97,10 @@ void CPam::init() {
                 return;
 
             g_pAuth->enqueueCheckAuthenticated();
+            if (AUTHENTICATED)
+                return;
         }
-    }).detach();
+    });
 }
 
 bool CPam::auth() {
@@ -181,6 +183,8 @@ bool CPam::checkWaiting() {
 
 void CPam::terminate() {
     m_sConversationState.inputSubmittedCondition.notify_all();
+    if (m_thread.joinable())
+        m_thread.join();
 }
 
 void CPam::resetConversation() {

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -90,15 +90,17 @@ void CPam::init() {
                 return;
 
             const auto AUTHENTICATED = auth();
-            m_bAuthenticated         = AUTHENTICATED;
 
             // For SIGUSR1 unlocks
             if (g_pHyprlock->isUnlocked())
                 return;
 
-            g_pAuth->enqueueCheckAuthenticated();
-            if (AUTHENTICATED)
+            if (!AUTHENTICATED)
+                g_pAuth->enqueueFail();
+            else {
+                g_pAuth->enqueueUnlock();
                 return;
+            }
         }
     });
 }
@@ -134,10 +136,6 @@ bool CPam::auth() {
     Debug::log(LOG, "auth: authenticated for {}", m_sPamModule);
 
     return true;
-}
-
-bool CPam::isAuthenticated() {
-    return m_bAuthenticated;
 }
 
 // clearing the input must be done from the main thread

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -61,7 +61,7 @@ int conv(int num_msg, const struct pam_message** msg, struct pam_response** resp
 }
 
 CPam::CPam() {
-    static auto* const PPAMMODULE = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("general:pam_module"));
+    static auto* const PPAMMODULE = (Hyprlang::STRING*)(g_pConfigManager->getValuePtr("auth:pam:module"));
     m_sPamModule                  = *PPAMMODULE;
 
     if (!std::filesystem::exists(std::filesystem::path("/etc/pam.d/") / m_sPamModule)) {

--- a/src/auth/Pam.hpp
+++ b/src/auth/Pam.hpp
@@ -34,7 +34,6 @@ class CPam : public IAuthImplementation {
     }
     virtual void                       init();
     virtual void                       handleInput(const std::string& input);
-    virtual bool                       isAuthenticated();
     virtual bool                       checkWaiting();
     virtual std::optional<std::string> getLastFailText();
     virtual std::optional<std::string> getLastPrompt();
@@ -44,8 +43,7 @@ class CPam : public IAuthImplementation {
     std::thread           m_thread;
     SPamConversationState m_sConversationState;
 
-    bool                  m_bBlockInput    = true;
-    bool                  m_bAuthenticated = false;
+    bool                  m_bBlockInput = true;
 
     std::string           m_sPamModule;
 

--- a/src/auth/Pam.hpp
+++ b/src/auth/Pam.hpp
@@ -41,6 +41,7 @@ class CPam : public IAuthImplementation {
     virtual void                       terminate();
 
   private:
+    std::thread           m_thread;
     SPamConversationState m_sConversationState;
 
     bool                  m_bBlockInput    = true;

--- a/src/auth/Pam.hpp
+++ b/src/auth/Pam.hpp
@@ -28,17 +28,17 @@ class CPam : public IAuthImplementation {
 
     void waitForInput();
 
-    ~CPam() override;
-    eAuthImplementations getImplType() override {
+    virtual ~CPam();
+    virtual eAuthImplementations getImplType() {
         return AUTH_IMPL_PAM;
     }
-    void                       init() override;
-    void                       handleInput(const std::string& input) override;
-    bool                       isAuthenticated() override;
-    bool                       checkWaiting() override;
-    std::optional<std::string> getLastFailText() override;
-    std::optional<std::string> getLastPrompt() override;
-    void                       terminate() override;
+    virtual void                       init();
+    virtual void                       handleInput(const std::string& input);
+    virtual bool                       isAuthenticated();
+    virtual bool                       checkWaiting();
+    virtual std::optional<std::string> getLastFailText();
+    virtual std::optional<std::string> getLastPrompt();
+    virtual void                       terminate();
 
   private:
     SPamConversationState m_sConversationState;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -171,11 +171,13 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:no_fade_out", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
-    m_config.addConfigValue("general:pam_module", Hyprlang::STRING{"hyprlock"});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});
-    m_config.addConfigValue("general:enable_fingerprint", Hyprlang::INT{0});
-    m_config.addConfigValue("general:fingerprint_ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
-    m_config.addConfigValue("general:fingerprint_present_message", Hyprlang::STRING{"Scanning fingerprint"});
+
+    m_config.addConfigValue("auth:pam:enabled", Hyprlang::INT{1});
+    m_config.addConfigValue("auth:pam:module", Hyprlang::STRING{"hyprlock"});
+    m_config.addConfigValue("auth:fingerprint:enabled", Hyprlang::INT{0});
+    m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
+    m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("background", "monitor", Hyprlang::STRING{""});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -388,6 +388,8 @@ void CHyprlock::run() {
     wl_display_roundtrip(m_sWaylandState.display);
 
     g_pRenderer = std::make_unique<CRenderer>();
+    g_pAuth     = std::make_unique<CAuth>();
+    g_pAuth->start();
 
     static auto* const PNOFADEOUT = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:no_fade_out");
     const bool         NOFADEOUT  = **PNOFADEOUT;
@@ -418,9 +420,6 @@ void CHyprlock::run() {
         g_pRenderer->asyncResourceGatherer->await();
         exit(1);
     }
-
-    g_pAuth = std::make_unique<CAuth>();
-    g_pAuth->start();
 
     const auto fingerprintAuth = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
     const auto dbusConn        = (fingerprintAuth) ? ((CFingerprint*)fingerprintAuth.get())->getConnection() : nullptr;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -68,7 +68,6 @@ class CHyprlock {
 
     size_t                          getPasswordBufferLen();
     size_t                          getPasswordBufferDisplayLen();
-    size_t                          getPasswordFailedAttempts();
 
     ext_session_lock_manager_v1*    getSessionLockMgr();
     ext_session_lock_v1*            getSessionLock();

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -1,7 +1,7 @@
 #include "PasswordInputField.hpp"
 #include "../Renderer.hpp"
 #include "../../core/hyprlock.hpp"
-#include "../../core/Auth.hpp"
+#include "../../auth/Auth.hpp"
 #include "../../config/ConfigDataValues.hpp"
 #include "../../helpers/Log.hpp"
 #include <hyprutils/string/String.hpp>
@@ -334,13 +334,13 @@ void CPasswordInputField::updatePlaceholder() {
         return;
     }
 
-    const auto AUTHFEEDBACK   = g_pAuth->m_bDisplayFailText ? g_pAuth->getLastFailText().value_or("Ups, no fail text?") : g_pAuth->getLastPrompt().value_or("Ups, no prompt?");
+    const auto AUTHFEEDBACK   = g_pAuth->getInlineFeedback();
     const auto ALLOWCOLORSWAP = outThick == 0 && colorConfig.swapFont;
 
-    if (!ALLOWCOLORSWAP && placeholder.lastAuthFeedback == AUTHFEEDBACK && g_pHyprlock->getPasswordFailedAttempts() == placeholder.failedAttempts)
+    if (!ALLOWCOLORSWAP && placeholder.lastAuthFeedback == AUTHFEEDBACK && g_pAuth->m_iFailedAttempts == placeholder.failedAttempts)
         return;
 
-    placeholder.failedAttempts   = g_pHyprlock->getPasswordFailedAttempts();
+    placeholder.failedAttempts   = g_pAuth->m_iFailedAttempts;
     placeholder.lastAuthFeedback = AUTHFEEDBACK;
 
     placeholder.asset = nullptr;


### PR DESCRIPTION
This has the goal to create an interface that hyprlock uses for authentication.

After this, error messages from fingerprint can be shown in the PasswordInputField by using `$FAIL` in `input-field:fail_text`. The input field will actually show a failure when we failed to match now as well.

BREAKING:
- `general:pam_module` -> `auth:pam:module`
- `general:enable_fingerprint` -> `auth:fingerprint:enabled`
- `general:fingerprint_ready_message` -> `auth:fingerprint:ready_message`
- `general:fingerprint_present_message` -> `auth:fingerprint:present_message`

Implicit changes introduced by this PR:
- Attempts now also factor in the failed attempts from fingerprint auth.
- A fingerprint swipe clears the password input buffer.