### PR TITLE
image: pass size to CImage for SVG rendering

### DIFF
--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -64,6 +64,7 @@ void CImage::onTimerUpdate() {
     request.asset     = path;
     request.type      = CAsyncResourceGatherer::eTargetType::TARGET_IMAGE;
     request.callback  = [REF = m_self]() { onAssetCallback(REF); };
+    request.props["size"] = Vector2D{(double)size, (double)size};
 
     g_pAsyncResourceGatherer->requestAsyncAssetPreload(request);
 }


### PR DESCRIPTION
SVG images failed to load with the error "loading svg: invalid size" because hyprlock was not passing the configured size to hyprgraphics' `CImage` constructor.

Unlike raster formats, SVG requires a target render size since it's vector-based. The `CImage` class has a two-argument constructor `CImage(path, size)` for this, but `getCairoSurfaceFromImageFile()` was only using the single-argument constructor, resulting in a 0x0 render target.

This fix passes the image widget's configured `size` parameter through the preload request props to `renderImage()`, which then forwards it to `getCairoSurfaceFromImageFile()`.

## Caveats

**This PR probably should not be merged** for the following reasons:

1. The current `size` option is not well-suited for SVG rendering - SVGs are rendered as square (size × size), ignoring intrinsic aspect ratio
2. A proper fix would require separate `width`/`height` options and querying intrinsic SVG dimensions from librsvg
3. Given the ongoing port to hyprtoolkit (#731), this may be better addressed there with a more complete implementation

Submitting this as a reference for the issue and as a potential stopgap if needed.

Fixes #940