### PR TITLE
label: fix crashes when keymap is a nullptr after suspend

### DIFF
--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -134,6 +134,25 @@ void CSeatManager::registerCursorShape(SP<CCWpCursorShapeManagerV1> shape) {
     m_pCursorShape = makeUnique<CCursorShape>(shape);
 }
 
+std::string CSeatManager::getActiveKbLayoutName() {
+    if (!m_pXKBState || !m_pXKBKeymap)
+        return "error";
+
+    const auto LAYOUTSNUM = xkb_keymap_num_layouts(m_pXKBKeymap);
+
+    for (uint32_t i = 0; i < LAYOUTSNUM; ++i) {
+        if (xkb_state_layout_index_is_active(m_pXKBState, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
+            const auto LAYOUTNAME = xkb_keymap_layout_get_name(m_pXKBKeymap, i);
+
+            if (LAYOUTNAME)
+                return std::string{LAYOUTNAME};
+            return "error";
+        }
+    }
+
+    return "none";
+}
+
 bool CSeatManager::registered() {
     return m_pSeat;
 }

--- a/src/core/Seat.hpp
+++ b/src/core/Seat.hpp
@@ -14,6 +14,7 @@ class CSeatManager {
     void               registerSeat(SP<CCWlSeat> seat);
     void               registerCursorShape(SP<CCWpCursorShapeManagerV1> shape);
     bool               registered();
+    std::string        getActiveKbLayoutName();
 
     SP<CCWlKeyboard>   m_pKeeb;
     SP<CCWlPointer>    m_pPointer;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -67,6 +67,8 @@ class CHyprlock {
     size_t                           getPasswordBufferLen();
     size_t                           getPasswordBufferDisplayLen();
 
+    std::string                      getActiveKeyboardLayout();
+
     SP<CCExtSessionLockManagerV1>    getSessionLockMgr();
     SP<CCExtSessionLockV1>           getSessionLock();
     SP<CCWlCompositor>               getCompositor();

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -101,21 +101,25 @@ static void replaceAllAttempts(std::string& str) {
 
 static void replaceAllLayout(std::string& str) {
 
-    const auto        LAYOUTIDX  = g_pHyprlock->m_uiActiveLayout;
-    const auto        LAYOUTNAME = xkb_keymap_layout_get_name(g_pSeatManager->m_pXKBKeymap, LAYOUTIDX);
-    const std::string STR        = LAYOUTNAME ? LAYOUTNAME : "error";
-    size_t            pos        = 0;
+    const auto LAYOUTIDX  = g_pHyprlock->m_uiActiveLayout;
+    const auto LAYOUTNAME = g_pSeatManager->getActiveKbLayoutName();
+    size_t     pos        = 0;
 
     while ((pos = str.find("$LAYOUT", pos)) != std::string::npos) {
         if (str.substr(pos, 8).ends_with('[') && str.substr(pos).contains(']')) {
             const std::string REPL = str.substr(pos + 8, str.find_first_of(']', pos) - 8 - pos);
             const CVarList    LANGS(REPL);
-            const std::string LANG = LANGS[LAYOUTIDX].empty() ? STR : LANGS[LAYOUTIDX] == "!" ? "" : LANGS[LAYOUTIDX];
+            if (LAYOUTIDX >= LANGS.size()) {
+                Debug::log(ERR, "Layout index {} out of bounds. Max is {}.", LAYOUTIDX, LANGS.size() - 1);
+                continue;
+            }
+
+            const std::string LANG = LANGS[LAYOUTIDX].empty() ? LAYOUTNAME : LANGS[LAYOUTIDX] == "!" ? "" : LANGS[LAYOUTIDX];
             str.replace(pos, 9 + REPL.length(), LANG);
             pos += LANG.length();
         } else {
-            str.replace(pos, 7, STR);
-            pos += STR.length();
+            str.replace(pos, 7, LAYOUTNAME);
+            pos += LAYOUTNAME.length();
         }
     }
 }


### PR DESCRIPTION
Fixes a crash reported in https://github.com/hyprwm/hyprlock/issues/695