### PR TITLE
allow signaling a parent process that the screen was locked

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -12,6 +12,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <unistd.h>
+#include <errno.h>
 #include <assert.h>
 #include <string.h>
 #include <xf86drm.h>

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -26,7 +26,7 @@ struct SDMABUFModifier {
 
 class CHyprlock {
   public:
-    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender, const bool noFadeIn);
+    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender, const bool noFadeIn, const int notifyFd);
     ~CHyprlock();
 
     void                            run();
@@ -168,6 +168,8 @@ class CHyprlock {
     std::vector<std::shared_ptr<CTimer>> m_vTimers;
 
     std::vector<uint32_t>                m_vPressedKeys;
+
+    int                                  m_iNotifyFd;
 };
 
 inline std::unique_ptr<CHyprlock> g_pHyprlock;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ void help() {
                  "  --immediate              - Lock immediately, ignoring any configured grace period\n"
                  "  --immediate-render       - Do not wait for resources before drawing the background\n"
                  "  --no-fade-in             - Disable the fade-in animation when the lock screen appears\n"
-                 "  -R, --ready-fd FD        - Write a single newline character to this file descriptor after locking the screen\n"
+                 "  -R FD, --ready-fd FD     - Write a single newline character to this file descriptor after locking the screen\n"
                  "  -D, --daemonize          - Run hyprlock in the background. This command will return after the screen has been locked\n"
                  "  -V, --version            - Show version information\n"
                  "  -h, --help               - Show this help message\n";


### PR DESCRIPTION
(partially) fixes #633 

Hi!
I've recently tried out hyprlock and it works nicely with my setup! (using Wayfire mostly) However, I also noticed the issue reported in #633 and I think it is mainly caused by not being able to delay suspend until the screen is locked.

This patch adds two (related) ways to signal to a parent process when the screen has been locked:

1. Writing to an inherited file descriptor: after the screen has been locked, a single newline is written to the FD given as an argument to the `-R` / `--ready-fd` option. Similar functionality exists in [swaylock](https://github.com/swaywm/swaylock/blob/master/swaylock.1.scd).
2. Creating a child process (with `fork()`) and waiting until it locks the screen (`-D` / `--daemonize` option). This ensures that when the parent process exits, the screen is locked. This is equivalent to the `-fork-on-lock` option in [waylock](https://codeberg.org/ifreund/waylock/src/branch/master/doc/waylock.1.scd) or the `-f` / `--daemonize` option of swaylock.

Using the second option and e.g. [swayidle](https://github.com/swaywm/swayidle), it can be ensured that the screen is locked before suspend:
```
swayidle -w before-sleep "hyprlock -D"
```
The first option can be tested e.g. with the screenlocker proxy service I'm working on:
https://github.com/dkondor/wayland-screenlock-proxy/tree/hyprlock

Caveats / TODO:
 - Not tested with hypridle yet (but likely would need the equivalent of the `-w` option in swayidle unless I'm missing something)
 - This only works well if  `no_fade_in = true` is set in the config, since it signals success immediately when getting the [locked](https://wayland.app/protocols/ext-session-lock-v1#ext_session_lock_v1:event:locked) event. I looked into how the fade-in animation is managed, and seems I would need to check when `bga == 1` [here](https://github.com/hyprwm/hyprlock/blob/e01afaf107650eb7f84ffe6444d1cfcfbb4a0ff5/src/renderer/Renderer.cpp#L235), but I'm unsure how to get this information to the `CHyprlock` class yet.
 - Both options do not work well together (if both `-D` and `-R` is given, the latter is ignored); not sure if this should be an error, or the worked around to still signal the fd given to `-R`

