### PR TITLE
widgets: execute shell commands from more keywords

### DIFF
--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -44,6 +44,18 @@ void CLabel::onTimerUpdate() {
 
     label = formatString(labelPreFormat);
 
+    try {
+        const auto LAYOUT = CLayoutValueData::fromAnyPv(props.at("position"));
+        if (LAYOUT->needsUpdate()) {
+            const auto OLD_POS = LAYOUT->getAbsolute(viewport);
+            LAYOUT->update();
+            if (OLD_POS != LAYOUT->getAbsolute(viewport)) { // redraw:
+                configPos = LAYOUT->getAbsolute(viewport);
+                g_pHyprlock->renderOutput(outputStringPort);
+            }
+        }
+    } catch (...) { /* TODO */ }
+
     if (label.formatted == oldFormatted && !label.alwaysUpdate)
         return;
 
@@ -70,8 +82,8 @@ void CLabel::plantTimer() {
         labelTimer = g_pHyprlock->addTimer(std::chrono::hours(1), onTimer, this, true);
 }
 
-CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, std::any>& props, const std::string& output) :
-    outputStringPort(output), shadow(this, props, viewport_) {
+CLabel::CLabel(const Vector2D& viewport_, const WidgetProps& props_, const std::string& output) :
+    outputStringPort(output), shadow(this, props_, viewport_), props(props_) {
     try {
         pos            = CLayoutValueData::fromAnyPv(props.at("position"))->getAbsolute(viewport_);
         labelPreFormat = std::any_cast<Hyprlang::STRING>(props.at("text"));

--- a/src/renderer/widgets/Label.hpp
+++ b/src/renderer/widgets/Label.hpp
@@ -12,9 +12,11 @@
 struct SPreloadedAsset;
 class CSessionLockSurface;
 
+using WidgetProps = std::unordered_map<std::string, std::any>;
+
 class CLabel : public IWidget {
   public:
-    CLabel(const Vector2D& viewport, const std::unordered_map<std::string, std::any>& props, const std::string& output);
+    CLabel(const Vector2D& viewport_, const WidgetProps& props_, const std::string& output);
     ~CLabel();
 
     virtual bool draw(const SRenderData& data);
@@ -46,4 +48,5 @@ class CLabel : public IWidget {
 
     CShadowable                             shadow;
     bool                                    updateShadow = true;
+    WidgetProps                             props;
 };


### PR DESCRIPTION
Draft PR for extending shell command execution to other keywords (`position`, `color`, `dots_text_format`, etc.)

This scuffed but functional first commit only works for a label's position.