### PR TITLE
core: move password buffer clearing to handleInput

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -29,6 +29,8 @@ void CAuth::submitInput(const std::string& input) {
     for (const auto& i : m_vImpls) {
         i->handleInput(input);
     }
+
+    g_pHyprlock->clearPasswordBuffer();
 }
 
 bool CAuth::checkWaiting() {
@@ -76,8 +78,6 @@ void CAuth::terminate() {
 
 static void passwordFailCallback(std::shared_ptr<CTimer> self, void* data) {
     g_pAuth->m_bDisplayFailText = true;
-
-    g_pHyprlock->clearPasswordBuffer();
 
     g_pHyprlock->enqueueForceUpdateTimers();
 

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -138,14 +138,7 @@ bool CPam::auth() {
     return true;
 }
 
-// clearing the input must be done from the main thread
-static void clearInputTimerCallback(std::shared_ptr<CTimer> self, void* data) {
-    g_pHyprlock->clearPasswordBuffer();
-}
-
 void CPam::waitForInput() {
-    g_pHyprlock->addTimer(std::chrono::milliseconds(1), clearInputTimerCallback, nullptr);
-
     std::unique_lock<std::mutex> lk(m_sConversationState.inputMutex);
     m_bBlockInput                          = false;
     m_sConversationState.waitingForPamAuth = false;

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -165,6 +165,9 @@ void CPasswordInputField::updateDots() {
     if (dots.currentAmount->goal() == passwordLength)
         return;
 
+    if (checkWaiting)
+        return;
+
     if (passwordLength == 0)
         dots.currentAmount->setValueAndWarp(passwordLength);
     else
@@ -298,7 +301,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
         }
     }
 
-    if (passwordLength == 0 && !placeholder.resourceID.empty()) {
+    if (passwordLength == 0 && !checkWaiting && !placeholder.resourceID.empty()) {
         SPreloadedAsset* currAsset = nullptr;
 
         if (!placeholder.asset)
@@ -451,7 +454,7 @@ void CPasswordInputField::updateColors() {
 
     if (checkWaiting)
         targetGrad = colorConfig.check;
-    else if (displayFail)
+    else if (displayFail && passwordLength == 0)
         targetGrad = colorConfig.fail;
 
     CGradientValueData* outerTarget = colorConfig.outer;


### PR DESCRIPTION
Makes more sense than clearing the input buffer in the auth impl. Also added a check for the password buffer length to reset the fail color as soon as the password length > 0.