### PR TITLE
core: fix parsing grad with decimal rgb(a) colors

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -78,7 +78,7 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
 
     const auto DATA = reinterpret_cast<CGradientValueData*>(*data);
 
-    CVarList   varlist(V, 0, ' ', true);
+    CVarList   varlist(V, 0, ' ');
     DATA->m_vColors.clear();
     DATA->m_bIsFallback = false;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -103,6 +103,9 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
             break;
         }
 
+        if (var.empty())
+            continue;
+
         try {
             DATA->m_vColors.push_back(CColor(configStringToInt(var)));
         } catch (std::exception& e) {


### PR DESCRIPTION
Regressed by https://github.com/hyprwm/hyprlock/commit/578246b9967dec77c56993dc55ca192d35ba9bb7
Closes #593

Could be a reason to release 0.6.1.