### PR TITLE
Add configuration option for maximum number of fingerprint retries

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -22,6 +22,7 @@ general {
 #         ready_message = Scan fingerprint to unlock
 #         present_message = Scanning...
 #         retry_delay = 250 # in milliseconds
+#         max_retries = 3 # Set to 0 for unlimited retries
 #     }
 # }
 

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -141,6 +141,7 @@ bool CFingerprint::createDeviceProxy() {
 
 void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
     Debug::log(LOG, "fprint: handling status {}", result);
+    static const auto FINGERPRINTMAXRETRIES = g_pConfigManager->getValue<Hyprlang::INT>("auth:fingerprint:max_retries");
     auto matchResult   = s_mapStringToTestType[result];
     bool authenticated = false;
     bool retry         = false;
@@ -153,7 +154,7 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
         case MATCH_INVALID: Debug::log(WARN, "fprint: unknown status: {}", result); break;
         case MATCH_NO_MATCH:
             stopVerify();
-            if (m_sDBUSState.retries >= 3) {
+            if (m_sDBUSState.retries >= *FINGERPRINTMAXRETRIES && *FINGERPRINTMAXRETRIES > 0) {
                 m_sFailureReason = "Fingerprint auth disabled (too many failed attempts)";
             } else {
                 done                         = false;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -226,6 +226,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
     m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
+    m_config.addConfigValue("auth:fingerprint:max_retries", Hyprlang::INT{3});
 
     m_config.addConfigValue("animations:enabled", Hyprlang::INT{1});
 


### PR DESCRIPTION
Satisfies #792 

Adds a new configuration option `auth:fingerprint:max_retries` with a default of 3, replacing the existing hard-coded value of 3 fingerprint retires.