### PR TITLE
example.conf. Add default animations

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -1,6 +1,13 @@
 # sample hyprlock.conf
 # for more configuration options, refer https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock
 
+animations {
+    enabled = true
+    bezier = linear, 1, 1, 0, 0
+    animation = fadeIn, 1, 5, linear
+    animation = fadeOut, 1, 5, linear
+}
+
 input-field {
   monitor =
   fade_on_empty = false


### PR DESCRIPTION
Added some default animations to the example config, that replicate old hyprlock behaviour. They both give a pleasant fade animation and provide some hints on how to organize and customize hyprlock.