### PR TITLE
fingerprint: update widgets after changing prompt

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -195,6 +195,8 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
 
     if (!authenticated && !retry)
         g_pAuth->enqueueFail(m_sFailureReason, AUTH_IMPL_FINGERPRINT);
+    else if (retry)
+        g_pHyprlock->enqueueForceUpdateTimers();
 
     if (done || m_sDBUSState.abort)
         m_sDBUSState.done = true;


### PR DESCRIPTION
When verification fails and a retry is needed (like when the user didn't hold
their finger for long enough) the prompt variable is changed but the widgets
aren't actually updated so the new prompt is never shown to the user. This fixes that.
