### PR TITLE
lock-surface: remove redundant sendDestroy calls

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -15,12 +15,6 @@ CSessionLockSurface::~CSessionLockSurface() {
 
     if (eglWindow)
         wl_egl_window_destroy(eglWindow);
-
-    if (lockSurface)
-        lockSurface->sendDestroy();
-
-    if (surface)
-        surface->sendDestroy();
 }
 
 CSessionLockSurface::CSessionLockSurface(const SP<COutput>& pOutput) : m_outputRef(pOutput), m_outputID(pOutput->m_ID) {


### PR DESCRIPTION
They are already part of the generated protocol code.

Generated dtor for wl lock surface for example:
```cpp
CCExtSessionLockSurfaceV1::~CCExtSessionLockSurfaceV1() {
    if (!destroyed)
        sendDestroy();
}
```