### PR TITLE
core: discard monitor screenshot when it's removed

### DIFF
--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -7,6 +7,7 @@
 #include "../../helpers/MiscFunctions.hpp"
 #include "../../core/AnimationManager.hpp"
 #include "../../config/ConfigManager.hpp"
+#include "src/renderer/AsyncResourceGatherer.hpp"
 #include <chrono>
 #include <hyprlang.hpp>
 #include <filesystem>
@@ -88,6 +89,9 @@ void CBackground::reset() {
         reloadTimer->cancel();
         reloadTimer.reset();
     }
+
+    if (g_pAsyncResourceGatherer && scAsset)
+        g_pAsyncResourceGatherer->unloadAsset(scAsset);
 
     blurredFB->destroyBuffer();
     pendingBlurredFB->destroyBuffer();


### PR DESCRIPTION
I am sort of tempted to just merge this because I feel like this is what causes most of the monitor issues that are currently floating around. 
But I am not actually sure and it does make the screenshots not reusable after a monitor disconnect like mentioned below.
So I am hoping to get some testing on this PR. If it fixes it we can do a proper fix and try to preserve the screenshot frames.

**Description**:

Succeeds the nvidia workaround, which didn't work as intended. What actually fixed it is discarding the screenshot frame I think.

This change will be made obsolete when migrating to the new gatherer from hyprgraphics. Migrating to it will make us revision screenshot frame management anyways.

It does introduce a cosmetic problem however:
When a monitor gets disconnected, its screenshot can't be used anymore. I hope to fix this by rendering it into a framebuffer.
