### PR TITLE
renderer: fix gradient copy size in renderBorder

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -272,7 +272,7 @@ void CRenderer::renderBorder(const CBox& box, const CGradientValueData& gradient
 
     glUniformMatrix3fv(borderShader.proj, 1, GL_TRUE, glMatrix.getMatrix().data());
 
-    glUniform4fv(borderShader.gradient, gradient.m_vColorsOkLabA.size(), (float*)gradient.m_vColorsOkLabA.data());
+    glUniform4fv(borderShader.gradient, gradient.m_vColorsOkLabA.size() / 4, (float*)gradient.m_vColorsOkLabA.data());
     glUniform1i(borderShader.gradientLength, gradient.m_vColorsOkLabA.size() / 4);
     glUniform1f(borderShader.angle, (int)(gradient.m_fAngle / (M_PI / 180.0)) % 360 * (M_PI / 180.0));
     glUniform1f(borderShader.alpha, alpha);


### PR DESCRIPTION
Same fix as https://github.com/hyprwm/Hyprland/commit/c2d14a2013b871b5d0b50c39ee781882d68e8b03.
Copied that unfortunately when adding the gradients.

Potentially cause of #741