### PR TITLE
widgets: algin rect outline radius with inner border radius

### DIFF
--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -56,6 +56,25 @@ Vector2D IWidget::posFromHVAlign(const Vector2D& viewport, const Vector2D& size,
     return pos;
 }
 
+int IWidget::roundingForBox(const CBox& box, int roundingConfig) {
+    const int MINHALFBOX = std::min(box.w, box.h) / 2.0;
+    if (roundingConfig == -1)
+        return MINHALFBOX;
+
+    return std::clamp(roundingConfig, 0, MINHALFBOX);
+}
+
+int IWidget::roundingForBorderBox(const CBox& borderBox, int roundingConfig, int thickness) {
+    const int MINHALFBORDER = std::min(borderBox.w, borderBox.h) / 2.0;
+    if (roundingConfig == -1)
+        return MINHALFBORDER;
+
+    else if (roundingConfig == 0)
+        return 0;
+
+    return std::clamp(roundingConfig + thickness, 0, MINHALFBORDER);
+}
+
 static void replaceAllAttempts(std::string& str) {
 
     const size_t      ATTEMPTS = g_pAuth->m_iFailedAttempts;

--- a/src/renderer/widgets/IWidget.hpp
+++ b/src/renderer/widgets/IWidget.hpp
@@ -10,10 +10,12 @@ class IWidget {
     };
     virtual ~IWidget() = default;
 
-    virtual bool     draw(const SRenderData& data) = 0;
+    virtual bool    draw(const SRenderData& data) = 0;
 
-    virtual Vector2D posFromHVAlign(const Vector2D& viewport, const Vector2D& size, const Vector2D& offset, const std::string& halign, const std::string& valign,
-                                    const double& ang = 0);
+    static Vector2D posFromHVAlign(const Vector2D& viewport, const Vector2D& size, const Vector2D& offset, const std::string& halign, const std::string& valign,
+                                   const double& ang = 0);
+    static int      roundingForBox(const CBox& box, int roundingConfig);
+    static int      roundingForBorderBox(const CBox& borderBox, int roundingConfig, int thickness);
 
     struct SFormatResult {
         std::string formatted;
@@ -23,5 +25,5 @@ class IWidget {
         bool        allowForceUpdate = false;
     };
 
-    virtual SFormatResult formatString(std::string in);
+    static SFormatResult formatString(std::string in);
 };

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -141,14 +141,14 @@ bool CImage::draw(const SRenderData& data) {
         texbox.w *= std::max(SCALEX, SCALEY);
         texbox.h *= std::max(SCALEX, SCALEY);
 
-        const bool ALLOWROUND = rounding > -1 && rounding < std::min(texbox.w, texbox.h) / 2.0;
-
         // plus borders if any
         CBox borderBox = {angle == 0 ? BORDERPOS : BORDERPOS + Vector2D{1.0, 1.0}, texbox.size() + IMAGEPOS * 2.0};
 
         borderBox.round();
 
-        const Vector2D FBSIZE = angle == 0 ? borderBox.size() : borderBox.size() + Vector2D{2.0, 2.0};
+        const Vector2D FBSIZE      = angle == 0 ? borderBox.size() : borderBox.size() + Vector2D{2.0, 2.0};
+        const int      ROUND       = roundingForBox(texbox, rounding);
+        const int      BORDERROUND = roundingForBorderBox(borderBox, rounding, border);
 
         imageFB.alloc(FBSIZE.x, FBSIZE.y, true);
         g_pRenderer->pushFb(imageFB.m_iFb);
@@ -156,11 +156,10 @@ bool CImage::draw(const SRenderData& data) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
-            g_pRenderer->renderBorder(borderBox, color, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : std::min(borderBox.w, borderBox.h) / 2.0,
-                                      1.0);
+            g_pRenderer->renderBorder(borderBox, color, border, BORDERROUND, 1.0);
 
         texbox.round();
-        g_pRenderer->renderTexture(texbox, asset->texture, 1.0, ALLOWROUND ? rounding : std::min(texbox.w, texbox.h) / 2.0, HYPRUTILS_TRANSFORM_NORMAL);
+        g_pRenderer->renderTexture(texbox, asset->texture, 1.0, ROUND, HYPRUTILS_TRANSFORM_NORMAL);
         g_pRenderer->popFb();
     }
 

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -213,8 +213,8 @@ bool CPasswordInputField::draw(const SRenderData& data) {
     fontCol.a *= fade.a * data.opacity;
 
     if (outThick > 0) {
-        const auto OUTERROUND = rounding == -1 ? outerBox.h / 2.0 : rounding;
-        g_pRenderer->renderBorder(outerBox, outerGrad, outThick, OUTERROUND, fade.a * data.opacity);
+        const int BORDERROUND = roundingForBorderBox(outerBox, rounding, outThick);
+        g_pRenderer->renderBorder(outerBox, outerGrad, outThick, BORDERROUND, fade.a * data.opacity);
 
         if (passwordLength != 0 && hiddenInputState.enabled && !fade.animated && data.opacity == 1.0) {
             CBox     outerBoxScaled = outerBox;
@@ -226,13 +226,14 @@ bool CPasswordInputField::draw(const SRenderData& data) {
                 outerBoxScaled.x += outerBoxScaled.w;
             glEnable(GL_SCISSOR_TEST);
             glScissor(outerBoxScaled.x, outerBoxScaled.y, outerBoxScaled.w, outerBoxScaled.h);
-            g_pRenderer->renderBorder(outerBox, hiddenInputState.lastColor, outThick, OUTERROUND, fade.a * data.opacity);
+            g_pRenderer->renderBorder(outerBox, hiddenInputState.lastColor, outThick, BORDERROUND, fade.a * data.opacity);
             glScissor(0, 0, viewport.x, viewport.y);
             glDisable(GL_SCISSOR_TEST);
         }
     }
 
-    g_pRenderer->renderRect(inputFieldBox, innerCol, rounding == -1 ? inputFieldBox.h / 2.0 : rounding - outThick - 1);
+    const int ROUND = roundingForBox(inputFieldBox, rounding);
+    g_pRenderer->renderRect(inputFieldBox, innerCol, ROUND);
 
     if (!hiddenInputState.enabled && !g_pHyprlock->m_bFadeStarted) {
         const int RECTPASSSIZE = std::nearbyint(inputFieldBox.h * dots.size * 0.5f) * 2.f;

--- a/src/renderer/widgets/Shape.cpp
+++ b/src/renderer/widgets/Shape.cpp
@@ -68,8 +68,9 @@ bool CShape::draw(const SRenderData& data) {
     }
 
     if (!shapeFB.isAllocated()) {
-        const auto MINHALFSHAPE = std::min(shapeBox.w, shapeBox.h) / 2.0;
-        const bool ALLOWROUND   = rounding > -1 && rounding < MINHALFSHAPE;
+        const int ROUND       = roundingForBox(shapeBox, rounding);
+        const int BORDERROUND = roundingForBorderBox(borderBox, rounding, border);
+        Debug::log(LOG, "round: {}, borderround: {}", ROUND, BORDERROUND);
 
         shapeFB.alloc(borderBox.width + borderBox.x * 2.0, borderBox.height + borderBox.y * 2.0, true);
         g_pRenderer->pushFb(shapeFB.m_iFb);
@@ -77,9 +78,9 @@ bool CShape::draw(const SRenderData& data) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (border > 0)
-            g_pRenderer->renderBorder(borderBox, borderGrad, border, ALLOWROUND ? (rounding == 0 ? 0 : rounding + std::round(border / M_PI)) : MINHALFBORDER, 1.0);
+            g_pRenderer->renderBorder(borderBox, borderGrad, border, BORDERROUND, 1.0);
 
-        g_pRenderer->renderRect(shapeBox, color, ALLOWROUND ? rounding : MINHALFSHAPE);
+        g_pRenderer->renderRect(shapeBox, color, ROUND);
         g_pRenderer->popFb();
     }
 


### PR DESCRIPTION
Closes #611

To verify that the the outline of a box matches with the inner border perfectly,
I used this:

```
input-field {
  monitor=
  size=25%, 5%
  inner_color=rgba(fff7ed20)
  outer_color=rgba(fff7ed20)
  position=0, -20
  rounding=15
  fade_on_empty = false
  valign=center
}
```

Because inner and outer color have the same alpha, one can easily spot if they overlap or not.

Previously if the rounding was to big, it used rounding 0.
Now it clamps it to the maximum.

Tested:
- [x] rouding -1 for shape, image and input-field
- [x] rouding -1 and border for shape, image and input-field
- [x] rounding 0 for shape, image and input-field
- [x] rounding 0 and border for shape, image and input-field