### PR TITLE
core: monitor replug workaround for nvidia

### DIFF
--- a/src/core/Egl.cpp
+++ b/src/core/Egl.cpp
@@ -38,8 +38,9 @@ CEGL::CEGL(wl_display* display) {
     if (eglCreatePlatformWindowSurfaceEXT == nullptr)
         throw std::runtime_error("Failed to get eglCreatePlatformWindowSurfaceEXT");
 
-    eglDisplay     = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, display, nullptr);
-    EGLint matched = 0;
+    const char* vendorString = nullptr;
+    eglDisplay               = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, display, nullptr);
+    EGLint matched           = 0;
     if (eglDisplay == EGL_NO_DISPLAY) {
         Debug::log(CRIT, "Failed to create EGL display");
         goto error;
@@ -64,6 +65,9 @@ CEGL::CEGL(wl_display* display) {
         Debug::log(CRIT, "Failed to create EGL context");
         goto error;
     }
+
+    vendorString = eglQueryString(eglDisplay, EGL_VENDOR);
+    m_isNvidia   = (vendorString) ? std::string{vendorString}.contains("NVIDIA") : false;
 
     return;
 

--- a/src/core/Egl.hpp
+++ b/src/core/Egl.hpp
@@ -17,6 +17,8 @@ class CEGL {
     PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC eglCreatePlatformWindowSurfaceEXT;
 
     void                                     makeCurrent(EGLSurface surf);
+
+    bool                                     m_isNvidia = false;
 };
 
 inline UP<CEGL> g_pEGL;


### PR DESCRIPTION
So I have been investigating #793 (Which has a confusing title, but I think all reports are caused by monitor re-plugging). Edit: wrong issue. I wanted to link this one: #695. They might be the same though. I think both probably have nothing to do with suspend per se.

I was able to reproduce the issue on this system:
```
Hyprland 0.50.0 built from branch main at commit 2859f1b795e1e772e9fc2132708ae03cd23ca39b  (keybinds: use the triggering keyboard for repeat timings (11309)).
Date: Tue Aug 5 15:54:55 2025
Tag: v0.50.0-68-g2859f1b7, commits: 6347
built against:
 aquamarine 0.9.2
 hyprlang 0.6.3
 hyprutils 0.8.2
 hyprcursor 0.1.13
 hyprgraphics 0.1.5


no flags were set


System Information:
System name: Linux
Node name: desktop
Release: 6.15.8-200.fc42.x86_64
Version: #1 SMP PREEMPT_DYNAMIC Thu Jul 24 13:26:52 UTC 2025


GPU information: 
0a:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP102 [GeForce GTX 1080 Ti] [10de:1b06] (rev a1) (prog-if 00 [VGA controller])
NVRM version: NVIDIA UNIX x86_64 Kernel Module  575.64.05  Fri Jul 18 16:01:21 UTC 2025


os-release: NAME="Fedora Linux"
VERSION="42 (Workstation Edition)"
RELEASE_TYPE=stable
ID=fedora
VERSION_ID=42
VERSION_CODENAME=""
PLATFORM_ID="platform:f42"
PRETTY_NAME="Fedora Linux 42 (Workstation Edition)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:42"
DEFAULT_HOSTNAME="fedora"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f42/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=42
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=42
SUPPORT_END=2026-05-13
VARIANT="Workstation Edition"
VARIANT_ID=workstation


plugins:

Explicit sync: supported
GL ver: 3.2
Backend: drm

Monitor info:
	Panel DP-2: 3840x2160, DP-2 Samsung Electric Company U28E850 HTPK600065 -> backend drm
		explicit ✔️
		edid:
			hdr ❌
			chroma ✔️
			bt2020 ❌
		vrr capable ❌
		non-desktop ❌
		

```

I can get back to it tomorrow and hopefully I will find a fix for the issue.

Somehow we are failing to create and render to a new session lock surface after the previous one has been destroyed.

This issue does not occur with swaylock and is reproducible in hyprland and sway.