### PR TITLE
widgets: use thread safe references

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -459,6 +459,8 @@ void CHyprlock::run() {
                 passed.push_back(t);
         }
 
+        timerscpy.clear();
+
         m_sLoopState.timersMutex.lock();
         std::erase_if(m_vTimers, [passed](const auto& timer) { return std::find(passed.begin(), passed.end(), timer) != passed.end(); });
         m_sLoopState.timersMutex.unlock();

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -388,13 +388,13 @@ void CRenderer::renderTextureMix(const CBox& box, const CTexture& tex, const CTe
 }
 
 template <class Widget>
-static void createWidget(std::vector<SP<IWidget>>& widgets) {
-    const auto W = makeShared<Widget>();
+static void createWidget(std::vector<std::shared_ptr<IWidget>>& widgets) {
+    const auto W = std::make_shared<Widget>();
     W->registerSelf(W);
     widgets.emplace_back(W);
 }
 
-std::vector<SP<IWidget>>& CRenderer::getOrCreateWidgetsFor(const CSessionLockSurface& surf) {
+std::vector<std::shared_ptr<IWidget>>& CRenderer::getOrCreateWidgetsFor(const CSessionLockSurface& surf) {
     RASSERT(surf.m_outputID != OUTPUT_INVALID, "Invalid output ID!");
 
     if (!widgets.contains(surf.m_outputID)) {

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -12,7 +12,7 @@
 #include "widgets/IWidget.hpp"
 #include "Framebuffer.hpp"
 
-typedef std::unordered_map<OUTPUTID, std::vector<SP<IWidget>>> widgetMap_t;
+typedef std::unordered_map<OUTPUTID, std::vector<std::shared_ptr<IWidget>>> widgetMap_t;
 
 class CRenderer {
   public:
@@ -37,18 +37,18 @@ class CRenderer {
     void renderTextureMix(const CBox& box, const CTexture& tex, const CTexture& tex2, float a = 1.0, float mixFactor = 0.0, int rounding = 0, std::optional<eTransform> tr = {});
     void blurFB(const CFramebuffer& outfb, SBlurParams params);
 
-    UP<CAsyncResourceGatherer>            asyncResourceGatherer;
-    std::chrono::system_clock::time_point firstFullFrameTime;
+    UP<CAsyncResourceGatherer>             asyncResourceGatherer;
+    std::chrono::system_clock::time_point  firstFullFrameTime;
 
-    void                                  pushFb(GLint fb);
-    void                                  popFb();
+    void                                   pushFb(GLint fb);
+    void                                   popFb();
 
-    void                                  removeWidgetsFor(OUTPUTID id);
-    void                                  reconfigureWidgetsFor(OUTPUTID id);
+    void                                   removeWidgetsFor(OUTPUTID id);
+    void                                   reconfigureWidgetsFor(OUTPUTID id);
 
-    void                                  startFadeIn();
-    void                                  startFadeOut(bool unlock = false, bool immediate = true);
-    std::vector<SP<IWidget>>&             getOrCreateWidgetsFor(const CSessionLockSurface& surf);
+    void                                   startFadeIn();
+    void                                   startFadeOut(bool unlock = false, bool immediate = true);
+    std::vector<std::shared_ptr<IWidget>>& getOrCreateWidgetsFor(const CSessionLockSurface& surf);
 
   private:
     widgetMap_t        widgets;

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -13,7 +13,7 @@ CBackground::~CBackground() {
     reset();
 }
 
-void CBackground::registerSelf(const SP<CBackground>& self) {
+void CBackground::registerSelf(const std::shared_ptr<CBackground>& self) {
     m_self = self;
 }
 
@@ -92,19 +92,19 @@ void CBackground::renderRect(CHyprColor color) {
     g_pRenderer->renderRect(monbox, color, 0);
 }
 
-static void onReloadTimer(WP<CBackground> ref) {
+static void onReloadTimer(std::weak_ptr<CBackground> ref) {
     if (auto PBG = ref.lock(); PBG) {
         PBG->onReloadTimerUpdate();
         PBG->plantReloadTimer();
     }
 }
 
-static void onCrossFadeTimer(WP<CBackground> ref) {
+static void onCrossFadeTimer(std::weak_ptr<CBackground> ref) {
     if (auto PBG = ref.lock(); PBG)
         PBG->onCrossFadeTimerUpdate();
 }
 
-static void onAssetCallback(WP<CBackground> ref) {
+static void onAssetCallback(std::weak_ptr<CBackground> ref) {
     if (auto PBG = ref.lock(); PBG)
         PBG->startCrossFadeOrUpdateRender();
 }

--- a/src/renderer/widgets/Background.hpp
+++ b/src/renderer/widgets/Background.hpp
@@ -27,7 +27,7 @@ class CBackground : public IWidget {
     CBackground() = default;
     ~CBackground();
 
-    void         registerSelf(const SP<CBackground>& self);
+    void         registerSelf(const std::shared_ptr<CBackground>& self);
 
     virtual void configure(const std::unordered_map<std::string, std::any>& props, const SP<COutput>& pOutput);
     virtual bool draw(const SRenderData& data);
@@ -42,7 +42,7 @@ class CBackground : public IWidget {
     void         startCrossFadeOrUpdateRender();
 
   private:
-    WP<CBackground> m_self;
+    std::weak_ptr<CBackground> m_self;
 
     // if needed
     CFramebuffer                            blurredFB;

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -12,18 +12,18 @@ CImage::~CImage() {
     reset();
 }
 
-void CImage::registerSelf(const SP<CImage>& self) {
+void CImage::registerSelf(const std::shared_ptr<CImage>& self) {
     m_self = self;
 }
 
-static void onTimer(WP<CImage> ref) {
+static void onTimer(std::weak_ptr<CImage> ref) {
     if (auto PIMAGE = ref.lock(); PIMAGE) {
         PIMAGE->onTimerUpdate();
         PIMAGE->plantTimer();
     }
 }
 
-static void onAssetCallback(WP<CImage> ref) {
+static void onAssetCallback(std::weak_ptr<CImage> ref) {
     if (auto PIMAGE = ref.lock(); PIMAGE)
         PIMAGE->renderUpdate();
 }

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -20,7 +20,7 @@ class CImage : public IWidget {
     CImage() = default;
     ~CImage();
 
-    void         registerSelf(const SP<CImage>& self);
+    void         registerSelf(const std::shared_ptr<CImage>& self);
 
     virtual void configure(const std::unordered_map<std::string, std::any>& props, const SP<COutput>& pOutput);
     virtual bool draw(const SRenderData& data);
@@ -35,7 +35,7 @@ class CImage : public IWidget {
     void         plantTimer();
 
   private:
-    WP<CImage>                              m_self;
+    std::weak_ptr<CImage>                   m_self;
 
     CFramebuffer                            imageFB;
 

--- a/src/renderer/widgets/Label.cpp
+++ b/src/renderer/widgets/Label.cpp
@@ -12,11 +12,11 @@ CLabel::~CLabel() {
     reset();
 }
 
-void CLabel::registerSelf(const SP<CLabel>& self) {
+void CLabel::registerSelf(const std::shared_ptr<CLabel>& self) {
     m_self = self;
 }
 
-static void onTimer(WP<CLabel> ref) {
+static void onTimer(std::weak_ptr<CLabel> ref) {
     if (auto PLABEL = ref.lock(); PLABEL) {
         // update label
         PLABEL->onTimerUpdate();
@@ -25,7 +25,7 @@ static void onTimer(WP<CLabel> ref) {
     }
 }
 
-static void onAssetCallback(WP<CLabel> ref) {
+static void onAssetCallback(std::weak_ptr<CLabel> ref) {
     if (auto PLABEL = ref.lock(); PLABEL)
         PLABEL->renderUpdate();
 }
@@ -115,13 +115,13 @@ void CLabel::configure(const std::unordered_map<std::string, std::any>& props, c
 }
 
 void CLabel::reset() {
+    if (g_pHyprlock->m_bTerminate)
+        return;
+
     if (labelTimer) {
         labelTimer->cancel();
         labelTimer.reset();
     }
-
-    if (g_pHyprlock->m_bTerminate)
-        return;
 
     if (asset)
         g_pRenderer->asyncResourceGatherer->unloadAsset(asset);

--- a/src/renderer/widgets/Label.hpp
+++ b/src/renderer/widgets/Label.hpp
@@ -17,7 +17,7 @@ class CLabel : public IWidget {
     CLabel() = default;
     ~CLabel();
 
-    void         registerSelf(const SP<CLabel>& self);
+    void         registerSelf(const std::shared_ptr<CLabel>& self);
 
     virtual void configure(const std::unordered_map<std::string, std::any>& prop, const SP<COutput>& pOutput);
     virtual bool draw(const SRenderData& data);
@@ -32,7 +32,7 @@ class CLabel : public IWidget {
     void         plantTimer();
 
   private:
-    WP<CLabel>                              m_self;
+    std::weak_ptr<CLabel>                   m_self;
 
     std::string                             getUniqueResourceId();
 

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -19,7 +19,7 @@ CPasswordInputField::~CPasswordInputField() {
     reset();
 }
 
-void CPasswordInputField::registerSelf(const SP<CPasswordInputField>& self) {
+void CPasswordInputField::registerSelf(const std::shared_ptr<CPasswordInputField>& self) {
     m_self = self;
 }
 
@@ -119,7 +119,7 @@ void CPasswordInputField::reset() {
     placeholder.currentText.clear();
 }
 
-static void fadeOutCallback(WP<CPasswordInputField> ref) {
+static void fadeOutCallback(std::weak_ptr<CPasswordInputField> ref) {
     if (const auto PP = ref.lock(); PP)
         PP->onFadeOutTimer();
 }

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -19,7 +19,7 @@ class CPasswordInputField : public IWidget {
     CPasswordInputField() = default;
     virtual ~CPasswordInputField();
 
-    void         registerSelf(const SP<CPasswordInputField>& self);
+    void         registerSelf(const std::shared_ptr<CPasswordInputField>& self);
 
     virtual void configure(const std::unordered_map<std::string, std::any>& prop, const SP<COutput>& pOutput);
     virtual bool draw(const SRenderData& data);
@@ -30,33 +30,33 @@ class CPasswordInputField : public IWidget {
     void         onFadeOutTimer();
 
   private:
-    WP<CPasswordInputField> m_self;
+    std::weak_ptr<CPasswordInputField> m_self;
 
-    void                    updateDots();
-    void                    updateFade();
-    void                    updatePlaceholder();
-    void                    updateWidth();
-    void                    updateHiddenInputState();
-    void                    updateInputState();
-    void                    updateColors();
+    void                               updateDots();
+    void                               updateFade();
+    void                               updatePlaceholder();
+    void                               updateWidth();
+    void                               updateHiddenInputState();
+    void                               updateInputState();
+    void                               updateColors();
 
-    bool                    firstRender  = true;
-    bool                    redrawShadow = false;
-    bool                    checkWaiting = false;
-    bool                    displayFail  = false;
+    bool                               firstRender  = true;
+    bool                               redrawShadow = false;
+    bool                               checkWaiting = false;
+    bool                               displayFail  = false;
 
-    size_t                  passwordLength = 0;
+    size_t                             passwordLength = 0;
 
-    PHLANIMVAR<Vector2D>    size;
-    Vector2D                pos;
-    Vector2D                viewport;
-    Vector2D                configPos;
-    Vector2D                configSize;
+    PHLANIMVAR<Vector2D>               size;
+    Vector2D                           pos;
+    Vector2D                           viewport;
+    Vector2D                           configPos;
+    Vector2D                           configSize;
 
-    std::string             halign, valign, configFailText, outputStringPort, configPlaceholderText, fontFamily;
-    uint64_t                configFailTimeoutMs = 2000;
+    std::string                        halign, valign, configFailText, outputStringPort, configPlaceholderText, fontFamily;
+    uint64_t                           configFailTimeoutMs = 2000;
 
-    int                     outThick, rounding;
+    int                                outThick, rounding;
 
     struct {
         PHLANIMVAR<float> currentAmount;

--- a/src/renderer/widgets/Shadowable.cpp
+++ b/src/renderer/widgets/Shadowable.cpp
@@ -2,7 +2,7 @@
 #include "../Renderer.hpp"
 #include <hyprlang.hpp>
 
-void CShadowable::configure(WP<IWidget> widget_, const std::unordered_map<std::string, std::any>& props, const Vector2D& viewport_) {
+void CShadowable::configure(std::weak_ptr<IWidget> widget_, const std::unordered_map<std::string, std::any>& props, const Vector2D& viewport_) {
     m_widget = widget_;
     viewport = viewport_;
 
@@ -15,7 +15,7 @@ void CShadowable::configure(WP<IWidget> widget_, const std::unordered_map<std::s
 void CShadowable::markShadowDirty() {
     const auto WIDGET = m_widget.lock();
 
-    if (!m_widget)
+    if (!WIDGET)
         return;
 
     if (passes == 0)
@@ -38,7 +38,7 @@ void CShadowable::markShadowDirty() {
 }
 
 bool CShadowable::draw(const IWidget::SRenderData& data) {
-    if (!m_widget || passes == 0)
+    if (!m_widget.expired() || passes == 0)
         return true;
 
     if (!shadowFB.isAllocated() || ignoreDraw)

--- a/src/renderer/widgets/Shadowable.hpp
+++ b/src/renderer/widgets/Shadowable.hpp
@@ -13,19 +13,19 @@ class CShadowable {
   public:
     virtual ~CShadowable() = default;
     CShadowable()          = default;
-    void configure(WP<IWidget> widget_, const std::unordered_map<std::string, std::any>& props, const Vector2D& viewport_ /* TODO: make this not the entire viewport */);
+    void configure(std::weak_ptr<IWidget> widget_, const std::unordered_map<std::string, std::any>& props, const Vector2D& viewport_ /* TODO: make this not the entire viewport */);
 
     // instantly re-renders the shadow using the widget's draw() method
     void         markShadowDirty();
     virtual bool draw(const IWidget::SRenderData& data);
 
   private:
-    WP<IWidget> m_widget;
-    int         size   = 10;
-    int         passes = 4;
-    float       boostA = 1.0;
-    CHyprColor  color{0, 0, 0, 1.0};
-    Vector2D    viewport;
+    std::weak_ptr<IWidget> m_widget;
+    int                    size   = 10;
+    int                    passes = 4;
+    float                  boostA = 1.0;
+    CHyprColor             color{0, 0, 0, 1.0};
+    Vector2D               viewport;
 
     // to avoid recursive shadows
     bool         ignoreDraw = false;

--- a/src/renderer/widgets/Shape.cpp
+++ b/src/renderer/widgets/Shape.cpp
@@ -7,7 +7,7 @@
 #include <hyprlang.hpp>
 #include <sys/types.h>
 
-void CShape::registerSelf(const SP<CShape>& self) {
+void CShape::registerSelf(const std::shared_ptr<CShape>& self) {
     m_self = self;
 }
 

--- a/src/renderer/widgets/Shape.hpp
+++ b/src/renderer/widgets/Shape.hpp
@@ -14,7 +14,7 @@ class CShape : public IWidget {
     CShape()          = default;
     virtual ~CShape() = default;
 
-    void         registerSelf(const SP<CShape>& self);
+    void         registerSelf(const std::shared_ptr<CShape>& self);
 
     virtual void configure(const std::unordered_map<std::string, std::any>& prop, const SP<COutput>& pOutput);
     virtual bool draw(const SRenderData& data);
@@ -23,26 +23,26 @@ class CShape : public IWidget {
     virtual void onHover(const Vector2D& pos);
 
   private:
-    WP<CShape>         m_self;
+    std::weak_ptr<CShape> m_self;
 
-    CFramebuffer       shapeFB;
+    CFramebuffer          shapeFB;
 
-    int                rounding;
-    double             border;
-    double             angle;
-    CHyprColor         color;
-    CGradientValueData borderGrad;
-    Vector2D           size;
-    Vector2D           pos;
-    CBox               shapeBox;
-    CBox               borderBox;
-    bool               xray;
+    int                   rounding;
+    double                border;
+    double                angle;
+    CHyprColor            color;
+    CGradientValueData    borderGrad;
+    Vector2D              size;
+    Vector2D              pos;
+    CBox                  shapeBox;
+    CBox                  borderBox;
+    bool                  xray;
 
-    std::string        halign, valign;
+    std::string           halign, valign;
 
-    bool               firstRender = true;
-    std::string        onclickCommand;
+    bool                  firstRender = true;
+    std::string           onclickCommand;
 
-    Vector2D           viewport;
-    CShadowable        shadow;
+    Vector2D              viewport;
+    CShadowable           shadow;
 };


### PR DESCRIPTION
I was able to repro the crash in #785 with a script that suspends as Hyprlock starts up.

<details><summary>test script</summary>

```bash
#!/usr/bin/env bash

test() {
  sudo rtcwake -m mem -s 3 &
  suspend_pid=$!
  sleep 0.5
  ~/desk/hyprlock/build/hyprlock --config ~/.config/hypr/hyprlock/lots-of-label-updates.conf &
  hyprlock_pid=$(pidof hyprlock)

  echo "Hyprlock PID: $hyprlock_pid"

  wait "$suspend_pid"

  sleep 3

  pkill -USR1 hyprlock

  wait "$hyprlock_pid"

  # Exit if hyprlock did not exit cleanly
  if [ $? -ne 0 ]; then
    echo "Hyprlock did not exit cleanly"
    exit 1
  fi
}

while true; do
  test
done
```

</details>

When the issue happens, we have a heap corruption occurring, because some refcount is corrupted. 

<details><summary>Example crash</summary>

```bt
#0  0x000000000049788f in Hyprutils::Memory::CWeakPointer<CLabel>::decrementWeak() ()
#1  0x00000000004b2faa in std::_Function_handler<void (std::shared_ptr<CTimer>, void*), CLabel::plantTimer()::{lambda(auto:1, auto:2)#1}>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) ()
#2  0x0000000000475aab in std::_Sp_counted_ptr_inplace<CTimer, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() ()
#3  0x000000000046e603 in CHyprlock::~CHyprlock() ()
#4  0x000000000047e144 in Hyprutils::Memory::Impl_::impl<CHyprlock>::destroy() ()
#5  0x000000000042bcb1 in Hyprutils::Memory::CUniquePointer<CHyprlock>::~CUniquePointer() ()
#6  0x00007f9748643bf1 in __run_exit_handlers ()
    at /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
#7  0x00007f9748643cb0 in exit () at /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
#8  0x00007f974862a485 in __libc_start_call_main ()
    at /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
#9  0x00007f974862a539 in __libc_start_main_impl ()
    at /nix/store/cg9s562sa33k78m63njfn1rw47dp9z0i-glibc-2.40-66/lib/libc.so.6
#10 0x0000000000429835 in _start ()
```

</details>

With https://github.com/hyprwm/hyprlock/commit/9f37c1c8e9923dff65b4b1771694be3be59b1836 I moved all references to hyprutils smart pointer, which fixed a bunch of crashes related to monitor changes.
Some references to widgets are passed to the AsyncResourceGatherer.
I thought it would be fine, since we move all the stuff to the other thread and never access or construct a new SP/WP within another thread.

However, there is a case where we have a wrong refcount when sleep happens at a specific point in time. Moving all widget pointers to STL smart pointers seems to fix the issue. (Havn't had a crash with that.)

Closes https://github.com/hyprwm/hyprlock/issues/785

Could potentially also fix some other open issues.