### PR TITLE
CMake: require wayland-protocols>=1.35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ pkg_check_modules(
   REQUIRED
   IMPORTED_TARGET
   wayland-client
-  wayland-protocols
+  wayland-protocols>=1.35
   wayland-egl
   hyprlang>=0.6.0
   egl


### PR DESCRIPTION
tablet-v2 was moved to stable in 1.35. Hyprlock will fail to build if a earlier version is used.