### PR TITLE
commenting error in example.conf

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -23,7 +23,7 @@ general {
 #         present_message = Scanning...
 #         retry_delay = 250 # in milliseconds
 #     }
-# }
+}
 
 animations {
     enabled = true


### PR DESCRIPTION
removal accidentally commented out "}" to close "general"