### PR TITLE
input: allow ignoring space in password input

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -214,6 +214,7 @@ void CConfigManager::init() {
 
     m_config.addConfigValue("general:text_trim", Hyprlang::INT{1});
     m_config.addConfigValue("general:hide_cursor", Hyprlang::INT{0});
+    m_config.addConfigValue("general:prevent_space_input", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -613,7 +613,11 @@ void CHyprlock::onKey(uint32_t key, bool down) {
 void CHyprlock::handleKeySym(xkb_keysym_t sym, bool composed) {
     const auto SYM = sym;
 
-    if (SYM == XKB_KEY_Escape || (m_bCtrl && (SYM == XKB_KEY_u || SYM == XKB_KEY_BackSpace || SYM == XKB_KEY_a))) {
+    static const auto PREVENTSPACE = g_pConfigManager->getValue<Hyprlang::INT>("general:prevent_space_input");
+    if (SYM == XKB_KEY_space  && *PREVENTSPACE) {
+      return;
+    }
+    else if (SYM == XKB_KEY_Escape || (m_bCtrl && (SYM == XKB_KEY_u || SYM == XKB_KEY_BackSpace || SYM == XKB_KEY_a))) {
         Debug::log(LOG, "Clearing password buffer");
 
         m_sPasswordState.passBuffer = "";


### PR DESCRIPTION
Adds the boolean config option "prevent_space_input". 
When enabled, it prevents space character from being entered into the input field. 

Need for this also mentioned in https://github.com/hyprwm/hyprlock/issues/803
