### PR TITLE
renderer: properly treat monitor `desc:` prefix

### DIFF
--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -406,7 +406,7 @@ std::vector<SP<IWidget>>& CRenderer::getOrCreateWidgetsFor(const CSessionLockSur
 
         const auto POUTPUT = surf.m_outputRef.lock();
         for (auto& c : CWIDGETS) {
-            if (!c.monitor.empty() && c.monitor != POUTPUT->stringPort && !POUTPUT->stringDesc.starts_with(c.monitor) && !POUTPUT->stringDesc.starts_with("desc:" + c.monitor))
+            if (!c.monitor.empty() && c.monitor != POUTPUT->stringPort && !POUTPUT->stringDesc.starts_with(c.monitor) && !("desc:" + POUTPUT->stringDesc).starts_with(c.monitor))
                 continue;
 
             // by type


### PR DESCRIPTION
Currently, selecting a monitor by its description using the `desc:` prefix (see wiki [here](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlock/#monitor-selection)) does not work due to a small logic bug. This fixes that.

Turns out there also was an issue for that, closes #737