### PR TITLE
fingerprint: allow fprint to suspend and cancel verify for us

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -65,18 +65,12 @@ void CFingerprint::init() {
         // When entering sleep, the wake signal will trigger startVerify().
         if (m_sDBUSState.sleeping)
             return;
-        inhibitSleep();
         startVerify();
     });
     m_sDBUSState.login->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
         Debug::log(LOG, "fprint: PrepareForSleep (start: {})", start);
-        if (start) {
-            m_sDBUSState.sleeping = true;
-            stopVerify();
-            m_sDBUSState.inhibitLock.reset();
-        } else {
-            m_sDBUSState.sleeping = false;
-            inhibitSleep();
+        m_sDBUSState.sleeping = start;
+        if (!m_sDBUSState.sleeping && !m_sDBUSState.verifying) {
             startVerify();
         }
     });
@@ -109,18 +103,6 @@ void CFingerprint::terminate() {
 
 std::shared_ptr<sdbus::IConnection> CFingerprint::getConnection() {
     return m_sDBUSState.connection;
-}
-
-void CFingerprint::inhibitSleep() {
-    m_sDBUSState.login->callMethodAsync("Inhibit")
-        .onInterface(LOGIN_MANAGER)
-        .withArguments("sleep", "hyprlock", "Fingerprint verifcation must be stopped before sleep", "delay")
-        .uponReplyInvoke([this](std::optional<sdbus::Error> e, sdbus::UnixFd fd) {
-            if (e)
-                Debug::log(WARN, "fprint: could not inhibit sleep: {}", e->what());
-            else
-                m_sDBUSState.inhibitLock = fd;
-        });
 }
 
 bool CFingerprint::createDeviceProxy() {
@@ -163,8 +145,11 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
     auto matchResult   = s_mapStringToTestType[result];
     bool authenticated = false;
     bool retry         = false;
-    if (m_sDBUSState.sleeping && matchResult != MATCH_DISCONNECTED)
+    if (m_sDBUSState.sleeping) {
+        stopVerify();
+        Debug::log(LOG, "fprint: device suspended");
         return;
+    }
     switch (matchResult) {
         case MATCH_INVALID: Debug::log(WARN, "fprint: unknown status: {}", result); break;
         case MATCH_NO_MATCH:
@@ -229,6 +214,7 @@ void CFingerprint::claimDevice() {
 }
 
 void CFingerprint::startVerify(bool isRetry) {
+    m_sDBUSState.verifying = true;
     if (!m_sDBUSState.device) {
         if (!createDeviceProxy())
             return;
@@ -256,6 +242,7 @@ void CFingerprint::startVerify(bool isRetry) {
 }
 
 bool CFingerprint::stopVerify() {
+    m_sDBUSState.verifying = false;
     if (!m_sDBUSState.device)
         return false;
     try {

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -70,9 +70,8 @@ void CFingerprint::init() {
     m_sDBUSState.login->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
         Debug::log(LOG, "fprint: PrepareForSleep (start: {})", start);
         m_sDBUSState.sleeping = start;
-        if (!m_sDBUSState.sleeping && !m_sDBUSState.verifying) {
+        if (!m_sDBUSState.sleeping && !m_sDBUSState.verifying)
             startVerify();
-        }
     });
 }
 

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -29,12 +29,12 @@ class CFingerprint : public IAuthImplementation {
         std::shared_ptr<sdbus::IConnection> connection;
         std::unique_ptr<sdbus::IProxy>      login;
         std::unique_ptr<sdbus::IProxy>      device;
-        sdbus::UnixFd                       inhibitLock;
 
-        bool                                abort    = false;
-        bool                                done     = false;
-        int                                 retries  = 0;
-        bool                                sleeping = false;
+        bool                                abort     = false;
+        bool                                done      = false;
+        int                                 retries   = 0;
+        bool                                sleeping  = false;
+        bool                                verifying = false;
     } m_sDBUSState;
 
     std::string m_sFingerprintReady;
@@ -44,8 +44,6 @@ class CFingerprint : public IAuthImplementation {
     std::string m_sFailureReason{""};
 
     void        handleVerifyStatus(const std::string& result, const bool done);
-
-    void        inhibitSleep();
 
     bool        createDeviceProxy();
     void        claimDevice();


### PR DESCRIPTION
fprint does have it's own logic to inhibit sleeping until it cancels active tasks. I believe that hyprlock's logic to stop the verification before sleeping was causing an issue within fprint as it tried to handle both at the same time.

I was only having this issue occasionally so I'm not sure this completely fixes it, which is why this is a draft.