### PR TITLE
nix: remove sdbus-cpp overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,11 +62,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764962281,
-        "narHash": "sha256-rGbEMhTTyTzw4iyz45lch5kXseqnqcEpmrHdy+zHsfo=",
+        "lastModified": 1766160771,
+        "narHash": "sha256-roINUGikWRqqgKrD4iotKbGj3ZKJl3hjMz5l/SyKrHw=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "fe686486ac867a1a24f99c753bb40ffed338e4b0",
+        "rev": "5ac060bfcf2f12b3a6381156ebbc13826a05b09f",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765186076,
-        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
+        "lastModified": 1766070988,
+        "narHash": "sha256-G/WVghka6c4bAzMhTwT2vjLccg/awmHkdKSd2JrycLc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
+        "rev": "c6245e83d836d0433170a16eb185cefe0572f8b8",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,7 +14,7 @@
   hyprwayland-scanner,
   pam,
   pango,
-  sdbus-cpp,
+  sdbus-cpp_2,
   systemdLibs,
   wayland,
   wayland-protocols,
@@ -46,7 +46,7 @@ stdenv.mkDerivation {
     hyprutils
     pam
     pango
-    sdbus-cpp
+    sdbus-cpp_2
     systemdLibs
     wayland
     wayland-protocols

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -18,7 +18,6 @@ in {
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
-    inputs.self.overlays.sdbuscpp
     (final: prev: {
       hyprlock = prev.callPackage ./default.nix {
         stdenv = prev.gcc15Stdenv;
@@ -28,17 +27,4 @@ in {
       };
     })
   ];
-
-  sdbuscpp = final: prev: {
-    sdbus-cpp = prev.sdbus-cpp.overrideAttrs (self: super: {
-      version = "2.0.0";
-
-      src = final.fetchFromGitHub {
-        owner = "Kistler-group";
-        repo = "sdbus-cpp";
-        rev = "refs/tags/v${self.version}";
-        hash = "sha256-W8V5FRhV3jtERMFrZ4gf30OpIQLYoj2yYGpnYOmH2+g=";
-      };
-    });
-  };
 }


### PR DESCRIPTION
sdbus-cpp_2 now in nixpkgs, thus I removed the overlay for it