### PR TITLE
clang-tidy: fix some errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,12 @@
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*\.hpp'
-FormatStyle: file
+FormatStyle: 'file'
 Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-forward-declararion-namespace,
-  -bugprone-forward-declararion-namespace,
+  -bugprone-forward-declaration-namespace,
+  -bugprone-forward-declaration-namespace,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,


### PR DESCRIPTION
I did c+p .clang-tidy from Hyprland and didn't check it for any errors, lol.