### PR TITLE
core: remove attemptRestoreOnDeath

### DIFF
--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -48,8 +48,6 @@ class CHyprlock {
     bool                             acquireSessionLock();
     void                             releaseSessionLock();
 
-    void                             attemptRestoreOnDeath();
-
     std::string                      spawnSync(const std::string& cmd);
 
     void                             onKey(uint32_t key, bool down);


### PR DESCRIPTION
This causes confusion when trying to help people debug or get traces.
I think now that we have the lock dead screen, where recovery options are stated, we don't need this any more.

It can also cause some leakage of the desktop or other weird behavior combined with other bugs. See #695