### PR TITLE
renderer: fix nvidia workaround

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -316,6 +316,7 @@ void CHyprlock::run() {
             g_pRenderer.reset();
             g_pEGL      = makeUnique<CEGL>(m_sWaylandState.display);
             g_pRenderer = makeUnique<CRenderer>();
+            g_pRenderer->warpOpacity(1.0);
         }
     });
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -617,3 +617,7 @@ void CRenderer::startFadeOut(bool unlock) {
     if (unlock)
         opacity->setCallbackOnEnd([](auto) { g_pHyprlock->releaseSessionLock(); }, true);
 }
+
+void CRenderer::warpOpacity(float newOpacity) {
+    opacity->setValueAndWarp(newOpacity);
+}

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -47,6 +47,7 @@ class CRenderer {
 
     void                                  startFadeIn();
     void                                  startFadeOut(bool unlock = false);
+    void                                  warpOpacity(float warpOpacity);
     std::vector<ASP<IWidget>>&            getOrCreateWidgetsFor(const CSessionLockSurface& surf);
 
   private:


### PR DESCRIPTION
I set the opacity manually in my original workaround and then removed it without thinking.
This makes the workaround function as intended.

See https://github.com/hyprwm/hyprlock/pull/845