### PR TITLE
core: use enqueueUnlock for unlocks via SIGUSR1

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -76,12 +76,12 @@ void CAuth::terminate() {
     }
 }
 
-static void passwordUnlockCallback(std::shared_ptr<CTimer> self, void* data) {
+static void unlockCallback(std::shared_ptr<CTimer> self, void* data) {
     g_pHyprlock->unlock();
 }
 
 void CAuth::enqueueUnlock() {
-    g_pHyprlock->addTimer(std::chrono::milliseconds(0), passwordUnlockCallback, nullptr);
+    g_pHyprlock->addTimer(std::chrono::milliseconds(0), unlockCallback, nullptr);
 }
 
 static void passwordFailCallback(std::shared_ptr<CTimer> self, void* data) {

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -73,7 +73,7 @@ static void registerSignalAction(int sig, void (*handler)(int), int sa_flags = 0
 static void handleUnlockSignal(int sig) {
     if (sig == SIGUSR1) {
         Debug::log(LOG, "Unlocking with a SIGUSR1");
-        g_pHyprlock->releaseSessionLock();
+        g_pAuth->enqueueUnlock();
     }
 }
 


### PR DESCRIPTION
This is a much needed change, because it makes sure the unlock happens within the wayland thread.

I am waiting for some feedback from #741, because it is somewhat related to this issue.