### PR TITLE
misc: remove hyprland-protocols from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ You need the following dependencies
 
 - cairo
 - hyprgraphics
-- hyprland-protocols
 - hyprlang
 - hyprutils
 - hyprwayland-scanner


### PR DESCRIPTION
hyprlock doesn't use it currently.

Closes https://github.com/hyprwm/hyprlock/issues/885