### PR TITLE
core: correct $LAYOUT replacement

### DIFF
--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -134,25 +134,6 @@ void CSeatManager::registerCursorShape(SP<CCWpCursorShapeManagerV1> shape) {
     m_pCursorShape = makeUnique<CCursorShape>(shape);
 }
 
-std::string CSeatManager::getActiveKbLayoutName() {
-    if (!m_pXKBState || !m_pXKBKeymap)
-        return "error";
-
-    const auto LAYOUTSNUM = xkb_keymap_num_layouts(m_pXKBKeymap);
-
-    for (uint32_t i = 0; i < LAYOUTSNUM; ++i) {
-        if (xkb_state_layout_index_is_active(m_pXKBState, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
-            const auto LAYOUTNAME = xkb_keymap_layout_get_name(m_pXKBKeymap, i);
-
-            if (LAYOUTNAME)
-                return std::string{LAYOUTNAME};
-            return "error";
-        }
-    }
-
-    return "none";
-}
-
 bool CSeatManager::registered() {
     return m_pSeat;
 }

--- a/src/core/Seat.hpp
+++ b/src/core/Seat.hpp
@@ -14,7 +14,6 @@ class CSeatManager {
     void               registerSeat(SP<CCWlSeat> seat);
     void               registerCursorShape(SP<CCWpCursorShapeManagerV1> shape);
     bool               registered();
-    std::string        getActiveKbLayoutName();
 
     SP<CCWlKeyboard>   m_pKeeb;
     SP<CCWlPointer>    m_pPointer;

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -65,8 +65,6 @@ class CHyprlock {
     size_t                           getPasswordBufferLen();
     size_t                           getPasswordBufferDisplayLen();
 
-    std::string                      getActiveKeyboardLayout();
-
     SP<CCExtSessionLockManagerV1>    getSessionLockMgr();
     SP<CCExtSessionLockV1>           getSessionLock();
     SP<CCWlCompositor>               getCompositor();

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -100,11 +100,16 @@ static void replaceAllAttempts(std::string& str) {
 }
 
 static void replaceAllLayout(std::string& str) {
+    std::string layoutName = "error";
+    const auto  LAYOUTIDX  = g_pHyprlock->m_uiActiveLayout;
 
-    const auto LAYOUTIDX  = g_pHyprlock->m_uiActiveLayout;
-    const auto LAYOUTNAME = g_pSeatManager->getActiveKbLayoutName();
-    size_t     pos        = 0;
+    if (g_pSeatManager->m_pXKBKeymap) {
+        const auto PNAME = xkb_keymap_layout_get_name(g_pSeatManager->m_pXKBKeymap, LAYOUTIDX);
+        if (PNAME)
+            layoutName = PNAME;
+    }
 
+    size_t pos = 0;
     while ((pos = str.find("$LAYOUT", pos)) != std::string::npos) {
         if (str.substr(pos, 8).ends_with('[') && str.substr(pos).contains(']')) {
             const std::string REPL = str.substr(pos + 8, str.find_first_of(']', pos) - 8 - pos);
@@ -114,12 +119,12 @@ static void replaceAllLayout(std::string& str) {
                 continue;
             }
 
-            const std::string LANG = LANGS[LAYOUTIDX].empty() ? LAYOUTNAME : LANGS[LAYOUTIDX] == "!" ? "" : LANGS[LAYOUTIDX];
+            const std::string LANG = LANGS[LAYOUTIDX].empty() ? layoutName : LANGS[LAYOUTIDX] == "!" ? "" : LANGS[LAYOUTIDX];
             str.replace(pos, 9 + REPL.length(), LANG);
             pos += LANG.length();
         } else {
-            str.replace(pos, 7, LAYOUTNAME);
-            pos += LAYOUTNAME.length();
+            str.replace(pos, 7, layoutName);
+            pos += layoutName.length();
         }
     }
 }


### PR DESCRIPTION
@geovex I saw your code in https://github.com/hyprwm/hyprlock/issues/739

I pulled it and guarded `g_pSeatManager->m_pXKBKeymap` to avoid the crash that motivated #699.
Let me know if the fix still works for you!

Closes #739