### PR TITLE
cmake: bump hyprutils version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ pkg_check_modules(
   pangocairo
   libdrm
   gbm
-  hyprutils>=0.3.3
+  hyprutils>=0.5.0
   sdbus-c++>=2.0.0
   hyprgraphics)
 


### PR DESCRIPTION
Missing from https://github.com/hyprwm/hyprlock/pull/689 (The warp updates require it)