### PR TITLE
seat: restore cursor shape to default

### DIFF
--- a/src/core/CursorShape.cpp
+++ b/src/core/CursorShape.cpp
@@ -15,6 +15,7 @@ void CCursorShape::setShape(const wpCursorShapeDeviceV1Shape shape) {
     if (!dev)
         dev = makeShared<CCWpCursorShapeDeviceV1>(mgr->sendGetPointer(g_pSeatManager->m_pPointer->resource()));
 
+    shapeChanged = true;
     dev->sendSetShape(lastCursorSerial, shape);
 }
 

--- a/src/core/CursorShape.hpp
+++ b/src/core/CursorShape.hpp
@@ -11,6 +11,7 @@ class CCursorShape {
     void     hideCursor();
 
     uint32_t lastCursorSerial = 0;
+    bool     shapeChanged     = false;
 
   private:
     SP<CCWpCursorShapeManagerV1> mgr = nullptr;

--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -8,6 +8,9 @@
 #include <linux/input-event-codes.h>
 
 CSeatManager::~CSeatManager() {
+    if (m_pCursorShape && m_pCursorShape->shapeChanged)
+        m_pCursorShape->setShape(wpCursorShapeDeviceV1Shape::WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT);
+
     if (m_pXKBState)
         xkb_state_unref(m_pXKBState);
     if (m_pXKBKeymap)


### PR DESCRIPTION
@gulafaran pointed out that we should probably restore the cursor in hyprlock.

~This does that. It restores it to the default one.
I needed to make sure it isn't possible that hyprlock sets the pointer after that restore and figured we should probably refuse to act on user input as soon as we started fade out.~

I didn't understand the apis properly. We only wanted to set the cursor shape back to default. Became a trivial change.