### PR TITLE
auth/fingerprint: implement retry logic for device connection and verification

### DIFF
--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -33,6 +33,7 @@ class CFingerprint : public IAuthImplementation {
         bool                                abort     = false;
         bool                                done      = false;
         int                                 retries   = 0;
+        int                                 connect_attempts = 0;
         bool                                sleeping  = false;
         bool                                verifying = false;
     } m_sDBUSState;
@@ -48,6 +49,8 @@ class CFingerprint : public IAuthImplementation {
     bool        createDeviceProxy();
     void        claimDevice();
     void        startVerify(bool isRetry = false);
+    void        handleRetry(const std::string& logMessage, bool isRetry = false);
+    void        retryVerify();
     bool        stopVerify();
     bool        releaseDevice();
 };

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -226,6 +226,8 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
     m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
+    m_config.addConfigValue("auth:fingerprint:init_retries", Hyprlang::INT{5});
+    m_config.addConfigValue("auth:fingerprint:init_retry_delay", Hyprlang::INT{1000});
 
     m_config.addConfigValue("animations:enabled", Hyprlang::INT{1});
 


### PR DESCRIPTION
I noticed that because of my fingerprint scanner drivers (open-fprintd + python-validity) it takes some time for it to initialize after resuming from suspend. and also that hyprlock just doesn't even wait. so I vibecoded (not exactly proud of that, but I don't know c++ yet, sorry) something hoping to fix it. it probably isn't good, but it works on my system.

i know that this should probably be fixed on the driver side, but I find this more useful and broader.

### changes
* **crash fix:** added `try-catch` blocks to prevent crashes when the service isn't ready immediately.
* **retry logic:** if the device is missing on wake, it now retries in a loop instead of failing instantly.
* **config:** added `auth:fingerprint:init_retries` and `auth:fingerprint:init_retry_delay` to control the patience level.
