### PR TITLE
core: remove dmabuf listeners after we are done with Screencopy

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -238,6 +238,18 @@ void CHyprlock::addDmabufListener() {
     });
 }
 
+void CHyprlock::removeDmabufListener() {
+    if (dma.linuxDmabufFeedback) {
+        dma.linuxDmabufFeedback->sendDestroy();
+        dma.linuxDmabufFeedback.reset();
+    }
+
+    if (dma.linuxDmabuf) {
+        dma.linuxDmabuf->sendDestroy();
+        dma.linuxDmabuf.reset();
+    }
+}
+
 void CHyprlock::run() {
     m_sWaylandState.registry = makeShared<CCWlRegistry>((wl_proxy*)wl_display_get_registry(m_sWaylandState.display));
     m_sWaylandState.registry->setGlobal([this](CCWlRegistry* r, uint32_t name, const char* interface, uint32_t version) {

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -118,6 +118,9 @@ class CHyprlock {
     } dma;
     gbm_device* createGBMDevice(drmDevice* dev);
 
+    void        addDmabufListener();
+    void        removeDmabufListener();
+
   private:
     struct {
         wl_display*                      display     = nullptr;
@@ -129,8 +132,6 @@ class CHyprlock {
         SP<CCZwlrScreencopyManagerV1>    screencopy  = nullptr;
         SP<CCWlShm>                      shm         = nullptr;
     } m_sWaylandState;
-
-    void addDmabufListener();
 
     struct {
         SP<CCExtSessionLockV1> lock = nullptr;

--- a/src/renderer/Screencopy.cpp
+++ b/src/renderer/Screencopy.cpp
@@ -80,9 +80,19 @@ CSCDMAFrame::CSCDMAFrame(SP<CCZwlrScreencopyFrameV1> sc) : m_sc(sc) {
     if (!glEGLImageTargetTexture2DOES) {
         glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
         if (!glEGLImageTargetTexture2DOES) {
-            Debug::log(ERR, "No glEGLImageTargetTexture2DOES??");
+            Debug::log(ERR, "[sc] No glEGLImageTargetTexture2DOES??");
             return;
         }
+    }
+
+    if (!g_pHyprlock->dma.linuxDmabuf) {
+        Debug::log(ERR, "[sc] No DMABUF support?");
+        return;
+    }
+
+    if (!g_pHyprlock->dma.gbmDevice) {
+        Debug::log(ERR, "[sc] No gbmDevice for DMABUF was created?");
+        return;
     }
 
     if (!eglQueryDmaBufModifiersEXT)


### PR DESCRIPTION
Maybe fixes https://github.com/hyprwm/hyprlock/issues/856, but we probably want this anyways.