### PR TITLE
output: send wl_output release event

### DIFF
--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -2,6 +2,11 @@
 #include "../helpers/Log.hpp"
 #include "hyprlock.hpp"
 
+COutput::~COutput() {
+    if (m_wlOutput)
+        m_wlOutput->sendRelease();
+}
+
 void COutput::create(WP<COutput> pSelf, SP<CCWlOutput> pWlOutput, uint32_t _name) {
     m_ID       = _name;
     m_wlOutput = pWlOutput;

--- a/src/core/Output.hpp
+++ b/src/core/Output.hpp
@@ -6,8 +6,8 @@
 
 class COutput {
   public:
-    COutput()  = default;
-    ~COutput() = default;
+    COutput() = default;
+    ~COutput();
 
     void                    create(WP<COutput> pSelf, SP<CCWlOutput> pWlOutput, uint32_t name);
 


### PR DESCRIPTION
This has the potential to fix some dynamic monitor issues.

I didn't try this, but in my mind it has the potential the monitor re-plugging issues on nvidia+.
Should be the correct thing to do anyways.