### PR TITLE
Add D-Bus signals to notify session lock and unlock states

### DIFF
--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -22,14 +22,12 @@ class CFingerprint : public IAuthImplementation {
     virtual std::optional<std::string>  getLastPrompt();
     virtual void                        terminate();
 
-    std::shared_ptr<sdbus::IConnection> getConnection();
-
   private:
     struct SDBUSState {
         std::string                         message = "";
 
         std::shared_ptr<sdbus::IConnection> connection;
-        std::unique_ptr<sdbus::IProxy>      login;
+        std::shared_ptr<sdbus::IProxy>      login;
         std::unique_ptr<sdbus::IProxy>      device;
         sdbus::UnixFd                       inhibitLock;
 

--- a/src/core/DBusManager.cpp
+++ b/src/core/DBusManager.cpp
@@ -1,0 +1,88 @@
+#include "DBusManager.hpp"
+#include "../helpers/Log.hpp"
+
+DBusManager& DBusManager::getInstance() {
+    static DBusManager instance;
+    return instance;
+}
+
+DBusManager::DBusManager() {
+    initializeConnection();
+}
+
+DBusManager::~DBusManager() {
+    // Resources are automatically cleaned up.
+}
+
+void DBusManager::initializeConnection() {
+    try {
+        m_connection = sdbus::createSystemBusConnection();
+
+        const sdbus::ServiceName destination{"org.freedesktop.login1"};
+        const sdbus::ObjectPath loginPath{"/org/freedesktop/login1"};
+        const sdbus::ObjectPath sessionPath{"/org/freedesktop/login1/session/auto"};
+
+        m_loginProxy = sdbus::createProxy(*m_connection, destination, loginPath);
+        m_sessionProxy = sdbus::createProxy(*m_connection, destination, sessionPath);
+
+        Debug::log(LOG, "[DBusManager] Initialized D-Bus connection. Service: {}. Login path: {}, Session path: {}",
+            std::string(destination), std::string(loginPath), std::string(sessionPath));
+    } catch (const sdbus::Error& e) {
+        Debug::log(ERR, "[DBusManager] D-Bus connection initialization failed: {}", e.what());
+    }
+}
+
+std::shared_ptr<sdbus::IConnection> DBusManager::getConnection() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_connection;
+}
+
+std::shared_ptr<sdbus::IProxy> DBusManager::getLoginProxy() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_loginProxy) {
+        initializeConnection();
+    }
+    return m_loginProxy;
+}
+
+std::shared_ptr<sdbus::IProxy> DBusManager::getSessionProxy() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_sessionProxy) {
+        initializeConnection();
+    }
+    return m_sessionProxy;
+}
+
+void DBusManager::setLockedHint(bool locked) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_sessionProxy) {
+        Debug::log(WARN, "[DBusManager] Cannot set locked hint: Proxy is not initialized.");
+        return;
+    }
+
+    try {
+        const sdbus::ServiceName interface{"org.freedesktop.login1.Session"};
+        m_sessionProxy->callMethod("SetLockedHint").onInterface(interface).withArguments(locked);
+
+        Debug::log(LOG, "[DBusManager] Sent 'SetLockedHint({})' on {}", locked, std::string(interface));
+    } catch (const sdbus::Error& e) {
+        Debug::log(WARN, "[DBusManager] Failed to send 'SetLockedHint({})': {}", locked, e.what());
+    }
+}
+
+void DBusManager::sendUnlockSignal() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_sessionProxy) {
+        Debug::log(WARN, "[DBusManager] Unlock signal skipped: Proxy is not initialized.");
+        return;
+    }
+
+    try {
+        const sdbus::ServiceName interface{"org.freedesktop.login1.Session"};
+        m_sessionProxy->callMethod("Unlock").onInterface(interface);
+
+        Debug::log(LOG, "[DBusManager] Sent 'Unlock' on {}", std::string(interface));
+    } catch (const sdbus::Error& e) {
+        Debug::log(WARN, "[DBusManager] Unlock signal failed: {}", e.what());
+    }
+}

--- a/src/core/DBusManager.cpp
+++ b/src/core/DBusManager.cpp
@@ -33,12 +33,10 @@ void DBusManager::initializeConnection() {
 }
 
 std::shared_ptr<sdbus::IConnection> DBusManager::getConnection() {
-    std::lock_guard<std::mutex> lock(m_mutex);
     return m_pConnection;
 }
 
 std::shared_ptr<sdbus::IProxy> DBusManager::getLoginProxy() {
-    std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_pLoginProxy)
         initializeConnection();
 
@@ -46,7 +44,6 @@ std::shared_ptr<sdbus::IProxy> DBusManager::getLoginProxy() {
 }
 
 std::shared_ptr<sdbus::IProxy> DBusManager::getSessionProxy() {
-    std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_pSessionProxy)
         initializeConnection();
 
@@ -54,7 +51,6 @@ std::shared_ptr<sdbus::IProxy> DBusManager::getSessionProxy() {
 }
 
 void DBusManager::setLockedHint(bool locked) {
-    std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_pSessionProxy) {
         Debug::log(WARN, "[DBusManager] Cannot set locked hint: Proxy is not initialized.");
         return;
@@ -71,7 +67,6 @@ void DBusManager::setLockedHint(bool locked) {
 }
 
 void DBusManager::sendUnlockSignal() {
-    std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_pSessionProxy) {
         Debug::log(WARN, "[DBusManager] Unlock signal skipped: Proxy is not initialized.");
         return;

--- a/src/core/DBusManager.cpp
+++ b/src/core/DBusManager.cpp
@@ -16,14 +16,14 @@ DBusManager::~DBusManager() {
 
 void DBusManager::initializeConnection() {
     try {
-        m_connection = sdbus::createSystemBusConnection();
+        m_pConnection = sdbus::createSystemBusConnection();
 
         const sdbus::ServiceName destination{"org.freedesktop.login1"};
         const sdbus::ObjectPath loginPath{"/org/freedesktop/login1"};
         const sdbus::ObjectPath sessionPath{"/org/freedesktop/login1/session/auto"};
 
-        m_loginProxy = sdbus::createProxy(*m_connection, destination, loginPath);
-        m_sessionProxy = sdbus::createProxy(*m_connection, destination, sessionPath);
+        m_pLoginProxy = sdbus::createProxy(*m_pConnection, destination, loginPath);
+        m_pSessionProxy = sdbus::createProxy(*m_pConnection, destination, sessionPath);
 
         Debug::log(LOG, "[DBusManager] Initialized D-Bus connection. Service: {}. Login path: {}, Session path: {}",
             std::string(destination), std::string(loginPath), std::string(sessionPath));
@@ -34,35 +34,35 @@ void DBusManager::initializeConnection() {
 
 std::shared_ptr<sdbus::IConnection> DBusManager::getConnection() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return m_connection;
+    return m_pConnection;
 }
 
 std::shared_ptr<sdbus::IProxy> DBusManager::getLoginProxy() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_loginProxy) {
+    if (!m_pLoginProxy)
         initializeConnection();
-    }
-    return m_loginProxy;
+
+    return m_pLoginProxy;
 }
 
 std::shared_ptr<sdbus::IProxy> DBusManager::getSessionProxy() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_sessionProxy) {
+    if (!m_pSessionProxy)
         initializeConnection();
-    }
-    return m_sessionProxy;
+
+    return m_pSessionProxy;
 }
 
 void DBusManager::setLockedHint(bool locked) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_sessionProxy) {
+    if (!m_pSessionProxy) {
         Debug::log(WARN, "[DBusManager] Cannot set locked hint: Proxy is not initialized.");
         return;
     }
 
     try {
         const sdbus::ServiceName interface{"org.freedesktop.login1.Session"};
-        m_sessionProxy->callMethod("SetLockedHint").onInterface(interface).withArguments(locked);
+        m_pSessionProxy->callMethod("SetLockedHint").onInterface(interface).withArguments(locked);
 
         Debug::log(LOG, "[DBusManager] Sent 'SetLockedHint({})' on {}", locked, std::string(interface));
     } catch (const sdbus::Error& e) {
@@ -72,14 +72,14 @@ void DBusManager::setLockedHint(bool locked) {
 
 void DBusManager::sendUnlockSignal() {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_sessionProxy) {
+    if (!m_pSessionProxy) {
         Debug::log(WARN, "[DBusManager] Unlock signal skipped: Proxy is not initialized.");
         return;
     }
 
     try {
         const sdbus::ServiceName interface{"org.freedesktop.login1.Session"};
-        m_sessionProxy->callMethod("Unlock").onInterface(interface);
+        m_pSessionProxy->callMethod("Unlock").onInterface(interface);
 
         Debug::log(LOG, "[DBusManager] Sent 'Unlock' on {}", std::string(interface));
     } catch (const sdbus::Error& e) {

--- a/src/core/DBusManager.hpp
+++ b/src/core/DBusManager.hpp
@@ -22,9 +22,9 @@ private:
 
     void initializeConnection();
 
-    std::shared_ptr<sdbus::IConnection> m_connection;
-    std::shared_ptr<sdbus::IProxy>      m_loginProxy;
-    std::shared_ptr<sdbus::IProxy>      m_sessionProxy;
+    std::shared_ptr<sdbus::IConnection> m_pConnection;
+    std::shared_ptr<sdbus::IProxy>      m_pLoginProxy;
+    std::shared_ptr<sdbus::IProxy>      m_pSessionProxy;
 
     std::mutex                          m_mutex;
 };

--- a/src/core/DBusManager.hpp
+++ b/src/core/DBusManager.hpp
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <string>
-#include <mutex>
 #include <sdbus-c++/sdbus-c++.h>
 
 class DBusManager {
@@ -25,6 +24,4 @@ private:
     std::shared_ptr<sdbus::IConnection> m_pConnection;
     std::shared_ptr<sdbus::IProxy>      m_pLoginProxy;
     std::shared_ptr<sdbus::IProxy>      m_pSessionProxy;
-
-    std::mutex                          m_mutex;
 };

--- a/src/core/DBusManager.hpp
+++ b/src/core/DBusManager.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <mutex>
+#include <sdbus-c++/sdbus-c++.h>
+
+class DBusManager {
+public:
+    static DBusManager& getInstance();
+
+    std::shared_ptr<sdbus::IConnection> getConnection();
+    std::shared_ptr<sdbus::IProxy>      getLoginProxy();
+    std::shared_ptr<sdbus::IProxy>      getSessionProxy();
+
+    void setLockedHint(bool locked);
+    void sendUnlockSignal();
+
+private:
+    DBusManager();
+    ~DBusManager();
+
+    void initializeConnection();
+
+    std::shared_ptr<sdbus::IConnection> m_connection;
+    std::shared_ptr<sdbus::IProxy>      m_loginProxy;
+    std::shared_ptr<sdbus::IProxy>      m_sessionProxy;
+
+    std::mutex                          m_mutex;
+};

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <condition_variable>
 #include <optional>
+#include <sdbus-c++/sdbus-c++.h>
 
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-compose.h>
@@ -33,6 +34,9 @@ class CHyprlock {
 
     void                            unlock();
     bool                            isUnlocked();
+
+    void                            setupDBus();
+    void                            sendUnlockSignal();
 
     void                            onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
     void                            onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);
@@ -165,6 +169,11 @@ class CHyprlock {
         bool                    timerEvent = false;
     } m_sLoopState;
 
+    struct SDBUSState {
+        std::unique_ptr<sdbus::IConnection> connection;
+        std::unique_ptr<sdbus::IProxy>      proxy;
+    } m_sDBUSState;
+    
     std::vector<std::shared_ptr<CTimer>> m_vTimers;
 
     std::vector<uint32_t>                m_vPressedKeys;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -12,7 +12,6 @@
 #include <vector>
 #include <condition_variable>
 #include <optional>
-#include <sdbus-c++/sdbus-c++.h>
 
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-compose.h>

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -35,9 +35,6 @@ class CHyprlock {
     void                            unlock();
     bool                            isUnlocked();
 
-    void                            setupDBus();
-    void                            sendUnlockSignal();
-
     void                            onGlobal(void* data, struct wl_registry* registry, uint32_t name, const char* interface, uint32_t version);
     void                            onGlobalRemoved(void* data, struct wl_registry* registry, uint32_t name);
 
@@ -168,11 +165,6 @@ class CHyprlock {
         std::mutex              timerRequestMutex;
         bool                    timerEvent = false;
     } m_sLoopState;
-
-    struct SDBUSState {
-        std::unique_ptr<sdbus::IConnection> connection;
-        std::unique_ptr<sdbus::IProxy>      proxy;
-    } m_sDBUSState;
     
     std::vector<std::shared_ptr<CTimer>> m_vTimers;
 


### PR DESCRIPTION
Send an "Unlock" D-Bus signal to notify programs listening for Unlock events.

This enables tools like hypridle to detect the Unlock event and execute the unlock_cmd.

Issues:
hyprwm/hypridle#79
hyprwm/hypridle#112