### PR TITLE
Add ctrl+a as binding to clear password

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -664,7 +664,7 @@ void CHyprlock::onKey(uint32_t key, bool down) {
 void CHyprlock::handleKeySym(xkb_keysym_t sym, bool composed) {
     const auto SYM = sym;
 
-    if (SYM == XKB_KEY_Escape || (m_bCtrl && (SYM == XKB_KEY_u || SYM == XKB_KEY_BackSpace))) {
+    if (SYM == XKB_KEY_Escape || (m_bCtrl && (SYM == XKB_KEY_u || SYM == XKB_KEY_BackSpace || SYM == XKB_KEY_a))) {
         Debug::log(LOG, "Clearing password buffer");
 
         m_sPasswordState.passBuffer = "";


### PR DESCRIPTION
This PR implements a key bind to clear the password field when `ctrl + a` is pressed.

I found it annoying, then saw [this thread](https://github.com/hyprwm/hyprlock/issues/821) that recommended this approach and decided to contribute.

While it is not ideal, I think it is a better standard result to clear the input rather than type `a` when pressing `ctrl + a`.

I built and tested it locally and it works as expected.

Let me know if I need to add anything else, I'm happy to contribute.