### PR TITLE
label: add relative values for font_size

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -14,6 +14,7 @@ enum eConfigValueDataTypes {
     CVD_TYPE_INVALID  = -1,
     CVD_TYPE_LAYOUT   = 0,
     CVD_TYPE_GRADIENT = 1,
+    CVD_TYPE_FONT_SIZE = 2,
 };
 
 class ICustomConfigValueData {
@@ -130,4 +131,58 @@ class CGradientValueData : public ICustomConfigValueData {
         RASSERT(P, "Empty config value");
         return P;
     }
+};
+
+enum eFontRelativeTypes {
+    FR_TYPE_ABSOLUTE = 0,
+    FR_TYPE_VIEW_WIDTH = 1,    
+    FR_TYPE_VIEW_HEIGHT = 2,    
+};
+
+class CFontSizeValueData : public ICustomConfigValueData {
+public:
+    CFontSizeValueData() {}
+    virtual ~CFontSizeValueData() {};
+
+    virtual eConfigValueDataTypes getDataType() {
+        return CVD_TYPE_FONT_SIZE;
+    }
+
+    static CFontSizeValueData* fromAnyPv(const std::any& v) {
+        RASSERT(v.type() == typeid(void*), "Invalid config value type");
+        const auto P = (CFontSizeValueData*)std::any_cast<void*>(v);
+        RASSERT(P, "Empty config value");
+        return P;
+    }
+
+    virtual std::string toString() {
+        return std::format("{}{}", m_size, valueSuffix());
+    }
+
+    const char *valueSuffix() {
+        switch (m_relativeTo) {
+            case FR_TYPE_VIEW_WIDTH:
+                return "vw";
+            case FR_TYPE_VIEW_HEIGHT:
+                return "vh";
+            case FR_TYPE_ABSOLUTE:
+            default:
+                return "px";
+        }
+    }
+
+    int getAbsolute(const Hyprutils::Math::Vector2D& viewport) {
+        switch (m_relativeTo) {
+            case FR_TYPE_VIEW_WIDTH:
+                return std::round((m_size / 100) * viewport.x);
+            case FR_TYPE_VIEW_HEIGHT:
+                return std::round((m_size / 100) * viewport.y);
+            case FR_TYPE_ABSOLUTE:
+            default:
+                return std::round(m_size);
+        }
+    }
+
+    float m_size;
+    eFontRelativeTypes m_relativeTo = FR_TYPE_ABSOLUTE;
 };

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -95,9 +95,39 @@ static Hyprlang::CParseResult configHandleLayoutOption(const char* v, void** dat
     return result;
 }
 
+static Hyprlang::CParseResult configHandleFontSizeOption(const char* v, void** data) {
+    const std::string      VALUE = v;
+    Hyprlang::CParseResult result;
+    
+    if (!*data)
+        *data = new CFontSizeValueData();
+
+    const auto DATA  = (CFontSizeValueData*)(*data);
+
+    std::string stripped;
+    if (VALUE.ends_with("vw")) {
+        DATA->m_relativeTo = FR_TYPE_VIEW_WIDTH;
+        stripped = VALUE.substr(0, VALUE.size() - 3);
+    } else if (VALUE.ends_with("vh")) {
+        DATA->m_relativeTo = FR_TYPE_VIEW_HEIGHT;
+        stripped = VALUE.substr(0, VALUE.size() - 3);
+    } else {
+        stripped = VALUE;
+    }
+
+    DATA->m_size = std::stof(VALUE);
+
+    return result;
+}
+
 static void configHandleLayoutOptionDestroy(void** data) {
     if (*data)
         delete reinterpret_cast<CLayoutValueData*>(*data);
+}
+
+static void configHandleFontSizeOptionDestroy(void** data) {
+    if (*data)
+        delete reinterpret_cast<CFontSizeValueData*>(*data);
 }
 
 static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** data) {
@@ -201,6 +231,10 @@ inline static constexpr auto GRADIENTCONFIG = [](const char* default_value) -> H
 
 inline static constexpr auto LAYOUTCONFIG = [](const char* default_value) -> Hyprlang::CUSTOMTYPE {
     return Hyprlang::CUSTOMTYPE{&configHandleLayoutOption, configHandleLayoutOptionDestroy, default_value};
+};
+
+inline static constexpr auto FONTSIZECONFIG = [](const char* default_value) -> Hyprlang::CUSTOMTYPE {
+    return Hyprlang::CUSTOMTYPE{&configHandleFontSizeOption, configHandleFontSizeOptionDestroy, default_value};
 };
 
 void CConfigManager::init() {
@@ -312,7 +346,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("label", "monitor", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("label", "position", LAYOUTCONFIG("0,0"));
     m_config.addSpecialConfigValue("label", "color", Hyprlang::INT{0xFFFFFFFF});
-    m_config.addSpecialConfigValue("label", "font_size", Hyprlang::INT{16});
+    m_config.addSpecialConfigValue("label", "font_size", FONTSIZECONFIG("16"));
     m_config.addSpecialConfigValue("label", "text", Hyprlang::STRING{"Sample Text"});
     m_config.addSpecialConfigValue("label", "font_family", Hyprlang::STRING{"Sans"});
     m_config.addSpecialConfigValue("label", "halign", Hyprlang::STRING{"none"});

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -82,8 +82,8 @@ CLabel::CLabel(const Vector2D& viewport_, const std::unordered_map<std::string, 
 
         std::string textAlign  = std::any_cast<Hyprlang::STRING>(props.at("text_align"));
         std::string fontFamily = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
-        CHyprColor      labelColor = std::any_cast<Hyprlang::INT>(props.at("color"));
-        int         fontSize   = std::any_cast<Hyprlang::INT>(props.at("font_size"));
+        CHyprColor  labelColor = std::any_cast<Hyprlang::INT>(props.at("color"));
+        int         fontSize   = CFontSizeValueData::fromAnyPv(props.at("font_size"))->getAbsolute(viewport_);
 
         label = formatString(labelPreFormat);
 


### PR DESCRIPTION
This adds ability to use relative sizing for `font_size` of label widget. It's really useful to use `%` to position and size widgets across displays with different resolutions, however such functionality is lacking in `font_size`. Added `vh` and `vw` suffixes to size text proportionally to viewport height and width respectively. This functions the same as [in css](https://developer.mozilla.org/en-US/docs/Web/CSS/length#relative_length_units). Also I picked `vw` and `vh` instead of `%` because [in css](https://developer.mozilla.org/en-US/docs/Web/CSS/percentage) it is defined as "relative to parent objects" font size and in hyprlock there is no parent object font size, so this would be just confusing whichever way it is implemented.

Examples in action (sorry for photos of screen, didn't figure out how to screenshot):
4K screen before (config was created for it):
![image](https://github.com/user-attachments/assets/53f56a06-d8d1-44ae-bab6-dd5d5d0dd768)

4K screen after (changed all values in config to `vh`):
![image](https://github.com/user-attachments/assets/31f0e337-359c-4d23-8587-c862044101d6)

1080p screen before:
![image](https://github.com/user-attachments/assets/15f416fc-98cd-4b27-9a84-8787c2753729)

1080p screen after:
![image](https://github.com/user-attachments/assets/62e8626d-baa5-4098-a62d-1dd02a3b2b84)


P.S. thanks for this awesome piece of software. Works like a charm!