### PR TITLE
output: refuse to create session lock surfaces with size 0x0

### DIFF
--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -56,6 +56,11 @@ void COutput::createSessionLockSurface() {
         return;
     }
 
+    if (size == Vector2D{0, 0}) {
+        Debug::log(WARN, "output {} refusing to create a lock surface with size 0x0", m_ID);
+        return;
+    }
+
     m_sessionLockSurface = makeUnique<CSessionLockSurface>(m_self.lock());
 }
 


### PR DESCRIPTION
Originally I didn't want to do this, because the protocol clearly wants us to create a lock surface for all outputs.
But when we have size 0x0 we will need to handle it later on and not render onto this surface. I think its better to just omit creating one.

This might be related to some open issues related to suspend and monitor handling.
Cause I think it is currently possible that focus lands on the unsafe fallback monitor after hyprlock creates a lock surface for it.
I will address that in Hyprland as well. I think we should not allow a session lock surface for the fallback output, because we don't want it to receive focus.