### PR TITLE
animations: fix overshoot beziers and cleanup animation config parsing

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -605,34 +605,32 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
     int64_t enabledInt = configStringToInt(ARGS[1]);
 
     // Checking that the int is 1 or 0 because the helper can return integers out of range.
-    if (enabledInt != 0 && enabledInt != 1)
+    if (enabledInt > 1 || enabledInt < 0)
         return "invalid animation on/off state";
 
-    if (enabledInt) {
-        int64_t speed = -1;
+    int64_t speed = -1;
 
-        // speed
-        if (isNumber(ARGS[2], true)) {
-            speed = std::stof(ARGS[2]);
+    // speed
+    if (isNumber(ARGS[2], true)) {
+        speed = std::stof(ARGS[2]);
 
-            if (speed <= 0) {
-                speed = 1.f;
-                return "invalid speed";
-            }
-        } else {
-            speed = 10.f;
+        if (speed <= 0) {
+            speed = 1.f;
             return "invalid speed";
         }
+    } else {
+        speed = 10.f;
+        return "invalid speed";
+    }
 
-        std::string bezierName = ARGS[3];
-        // ARGS[4] (style) currently usused by hyprlock
-        m_AnimationTree.setConfigForNode(ANIMNAME, enabledInt, speed, ARGS[3], "");
+    std::string bezierName = ARGS[3];
+    // ARGS[4] (style) currently usused by hyprlock
+    m_AnimationTree.setConfigForNode(ANIMNAME, enabledInt, speed, bezierName, "");
 
-        if (!g_pAnimationManager->bezierExists(bezierName)) {
-            const auto PANIMNODE      = m_AnimationTree.getConfig(ANIMNAME);
-            PANIMNODE->internalBezier = "default";
-            return "no such bezier";
-        }
+    if (!g_pAnimationManager->bezierExists(bezierName)) {
+        const auto PANIMNODE      = m_AnimationTree.getConfig(ANIMNAME);
+        PANIMNODE->internalBezier = "default";
+        return "no such bezier";
     }
 
     return {};

--- a/src/core/AnimationManager.cpp
+++ b/src/core/AnimationManager.cpp
@@ -3,15 +3,13 @@
 #include "../config/ConfigDataValues.hpp"
 #include "../config/ConfigManager.hpp"
 
-#include <utility>
-
 CHyprlockAnimationManager::CHyprlockAnimationManager() {
     ;
 }
 
 template <Animable VarType>
 void updateVariable(CAnimatedVariable<VarType>& av, const float POINTY, bool warp = false) {
-    if (POINTY >= 1.f || warp || !av.enabled() || av.value() == av.goal()) {
+    if (warp || !av.enabled() || av.value() == av.goal()) {
         av.warp();
         return;
     }
@@ -21,7 +19,7 @@ void updateVariable(CAnimatedVariable<VarType>& av, const float POINTY, bool war
 }
 
 void updateColorVariable(CAnimatedVariable<CHyprColor>& av, const float POINTY, bool warp = false) {
-    if (POINTY >= 1.f || warp || !av.enabled() || av.value() == av.goal()) {
+    if (warp || !av.enabled() || av.value() == av.goal()) {
         av.warp();
         return;
     }
@@ -45,7 +43,7 @@ void updateColorVariable(CAnimatedVariable<CHyprColor>& av, const float POINTY, 
 }
 
 void updateGradientVariable(CAnimatedVariable<CGradientValueData>& av, const float POINTY, bool warp = false) {
-    if (POINTY >= 1.f || warp || av.value() == av.goal()) {
+    if (warp || av.value() == av.goal()) {
         av.warp();
         return;
     }
@@ -87,27 +85,28 @@ void CHyprlockAnimationManager::tick() {
         const auto SPENT   = PAV->getPercent();
         const auto PBEZIER = getBezier(PAV->getBezierName());
         const auto POINTY  = PBEZIER->getYForPoint(SPENT);
+        const bool WARP    = !**PANIMATIONSENABLED || SPENT >= 1.f;
 
         switch (PAV->m_Type) {
             case AVARTYPE_FLOAT: {
                 auto pTypedAV = dynamic_cast<CAnimatedVariable<float>*>(PAV.get());
                 RASSERT(pTypedAV, "Failed to upcast animated float");
-                updateVariable(*pTypedAV, POINTY, !**PANIMATIONSENABLED);
+                updateVariable(*pTypedAV, POINTY, WARP);
             } break;
             case AVARTYPE_VECTOR: {
                 auto pTypedAV = dynamic_cast<CAnimatedVariable<Vector2D>*>(PAV.get());
                 RASSERT(pTypedAV, "Failed to upcast animated Vector2D");
-                updateVariable(*pTypedAV, POINTY, !**PANIMATIONSENABLED);
+                updateVariable(*pTypedAV, POINTY, WARP);
             } break;
             case AVARTYPE_COLOR: {
                 auto pTypedAV = dynamic_cast<CAnimatedVariable<CHyprColor>*>(PAV.get());
                 RASSERT(pTypedAV, "Failed to upcast animated CHyprColor");
-                updateColorVariable(*pTypedAV, POINTY, !**PANIMATIONSENABLED);
+                updateColorVariable(*pTypedAV, POINTY, WARP);
             } break;
             case AVARTYPE_GRADIENT: {
                 auto pTypedAV = dynamic_cast<CAnimatedVariable<CGradientValueData>*>(PAV.get());
                 RASSERT(pTypedAV, "Failed to upcast animated CGradientValueData");
-                updateGradientVariable(*pTypedAV, POINTY, !**PANIMATIONSENABLED);
+                updateGradientVariable(*pTypedAV, POINTY, WARP);
             } break;
             default: continue;
         }


### PR DESCRIPTION
The change in the animationmgr is the same as https://github.com/hyprwm/Hyprland/pull/9000.

Also adapted the simplification in `CConfigManager::handleAnimation` from Hyprland.