### PR TITLE
core: terminate auth after recieving `finished`

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -418,6 +418,7 @@ void CHyprlock::run() {
         m_sLoopState.timerCV.notify_all();
         g_pRenderer->asyncResourceGatherer->notify();
         g_pRenderer->asyncResourceGatherer->await();
+        g_pAuth->terminate();
         exit(1);
     }
 


### PR DESCRIPTION
This probably fixes https://github.com/hyprwm/hyprlock/issues/577