### PR TITLE
config: add sizex using CLayoutXValueData for reproducible layouting of image and label

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -12,8 +12,9 @@ using namespace Hyprutils::String;
 
 enum eConfigValueDataTypes {
     CVD_TYPE_INVALID  = -1,
-    CVD_TYPE_LAYOUT   = 0,
+    CVD_TYPE_LAYOUTXY = 0,
     CVD_TYPE_GRADIENT = 1,
+    CVD_TYPE_LAYOUTX  = 2,
 };
 
 class ICustomConfigValueData {
@@ -25,22 +26,22 @@ class ICustomConfigValueData {
     virtual std::string           toString() = 0;
 };
 
-class CLayoutValueData : public ICustomConfigValueData {
+class CLayoutXYValueData : public ICustomConfigValueData {
   public:
-    CLayoutValueData() {};
-    virtual ~CLayoutValueData() {};
+    CLayoutXYValueData() {};
+    virtual ~CLayoutXYValueData() {};
 
     virtual eConfigValueDataTypes getDataType() {
-        return CVD_TYPE_LAYOUT;
+        return CVD_TYPE_LAYOUTXY;
     }
 
     virtual std::string toString() {
         return std::format("{}{},{}{}", m_vValues.x, (m_sIsRelative.x) ? "%" : "px", m_vValues.y, (m_sIsRelative.y) ? "%" : "px");
     }
 
-    static CLayoutValueData* fromAnyPv(const std::any& v) {
+    static CLayoutXYValueData* fromAnyPv(const std::any& v) {
         RASSERT(v.type() == typeid(void*), "Invalid config value type");
-        const auto P = (CLayoutValueData*)std::any_cast<void*>(v);
+        const auto P = (CLayoutXYValueData*)std::any_cast<void*>(v);
         RASSERT(P, "Empty config value");
         return P;
     }
@@ -57,6 +58,34 @@ class CLayoutValueData : public ICustomConfigValueData {
         bool x = false;
         bool y = false;
     } m_sIsRelative;
+};
+
+class CLayoutXValueData : public ICustomConfigValueData {
+  public:
+    CLayoutXValueData() {};
+    virtual ~CLayoutXValueData() {};
+
+    virtual eConfigValueDataTypes getDataType() {
+        return CVD_TYPE_LAYOUTXY;
+    }
+
+    virtual std::string toString() {
+        return std::format("{}{}", m_fValue, (m_sIsRelative) ? "%" : "px");
+    }
+
+    static CLayoutXValueData* fromAnyPv(const std::any& v) {
+        RASSERT(v.type() == typeid(void*), "Invalid config value type");
+        const auto P = (CLayoutXValueData*)std::any_cast<void*>(v);
+        RASSERT(P, "Empty config value");
+        return P;
+    }
+
+    double getAbsolute(const Hyprutils::Math::Vector2D& viewport) {
+        return (m_sIsRelative) ? (m_fValue / 100) * viewport.x : m_fValue;
+    }
+
+    double m_fValue      = 0;
+    bool   m_sIsRelative = false;
 };
 
 class CGradientValueData : public ICustomConfigValueData {

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -53,7 +53,7 @@ Vector2D IWidget::posFromHVAlign(const Vector2D& viewport, const Vector2D& size,
     else if (valign != "none")
         Debug::log(ERR, "IWidget: invalid valign {}", valign);
 
-    return pos;
+    return pos.round();
 }
 
 static void replaceAllAttempts(std::string& str) {

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -29,7 +29,7 @@ class CImage : public IWidget {
   private:
     CFramebuffer                            imageFB;
 
-    int                                     size;
+    double                                  sizex;
     int                                     rounding;
     double                                  border;
     double                                  angle;

--- a/src/renderer/widgets/Label.hpp
+++ b/src/renderer/widgets/Label.hpp
@@ -32,6 +32,7 @@ class CLabel : public IWidget {
     Vector2D                                viewport;
     Vector2D                                pos;
     Vector2D                                configPos;
+    double                                  sizex;
     double                                  angle;
     std::string                             resourceID;
     std::string                             pendingResourceID; // if dynamic label

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -13,8 +13,8 @@ using namespace Hyprutils::String;
 CPasswordInputField::CPasswordInputField(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
     viewport(viewport_), outputStringPort(output), shadow(this, props, viewport_) {
     try {
-        pos                      = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
-        size                     = CLayoutValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
+        pos                      = CLayoutXYValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
+        size                     = CLayoutXYValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
         halign                   = std::any_cast<Hyprlang::STRING>(props.at("halign"));
         valign                   = std::any_cast<Hyprlang::STRING>(props.at("valign"));
         outThick                 = std::any_cast<Hyprlang::INT>(props.at("outline_thickness"));

--- a/src/renderer/widgets/Shape.cpp
+++ b/src/renderer/widgets/Shape.cpp
@@ -7,12 +7,12 @@
 CShape::CShape(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props) : shadow(this, props, viewport_) {
 
     try {
-        size       = CLayoutValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
+        size       = CLayoutXYValueData::fromAnyPv(props.at("size"))->getAbsolute(viewport_);
         rounding   = std::any_cast<Hyprlang::INT>(props.at("rounding"));
         border     = std::any_cast<Hyprlang::INT>(props.at("border_size"));
         color      = std::any_cast<Hyprlang::INT>(props.at("color"));
         borderGrad = *CGradientValueData::fromAnyPv(props.at("border_color"));
-        pos        = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
+        pos        = CLayoutXYValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
         halign     = std::any_cast<Hyprlang::STRING>(props.at("halign"));
         valign     = std::any_cast<Hyprlang::STRING>(props.at("valign"));
         angle      = std::any_cast<Hyprlang::FLOAT>(props.at("rotate"));


### PR DESCRIPTION
Closes #555
Closes #261

BREAKING: removed `image:size` in favour of `image:sizex`.

**Image**:

Image is now dimensioned via `sizex` which allows you to specify the x dimension in px or %. The y dimension is inferred from the ratio of the image.

**Label**:

Label keeps the `font_size` option and `sizex` will be 0 per default. As long as `sizex` stays 0, labels behave the same as currently.
However, you can now set the absolute size of a label with `sizex` (y is inferred from the texture). In combination with `font_size` this allows to configure the _sharpness_ in a way.