### PR TITLE
background: reload screenshot if reload_cmd specified

### DIFF
--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -72,12 +72,13 @@ void CBackground::configure(const std::unordered_map<std::string, std::any>& pro
     } else if (!path.empty())
         resourceID = g_asyncResourceManager->requestImage(path, m_imageRevision, nullptr);
 
-    if (!isScreenshot && reloadTime > -1) {
+    if (!reloadCommand.empty() && reloadTime > -1) {
         try {
-            modificationTime = std::filesystem::last_write_time(absolutePath(path, ""));
+            if (!isScreenshot)
+                modificationTime = std::filesystem::last_write_time(absolutePath(path, ""));
         } catch (std::exception& e) { Debug::log(ERR, "{}", e.what()); }
 
-        plantReloadTimer(); // No reloads for screenshots.
+        plantReloadTimer(); // No reloads if reloadCommand is empty
     }
 }
 


### PR DESCRIPTION
Allow setting a reload command for background when using screenshot.

One benefit of adding this featue is allowing locking with a screenshot while in the grace period and then switch to a different image.