### PR TITLE
core: nvidia workaround destroy renderer before EGL

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -312,8 +312,8 @@ void CHyprlock::run() {
         if (g_pEGL->m_isNvidia && m_vOutputs.empty()) {
             Debug::log(LOG, "NVIDIA Workaround: destroying rendering context to avoid crash on reconnect!");
 
-            g_pEGL.reset();
             g_pRenderer.reset();
+            g_pEGL.reset();
             g_pEGL      = makeUnique<CEGL>(m_sWaylandState.display);
             g_pRenderer = makeUnique<CRenderer>();
             g_pRenderer->warpOpacity(1.0);


### PR DESCRIPTION
Fix this:

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f4d8a6f2410 in ?? ()
[Current thread is 1 (Thread 0x7f4d9131bd00 (LWP 6530))]
(gdb) bt
#0  0x00007f4d8a6f2410 in ?? ()
#1  0x00005572d6037393 in CShader::destroy (this=0x5572eb0915c0) at /usr/src/debug/hyprlock-git/hyprlock/src/renderer/Shader.cpp:20
#2  CShader::~CShader (this=0x5572eb0915c0) at /usr/src/debug/hyprlock-git/hyprlock/src/renderer/Shader.cpp:16
#3  0x00005572d60091c9 in CRenderer::~CRenderer (this=0x5572eb090ef0) at /usr/src/debug/hyprlock-git/hyprlock/src/core/../renderer/Renderer.hpp:17
#4  std::default_delete<CRenderer>::operator() (this=0x5572eb1607e1, __ptr=0x5572eb090ef0) at /usr/include/c++/15.2.1/bits/unique_ptr.h:93
#5  Hyprutils::Memory::Impl_::impl<CRenderer>::_destroy (this=0x5572eb1607c0) at /usr/include/hyprutils/memory/ImplBase.hpp:60
#6  Hyprutils::Memory::Impl_::impl<CRenderer>::destroy (this=0x5572eb1607c0) at /usr/include/hyprutils/memory/ImplBase.hpp:94
#7  0x00005572d5ff1a71 in Hyprutils::Memory::CUniquePointer<CRenderer>::destroyImpl (this=0x5572d60b7e08 <g_pRenderer>) at /usr/include/hyprutils/memory/UniquePtr.hpp:125
#8  Hyprutils::Memory::CUniquePointer<CRenderer>::decrement (this=0x5572d60b7e08 <g_pRenderer>) at /usr/include/hyprutils/memory/UniquePtr.hpp:111
#9  Hyprutils::Memory::CUniquePointer<CRenderer>::~CUniquePointer (this=0x5572d60b7e08 <g_pRenderer>) at /usr/include/hyprutils/memory/UniquePtr.hpp:52
#10 0x00007f4d92647431 in ?? () from /usr/lib/libc.so.6
#11 0x00007f4d92647500 in exit () from /usr/lib/libc.so.6
#12 0x00005572d6004ed0 in CHyprlock::run (this=0x5572eaecda40) at /usr/src/debug/hyprlock-git/hyprlock/src/core/hyprlock.cpp:393
#13 0x00005572d5fad67c in main (argc=1, argv=<optimized out>, envp=<optimized out>) at /usr/src/debug/hyprlock-git/hyprlock/src/main.cpp:132
```

Thanks @gulafaran 