### PR TITLE
fingerprint: add a delay after an unrecognized fingerprint

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -169,7 +169,13 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
                 m_sFailureReason = "Fingerprint auth disabled (too many failed attempts)";
             } else {
                 done = false;
-                startVerify(true);
+                static const auto RETRYDELAY = **(Hyprlang::INT* const*)(g_pConfigManager->getValuePtr("auth:fingerprint:retry_delay"));
+                g_pHyprlock->addTimer(
+                    std::chrono::milliseconds(RETRYDELAY),
+                    [](std::shared_ptr<CTimer> self, void* data) {
+                        ((CFingerprint*)data)->startVerify(true);
+                    },
+                    this);
             }
             break;
         case MATCH_UNKNOWN_ERROR:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -181,6 +181,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:enabled", Hyprlang::INT{0});
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
+    m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
 
     m_config.addSpecialCategory("background", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("background", "monitor", Hyprlang::STRING{""});


### PR DESCRIPTION
Add a new config option ("auth:fingerprint:retry_delay") that adds a delay after an unrecognized fingerprint has been scanned. The default delay is 250ms. Currently when an incorrect finger is scanned, it gets scanned as fast as possible which leads to the number of retries being using up extremely quickly.
