### PR TITLE
core: don't attempt to unlock when we are not locked yet

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -518,6 +518,11 @@ void CHyprlock::run() {
 }
 
 void CHyprlock::unlock() {
+    if (!m_bLocked) {
+        Debug::log(WARN, "Unlock called, but not locked yet. This can happen when dpms is off during the grace period.");
+        return;
+    }
+
     const bool IMMEDIATE = m_sCurrentDesktop != "Hyprland";
 
     g_pRenderer->startFadeOut(true, IMMEDIATE);


### PR DESCRIPTION
This fixes a bug that can happen when the rending of a session lock surface is delayed (for example when dmps is off). 
Launching hyprlock during dmps off and then waking the screen ended up in hyprlock being deadlocked.