### PR TITLE
core: add grace option

### DIFF
--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -29,7 +29,7 @@ struct SDMABUFModifier {
 
 class CHyprlock {
   public:
-    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender);
+    CHyprlock(const std::string& wlDisplay, const bool immediate, const bool immediateRender, const long grace);
     ~CHyprlock();
 
     void                             run();


### PR DESCRIPTION
This adds the `--grace` option to specify a grace value that will override the one from config, when running hyprlock. We already have the `--immediate` option, which does the opposite. This can be useful when say you have grace = 0 in the config (I don't like having a grace time on lockscreen), while you want to lock with a grace just for this time.

`--grace` accepts a `long` value, which is valid if `>= 0`, with a default value of `-1`, indicating no override was passed.

I have modified the `immediate` check logic in `core/hyprlock.cpp` to address the same and load the value from config only if a valid `grace` was passed.

Closes #776