### PR TITLE
core: don't rely on the locked event to create lock surfaces dynamically

### DIFF
--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -18,10 +18,10 @@ COutput::COutput(SP<CCWlOutput> output_, uint32_t name_) : name(name_), output(o
     output->setScale([this](CCWlOutput* r, int32_t sc) { scale = sc; });
 
     output->setDone([this](CCWlOutput* r) {
+        done = true;
         Debug::log(LOG, "output {} done", name);
-        if (g_pHyprlock->m_bLocked && !sessionLockSurface) {
-            // if we are already locked, create a surface dynamically
-            Debug::log(LOG, "Creating a surface dynamically for output as we are already locked");
+        if (g_pHyprlock->m_lockAquired && !sessionLockSurface) {
+            Debug::log(LOG, "output {} creating a new lock surface", name);
             sessionLockSurface = std::make_unique<CSessionLockSurface>(this);
         }
     });

--- a/src/core/Output.hpp
+++ b/src/core/Output.hpp
@@ -12,6 +12,7 @@ class COutput {
 
     uint32_t                             name      = 0;
     bool                                 focused   = false;
+    bool                                 done      = false;
     wl_output_transform                  transform = WL_OUTPUT_TRANSFORM_NORMAL;
     Vector2D                             size;
     int                                  scale      = 1;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -48,10 +48,8 @@ class CHyprlock {
     void                             onLockLocked();
     void                             onLockFinished();
 
-    void                             acquireSessionLock();
+    bool                             acquireSessionLock();
     void                             releaseSessionLock();
-
-    void                             createSessionLockSurfaces();
 
     void                             attemptRestoreOnDeath();
 
@@ -88,7 +86,8 @@ class CHyprlock {
 
     bool                             m_bTerminate = false;
 
-    bool                             m_bLocked = false;
+    bool                             m_lockAquired = false;
+    bool                             m_bLocked     = false;
 
     bool                             m_bCapsLock = false;
     bool                             m_bNumLock  = false;


### PR DESCRIPTION
Related to https://github.com/hyprwm/Hyprland/pull/9399

Together with the hyprland PR this fixes parts of https://github.com/hyprwm/hyprlock/issues/678. Possibly related to https://github.com/hyprwm/hyprlock/issues/101 as well.