### PR TITLE
core: move wayland event reading into the poll thread

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -117,8 +117,6 @@ void CSessionLockSurface::onScaleUpdate() {
 }
 
 void CSessionLockSurface::render() {
-    Debug::log(TRACE, "render lock");
-
     if (frameCallback || !readyForFrame) {
         needsFrame = true;
         return;
@@ -127,9 +125,15 @@ void CSessionLockSurface::render() {
     g_pAnimationManager->tick();
     const auto FEEDBACK = g_pRenderer->renderLock(*this);
     frameCallback       = makeShared<CCWlCallback>(surface->sendFrame());
-    frameCallback->setDone([this](CCWlCallback* r, uint32_t data) {
+    frameCallback->setDone([this](CCWlCallback* r, uint32_t frameTime) {
         if (g_pHyprlock->m_bTerminate)
             return;
+
+        Debug::log(TRACE, "[{}] frame {}, Current fps: {:.2f}", output->stringPort, m_frames, 1000.f / (frameTime - m_lastFrameTime));
+
+        m_lastFrameTime = frameTime;
+
+        m_frames++;
 
         onCallback();
     });

--- a/src/core/LockSurface.hpp
+++ b/src/core/LockSurface.hpp
@@ -42,6 +42,9 @@ class CSessionLockSurface {
 
     bool                          needsFrame = false;
 
+    uint32_t                      m_lastFrameTime = 0;
+    uint32_t                      m_frames        = 0;
+
     // wayland callbacks
     SP<CCWlCallback> frameCallback = nullptr;
 

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -151,6 +151,9 @@ class CHyprlock {
         std::condition_variable loopCV;
         bool                    event = false;
 
+        std::condition_variable wlDispatchCV;
+        bool                    wlDispatched = false;
+
         std::condition_variable timerCV;
         std::mutex              timerRequestMutex;
         bool                    timerEvent = false;

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -198,8 +198,6 @@ CRenderer::CRenderer() {
     g_pAnimationManager->createAnimation(0.f, opacity, g_pConfigManager->m_AnimationTree.getConfig("fadeIn"));
 }
 
-static int frames = 0;
-
 //
 CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf) {
     static auto* const PDISABLEBAR = (Hyprlang::INT* const*)g_pConfigManager->getValuePtr("general:disable_loading_bar");
@@ -237,10 +235,6 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
             feedback.needsFrame = w->draw({opacity->value()}) || feedback.needsFrame;
         }
     }
-
-    frames++;
-
-    Debug::log(TRACE, "frame {}", frames);
 
     feedback.needsFrame = feedback.needsFrame || !asyncResourceGatherer->gathered;
 


### PR DESCRIPTION
This was done, so that we can

  wl_display_prepare_read -> poll -> wl_display_read_events

That fixes synchronization issues on nvidia proprietary drivers.

Closes https://github.com/hyprwm/hyprlock/issues/572
Closes https://github.com/hyprwm/hyprlock/issues/525
Closes https://github.com/hyprwm/hyprlock/issues/419
Closes https://github.com/hyprwm/hyprlock/issues/128