### PR TITLE
core: move fail_timeout from input-field to general

### DIFF
--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "../defines.hpp"
+#include "../core/Timer.hpp"
 
 enum eAuthImplementations {
     AUTH_IMPL_PAM         = 0,
@@ -47,6 +48,8 @@ class CAuth {
     void                       enqueueUnlock();
     void                       enqueueFail(const std::string& failText, eAuthImplementations implType);
 
+    void                       resetDisplayFail();
+
     // Should only be set via the main thread
     bool m_bDisplayFailText = false;
 
@@ -58,6 +61,7 @@ class CAuth {
     } m_sCurrentFail;
 
     std::vector<SP<IAuthImplementation>> m_vImpls;
+    std::shared_ptr<CTimer>              m_resetDisplayFailTimer;
 };
 
 inline UP<CAuth> g_pAuth;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -216,6 +216,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});
     m_config.addConfigValue("general:screencopy_mode", Hyprlang::INT{0});
+    m_config.addConfigValue("general:fail_timeout", Hyprlang::INT{2000});
 
     m_config.addConfigValue("auth:pam:enabled", Hyprlang::INT{1});
     m_config.addConfigValue("auth:pam:module", Hyprlang::STRING{"hyprlock"});
@@ -297,7 +298,6 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "check_color", GRADIENTCONFIG("0xFF22CC88"));
     m_config.addSpecialConfigValue("input-field", "fail_color", GRADIENTCONFIG("0xFFCC2222"));
     m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{"<i>$FAIL</i>"});
-    m_config.addSpecialConfigValue("input-field", "fail_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "capslock_color", GRADIENTCONFIG(""));
     m_config.addSpecialConfigValue("input-field", "numlock_color", GRADIENTCONFIG(""));
     m_config.addSpecialConfigValue("input-field", "bothlock_color", GRADIENTCONFIG(""));
@@ -473,7 +473,6 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"check_color", m_config.getSpecialConfigValue("input-field", "check_color", k.c_str())},
                 {"fail_color", m_config.getSpecialConfigValue("input-field", "fail_color", k.c_str())},
                 {"fail_text", m_config.getSpecialConfigValue("input-field", "fail_text", k.c_str())},
-                {"fail_timeout", m_config.getSpecialConfigValue("input-field", "fail_timeout", k.c_str())},
                 {"capslock_color", m_config.getSpecialConfigValue("input-field", "capslock_color", k.c_str())},
                 {"numlock_color", m_config.getSpecialConfigValue("input-field", "numlock_color", k.c_str())},
                 {"bothlock_color", m_config.getSpecialConfigValue("input-field", "bothlock_color", k.c_str())},

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -602,6 +602,9 @@ void CHyprlock::onKey(uint32_t key, bool down) {
         return;
     }
 
+    if (g_pAuth->m_bDisplayFailText)
+        g_pAuth->resetDisplayFail();
+
     if (down) {
         m_bCapsLock = xkb_state_mod_name_is_active(g_pSeatManager->m_pXKBState, XKB_MOD_NAME_CAPS, XKB_STATE_MODS_LOCKED);
         m_bNumLock  = xkb_state_mod_name_is_active(g_pSeatManager->m_pXKBState, XKB_MOD_NAME_NUM, XKB_STATE_MODS_LOCKED);

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -7,7 +7,6 @@
 #include "Shadowable.hpp"
 #include "../../config/ConfigDataValues.hpp"
 #include "../../helpers/AnimatedVariable.hpp"
-#include <chrono>
 #include <hyprutils/math/Vector2D.hpp>
 #include <vector>
 #include <any>
@@ -83,7 +82,6 @@ class CPasswordInputField : public IWidget {
         size_t                   failedAttempts = 0;
 
         std::vector<std::string> registeredResourceIDs;
-
     } placeholder;
 
     struct {


### PR DESCRIPTION
Initial version of this PR intended to fix some edge cases when rapidly providing input, where you would see the fail color, but no fail text placeholder.

Now it does that plus moving the `input-field:fail_timeout` setting.
It is easier and more flexible to handle the duration for which an auth failure gets displayed outside of the PasswordInputField widget.
Now per input-field fail_timeout settings wont be supported, but that didn't work anyways (smallest `fail_timeout` always took precedence)

