### PR TITLE
add capability to use command line or config to set value of grace

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -214,6 +214,7 @@ void CConfigManager::init() {
 
     m_config.addConfigValue("general:text_trim", Hyprlang::INT{1});
     m_config.addConfigValue("general:hide_cursor", Hyprlang::INT{0});
+    m_config.addConfigValue("general:grace", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -45,8 +45,10 @@ CHyprlock::CHyprlock(const std::string& wlDisplay, const bool immediateRender, c
 
     if (graceSeconds > 0)
         m_tGraceEnds = std::chrono::system_clock::now() + std::chrono::seconds(graceSeconds);
-    else
-        m_tGraceEnds = std::chrono::system_clock::from_time_t(0);
+    else {
+        static const auto GRACE = g_pConfigManager->getValue<Hyprlang::INT>("general:grace");
+        m_tGraceEnds            = *GRACE ? std::chrono::system_clock::now() + std::chrono::seconds(*GRACE) : std::chrono::system_clock::from_time_t(0);
+    }
 
     static const auto IMMEDIATERENDER = g_pConfigManager->getValue<Hyprlang::INT>("general:immediate_render");
     m_bImmediateRender                = immediateRender || *IMMEDIATERENDER;


### PR DESCRIPTION
In this pull request, [802](https://github.com/hyprwm/hyprlock/pull/802/commits/6c3ba296c161766acf56923898e1f0ca3802229b), the config file grace option was removed and replaced with a command line only option.
Having the option in a config file allows it to be managed in a code repository, and it allows configuration without having to manipulate preconfigured application managers.

Enable both capabilities with command line taking precedence.