### PR TITLE
Make detection of PAM library more portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,25 @@ pkg_check_modules(
   pangocairo
   libdrm
   gbm
-  pam
   hyprutils>=0.8.0
   sdbus-c++>=2.0.0
   hyprgraphics)
+find_library(PAM_FOUND pam)
+if(PAM_FOUND)
+  message(STATUS "Found pam")
+  set(PAM_LIB ${PAM_FOUND})
+else()
+  pkg_check_modules(PAM IMPORTED_TARGET pam)
+  if(PAM_FOUND)
+    set(PAM_LIB PkgConfig::PAM)
+  else()
+    message(FATAL_ERROR "The required library libpam was not found.")
+  endif()
+endif()
 
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 add_executable(hyprlock ${SRCFILES})
-target_link_libraries(hyprlock PRIVATE pam rt Threads::Threads PkgConfig::deps
+target_link_libraries(hyprlock PRIVATE ${PAM_LIB} rt Threads::Threads PkgConfig::deps
                                        OpenGL::EGL OpenGL::GLES3)
 
 # protocols


### PR DESCRIPTION
A check for PAM library was added by https://github.com/hyprwm/hyprlock/pull/795. FreeBSD's base system has PAM implementation based on [OpenPAM](http://www.openpam.org/) and it does not provide `pam.pc` file. So `pkg_check_modules()` fails to detect PAM library.

This PR proposes a small change to how PAM library is detected by cmake. First, cmake tries to find it using `find_library()`. FreeBSD's `libpam` is in standard search paths so cmake can find it. If otherwise, cmake falls back to `pkg_check_modules()` so any system providing `pam.pc` can be supported.