### PR TITLE
Add CMake check for libpam using pkg_check_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ pkg_check_modules(
   pangocairo
   libdrm
   gbm
+  pam
   hyprutils>=0.5.0
   sdbus-c++>=2.0.0
   hyprgraphics)


### PR DESCRIPTION
Just a small edit to `CMakeLists.txt`: I added a `pkg_check_modules` entry for `pam.pc` to ensure that the `libpam` dependency is properly detected during the CMake configuration step, similar to how other dependencies like `spng` are handled.
