### PR TITLE
misc: add git commit hash to --version when not on tag v${VERSION}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,28 @@ set(CMAKE_CXX_STANDARD 23)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value
                     -Wno-missing-field-initializers -Wno-narrowing)
 
+# get git commit
+execute_process(
+  OUTPUT_VARIABLE GIT_SHORT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND git rev-parse --short HEAD
+)
+
+# get git commit of v$VERSION
+execute_process(
+  OUTPUT_VARIABLE GIT_TAG_SHORT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND git rev-parse --short v${VERSION}
+)
+
+add_compile_definitions(HYPRLOCK_VERSION="${VERSION}")
+add_compile_definitions(HYPRLOCK_COMMIT="${GIT_SHORT_HASH}")
+add_compile_definitions(HYPRLOCK_VERSION_COMMIT="${GIT_TAG_SHORT_HASH}")
+
 # position independent build: __FILE__
 add_compile_options(-fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
-add_compile_definitions(HYPRLOCK_VERSION="${VERSION}")
 
 # dependencies
 message(STATUS "Checking deps...")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "src/helpers/Log.hpp"
 #include <cstddef>
 #include <iostream>
+#include <string_view>
 
 void help() {
     std::cout << "Usage: hyprlock [options]\n\n"
@@ -46,7 +47,12 @@ int main(int argc, char** argv, char** envp) {
         }
 
         if (arg == "--version" || arg == "-V") {
-            std::cout << "Hyprlock version " << HYPRLOCK_VERSION << "\n";
+            constexpr bool ISTAGGEDRELEASE = std::string_view(HYPRLOCK_COMMIT) == HYPRLOCK_VERSION_COMMIT;
+
+            std::cout << "Hyprlock version v" << HYPRLOCK_VERSION;
+            if (!ISTAGGEDRELEASE)
+                std::cout << " (commit " << HYPRLOCK_COMMIT << ")";
+            std::cout << std::endl;
             return 0;
         }
 


### PR DESCRIPTION
Opted for doing it straight in cmake, since we don't need all the stuff that `generateVersion.sh` in Hyprland does.
This only appends the short git hash when we are not on the tag v${VERSION} where ${VERSION} is the content of the VERSION file.

Merging this implies that `Hyprlock version 0.6.0` can be actual v0.6.0, https://github.com/hyprwm/hyprlock/commit/058830668e92e92b3179319090b5d523ba4d59a4 or https://github.com/hyprwm/hyprlock/commit/d12b4a7fbaf570fbe9322c09a777c124fbf15306, since those 2 commit don't have this yet