### PR TITLE
auth: fixup prompt and fail substitution

### DIFF
--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -28,34 +28,35 @@ class CAuth {
   public:
     CAuth();
 
-    void start();
+    void                                 start();
 
-    void submitInput(const std::string& input);
-    bool checkWaiting();
+    void                                 submitInput(const std::string& input);
+    bool                                 checkWaiting();
 
-    // Used by the PasswordInput field. We are constraint to a single line for the authentication feedback there.
-    // Based on m_bDisplayFailText, this will return either the fail text or the prompt.
-    // Based on m_eLastActiveImpl, it will select the implementation.
-    std::string                          getInlineFeedback();
+    const std::string&                   getCurrentFailText();
 
     std::optional<std::string>           getFailText(eAuthImplementations implType);
     std::optional<std::string>           getPrompt(eAuthImplementations implType);
+    size_t                               getFailedAttempts();
 
     std::shared_ptr<IAuthImplementation> getImpl(eAuthImplementations implType);
 
     void                                 terminate();
 
-    // Should only be set via the main thread
-    bool   m_bDisplayFailText = false;
-    size_t m_iFailedAttempts  = 0;
+    void                                 enqueueUnlock();
+    void                                 enqueueFail(const std::string& failText, eAuthImplementations implType);
 
-    void   enqueueUnlock();
-    void   enqueueFail();
-    void   postActivity(eAuthImplementations implType);
+    // Should only be set via the main thread
+    bool m_bDisplayFailText = false;
 
   private:
+    struct {
+        std::string          failText       = "";
+        eAuthImplementations failSource     = AUTH_IMPL_PAM;
+        size_t               failedAttempts = 0;
+    } m_sCurrentFail;
+
     std::vector<std::shared_ptr<IAuthImplementation>> m_vImpls;
-    std::optional<eAuthImplementations>               m_eLastActiveImpl = std::nullopt;
 };
 
 inline std::unique_ptr<CAuth> g_pAuth;

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -96,7 +96,7 @@ void CPam::init() {
                 return;
 
             if (!AUTHENTICATED)
-                g_pAuth->enqueueFail();
+                g_pAuth->enqueueFail(m_sConversationState.failText, AUTH_IMPL_PAM);
             else {
                 g_pAuth->enqueueUnlock();
                 return;
@@ -124,7 +124,6 @@ bool CPam::auth() {
     handle = nullptr;
 
     m_sConversationState.waitingForPamAuth = false;
-    g_pAuth->postActivity(AUTH_IMPL_PAM);
 
     if (ret != PAM_SUCCESS) {
         if (!m_sConversationState.failTextFromPam)
@@ -156,7 +155,6 @@ void CPam::waitForInput() {
 }
 
 void CPam::handleInput(const std::string& input) {
-    g_pAuth->postActivity(AUTH_IMPL_PAM);
     std::unique_lock<std::mutex> lk(m_sConversationState.inputMutex);
 
     if (!m_sConversationState.inputRequested)

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -72,9 +72,6 @@ class CPasswordInputField : public IWidget {
 
         std::string              currentText    = "";
         size_t                   failedAttempts = 0;
-        bool                     canGetNewText  = true;
-
-        std::string              lastAuthFeedback;
 
         std::vector<std::string> registeredResourceIDs;
 


### PR DESCRIPTION
This PR brings back fingerprint errors in `$FAIL`. That was regressed by https://github.com/hyprwm/hyprlock/pull/603.

BREAKING:
- Removed $PROMPT variable. Either use $PAMPROMPT or $FPRINTPROMPT.
- Removed $FPRINTMESSAGE. Use $FPRINTPROMPT instead. There is also
  $FPRINTFAIL.