### PR TITLE
input-field: fix width animations

### DIFF
--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -24,6 +24,7 @@ class CPasswordInputField : public IWidget {
     void        updateDots();
     void        updateFade();
     void        updatePlaceholder();
+    void        updateWidth();
     void        updateHiddenInputState();
     void        updateInputState();
     void        updateColors();
@@ -45,6 +46,12 @@ class CPasswordInputField : public IWidget {
     uint64_t    configFailTimeoutMs = 2000;
 
     int         outThick, rounding;
+
+    struct {
+        std::chrono::system_clock::time_point start;
+        bool                                  animated = false;
+        double                                source   = 0;
+    } dynamicWidth;
 
     struct {
         float                                 currentAmount = 0;


### PR DESCRIPTION
This fixes some problems with the input field resize. 
- support fading to a smaller size
- don't draw the shadow when fading
- don't draw the asset when the input field size is to small

Motivated me to start porting hyprlands animation manager to hyprlock.