### PR TITLE
input-field: Fix crash when numlock is on and numlock_color is fallback

### DIFF
--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -418,7 +418,7 @@ void CPasswordInputField::updateColors() {
     CHyprColor          innerTarget = colorConfig.inner;
     CHyprColor          fontTarget  = (displayFail) ? colorConfig.fail->m_vColors.front() : colorConfig.font;
 
-    if (checkWaiting || displayFail || g_pHyprlock->m_bCapsLock || NUMLOCK) {
+    if (checkWaiting || displayFail || g_pHyprlock->m_bCapsLock || (NUMLOCK && !colorConfig.num->m_bIsFallback)) {
         if (BORDERLESS && colorConfig.swapFont) {
             fontTarget = targetGrad->m_vColors.front();
         } else if (BORDERLESS && !colorConfig.swapFont) {


### PR DESCRIPTION
## Issue
Hyprlock crashes in `updateColors()` when:
- Numlock is enabled.
- `colorConfig.num` is a fallback value.

There is an inconsistency in condition checks when assigning and later using `targetGrad`:

1. **When assigning `targetGrad`** (Line 409), the condition checks both:
   - Whether numlock is enabled.
   - Whether `colorConfig.num` is **not** a fallback.

2. **When using `targetGrad`** (Line 421), the condition only checks for numlock, but **does not** check if `numlock_color` is a fallback.  
   - If `numlock_color` **is** a fallback, `targetGrad` remains `nullptr`, leading to a crash.

## Fix
- Updated the condition in Line 421 to **match** the condition used when assigning `targetGrad`.