### PR TITLE
core: treat touch as click

### DIFF
--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <linux/input-event-codes.h>
 
 CSeatManager::~CSeatManager() {
     if (m_pXKBState)
@@ -76,7 +77,15 @@ void CSeatManager::registerSeat(SP<CCWlSeat> seat) {
                 g_pHyprlock->onClick(button, state == WL_POINTER_BUTTON_STATE_PRESSED, g_pHyprlock->m_vMouseLocation);
             });
         }
-
+        if (caps & WL_SEAT_CAPABILITY_TOUCH) {
+            m_pTouch = makeShared<CCWlTouch>(r->sendGetTouch());
+            m_pTouch->setDown([](CCWlTouch* r, uint32_t serial, uint32_t time, wl_proxy* surface, int32_t id, wl_fixed_t x, wl_fixed_t y) {
+                g_pHyprlock->onClick(BTN_LEFT, true, {wl_fixed_to_double(x), wl_fixed_to_double(y)});
+            });
+            m_pTouch->setUp([](CCWlTouch* r, uint32_t serial, uint32_t time, int32_t id) {
+                g_pHyprlock->onClick(BTN_LEFT, false, {0, 0});
+            });
+        };
         if (caps & WL_SEAT_CAPABILITY_KEYBOARD) {
             m_pKeeb = makeShared<CCWlKeyboard>(r->sendGetKeyboard());
 

--- a/src/core/Seat.hpp
+++ b/src/core/Seat.hpp
@@ -17,6 +17,7 @@ class CSeatManager {
 
     SP<CCWlKeyboard>   m_pKeeb;
     SP<CCWlPointer>    m_pPointer;
+    SP<CCWlTouch>      m_pTouch;
 
     UP<CCursorShape>   m_pCursorShape;
 


### PR DESCRIPTION
This treats touch input events as (left) clicks.

Currently the onClick implementation does not care which (mouse) button is used to click on an element. So it might be acceptable to remove the include and use a fixed value (0 or 272). However, this might lead to problems if onClick ever learns to distinguish between different clicks.

This only works for "real" finger touch inputs, (tablet) pen touches are translated to pointer move events, but the tab event does not seem to reach hyprlock.

Tested on a surface go 1 and a thinkpad x1 yoga gen1 with arch.