### PR TITLE
cmake: add "libpam" as an alias for "pam"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,18 +89,19 @@ pkg_check_modules(
   hyprutils>=0.8.0
   sdbus-c++>=2.0.0
   hyprgraphics>=0.1.6)
-find_library(PAM_FOUND pam)
+find_library(PAM_FOUND NAMES pam libpam)
 if(PAM_FOUND)
-  message(STATUS "Found pam")
   set(PAM_LIB ${PAM_FOUND})
 else()
-  pkg_check_modules(PAM IMPORTED_TARGET pam)
+  pkg_check_modules(PAM IMPORTED_TARGET pam libpam)
   if(PAM_FOUND)
     set(PAM_LIB PkgConfig::PAM)
   else()
     message(FATAL_ERROR "The required library libpam was not found.")
   endif()
 endif()
+
+message(STATUS "Found pam at ${PAM_LIB}")
 
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 add_executable(hyprlock ${SRCFILES})


### PR DESCRIPTION
For building on debian, where it's named "libpam". See #892