### PR TITLE
Fix fingerprint sensor timeout on long-running lock sessions

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -40,6 +40,8 @@ CFingerprint::CFingerprint() {
     m_sFingerprintReady                  = *FINGERPRINTREADY;
     static const auto FINGERPRINTPRESENT = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:present_message");
     m_sFingerprintPresent                = *FINGERPRINTPRESENT;
+    static const auto INACTIVETIMEOUT    = g_pConfigManager->getValue<Hyprlang::INT>("auth:fingerprint:inactive_timeout");
+    m_sInactiveTimeout = *INACTIVETIMEOUT;
 }
 
 CFingerprint::~CFingerprint() {
@@ -96,8 +98,60 @@ bool CFingerprint::checkWaiting() {
 }
 
 void CFingerprint::terminate() {
+    // Clean up inactivity timer
+    if (m_pInactivityTimer) {
+        m_pInactivityTimer->cancel();
+        m_pInactivityTimer.reset();
+    }
+
     if (!m_sDBUSState.abort)
         releaseDevice();
+}
+
+void CFingerprint::setupInactivityTimer() {
+    // Check if we should process activity
+    if (m_sInactiveTimeout <= 0 || m_sDBUSState.abort || m_sDBUSState.done)
+        return;
+
+    // Cancel existing inactivity timer
+    if (m_pInactivityTimer) {
+        m_pInactivityTimer->cancel();
+        m_pInactivityTimer.reset();
+    }
+
+    // Create new inactivity timer
+    m_pInactivityTimer = g_pHyprlock->addTimer(std::chrono::milliseconds(m_sInactiveTimeout * 1000),
+                                                   [](ASP<CTimer> self, void* data) { ((CFingerprint*)data)->onInactivityTimeout(); }, this);
+}
+
+void CFingerprint::onActivity() {
+    // Resume scanning if paused
+    if (!m_sDBUSState.verifying) {
+        Debug::log(LOG, "fprint: activity detected, resuming verification");
+        startVerify();
+    }
+}
+
+void CFingerprint::onInactivityTimeout() {
+    // Check if we should proceed with timeout
+    if (m_sDBUSState.abort || m_sDBUSState.done || !m_sDBUSState.verifying)
+        return;
+
+    Debug::log(LOG, "fprint: inactivity timeout, pausing verification");
+
+    stopVerify();
+
+    releaseDevice();
+
+    // Clear the device proxy (destructive stop)
+    m_sDBUSState.device.reset();
+
+    // Clear the prompt text to provide user feedback
+    m_sPrompt = "";
+    g_pHyprlock->enqueueForceUpdateTimers();
+
+    // Clear the inactivity timer
+    m_pInactivityTimer.reset();
 }
 
 std::shared_ptr<sdbus::IConnection> CFingerprint::getConnection() {
@@ -235,8 +289,11 @@ void CFingerprint::startVerify(bool isRetry) {
             if (isRetry) {
                 m_sDBUSState.retries++;
                 m_sPrompt = "Could not match fingerprint. Try again.";
-            } else
+            } else {
                 m_sPrompt = m_sFingerprintReady;
+
+                setupInactivityTimer();
+            }
         }
         g_pHyprlock->enqueueForceUpdateTimers();
     });

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -22,6 +22,8 @@ class CFingerprint : public IAuthImplementation {
     virtual std::optional<std::string>  getLastPrompt();
     virtual void                        terminate();
 
+    void                                onActivity();
+
     std::shared_ptr<sdbus::IConnection> getConnection();
 
   private:
@@ -39,9 +41,12 @@ class CFingerprint : public IAuthImplementation {
 
     std::string m_sFingerprintReady;
     std::string m_sFingerprintPresent;
+    int m_sInactiveTimeout;
 
     std::string m_sPrompt{""};
     std::string m_sFailureReason{""};
+
+    ASP<CTimer>                           m_pInactivityTimer;
 
     void        handleVerifyStatus(const std::string& result, const bool done);
 
@@ -50,4 +55,7 @@ class CFingerprint : public IAuthImplementation {
     void        startVerify(bool isRetry = false);
     bool        stopVerify();
     bool        releaseDevice();
+
+    void        onInactivityTimeout();
+    void        setupInactivityTimer();
 };

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -226,6 +226,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
     m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
+    m_config.addConfigValue("auth:fingerprint:inactive_timeout", Hyprlang::INT{30});
 
     m_config.addConfigValue("animations:enabled", Hyprlang::INT{1});
 

--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -34,6 +34,8 @@ void CSeatManager::registerSeat(SP<CCWlSeat> seat) {
             m_pPointer->setMotion([](CCWlPointer* r, uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
                 g_pHyprlock->m_vMouseLocation = {wl_fixed_to_double(surface_x), wl_fixed_to_double(surface_y)};
 
+                g_pHyprlock->onMouseMove(g_pHyprlock->m_vMouseLocation);
+
                 if (!*HIDECURSOR)
                     g_pHyprlock->onHover(g_pHyprlock->m_vMouseLocation);
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -552,6 +552,14 @@ void CHyprlock::repeatKey(xkb_keysym_t sym) {
 }
 
 void CHyprlock::onKey(uint32_t key, bool down) {
+    // Notify fingerprint of activity
+    if (g_pAuth) {
+        auto fpImpl = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
+        if (fpImpl) {
+            ((CFingerprint*)fpImpl.get())->onActivity();
+        }
+    }
+
     if (isUnlocked())
         return;
 
@@ -660,6 +668,14 @@ void CHyprlock::onClick(uint32_t button, bool down, const Vector2D& pos) {
     if (!m_focusedOutput->m_sessionLockSurface)
         return;
 
+    // Notify fingerprint of activity
+    if (g_pAuth) {
+        auto fpImpl = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
+        if (fpImpl) {
+            ((CFingerprint*)fpImpl.get())->onActivity();
+        }
+    }
+
     const auto SCALEDPOS = pos * m_focusedOutput->m_sessionLockSurface->fractionalScale;
     const auto widgets   = g_pRenderer->getOrCreateWidgetsFor(*m_focusedOutput->m_sessionLockSurface);
     for (const auto& widget : widgets) {
@@ -705,6 +721,16 @@ void CHyprlock::onHover(const Vector2D& pos) {
 
     if (outputNeedsRedraw)
         m_focusedOutput->m_sessionLockSurface->render();
+}
+
+void CHyprlock::onMouseMove(const Vector2D& pos) {
+    // Notify fingerprint of activity
+    if (g_pAuth) {
+        auto fpImpl = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
+        if (fpImpl) {
+            ((CFingerprint*)fpImpl.get())->onActivity();
+        }
+    }
 }
 
 bool CHyprlock::acquireSessionLock() {

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -48,6 +48,7 @@ class CHyprlock {
     void                       onKey(uint32_t key, bool down);
     void                       onClick(uint32_t button, bool down, const Vector2D& pos);
     void                       onHover(const Vector2D& pos);
+    void                       onMouseMove(const Vector2D& pos);
     void                       startKeyRepeat(xkb_keysym_t sym);
     void                       repeatKey(xkb_keysym_t sym);
     void                       handleKeySym(xkb_keysym_t sym, bool compose);


### PR DESCRIPTION
## Summary

This PR addresses issue #702 where fingerprint authentication stops working after the session is left locked for approximately 3-5 minutes (for me).

The root cause I identified is that keeping the fingerprint sensor in an active verification state indefinitely causes some device drivers to disconnect or disable the sensor, leading to a no-retry error in Hyprlock's fingerprint handler.

## Changes

The solution introduces an **inactivity timeout mechanism** that automatically pauses fingerprint verification when no user input is detected, then resumes scanning when the user interacts with the lock screen:

1. **New configuration parameter**: `auth:fingerprint:inactive_timeout` 
   - Default value: **30 seconds**
   - When set to `<= 0`, the timeout is disabled (preserving previous behavior)
   - Configurable to suit different hardware and user preferences

2. **Activity tracking**: The fingerprint handler now monitors user input events:
   - Mouse movement
   - Mouse clicks
   - Keyboard input

3. **Verification management**:
   - After the configured timeout period with no activity, fingerprint verification is paused and the Fingerprint Sensor is **released**
   - When user activity is detected, verification automatically resumes and the Fingerprint Sensor is **claimed** again
   - The prompt message is cleared when paused to provide visual feedback to the user

## Implementation Details

**Modified files:**
- `src/auth/Fingerprint.cpp` / `.hpp`: Core timeout logic and activity handling
- `src/config/ConfigManager.cpp`: New configuration parameter
- `src/core/Seat.cpp`: Mouse movement event tracking
- `src/core/hyprlock.cpp` / `.hpp`: New `onMouseMove` handler. Activity event propagation to fingerprint handler

**Key technical choices:**
- Uses a cancellable timer that resets on each activity event
- Non-destructive pause: verification is stopped and device released, but can be resumed
- Prompt clearing provides user feedback when in paused state

## Configuration

Users can add this to their `hyprlock.conf`:

```conf
auth {
    fingerprint {
        enabled = true
        inactive_timeout = 30  # seconds, set to 0 to disable
    }
}
```

## Discussion Points

I chose a **30-second default** as a balance between:
- Keeping the sensor active for quick unlock attempts
- Preventing driver issues on extended lock sessions
- Reducing unnecessary hardware activity

It also means that the timeout is enabled by default. My rational is that I believe:
1. Others currently have the issue so...
2. I don't think it's a good idea to hold the sensor in a "read/verify" state indefinitely in general

Thoughts?

When the Fingerprint verification is paused, I decided to remove the `$FPRINTPROMPT` content to provide a kind of visual feedback to the user. This is based on the observation that `$FPRINTPROMPT` is initially empty when hyprlock start rendering.

Thoughts?

I added the new `onMouseMove()` event handler on `CHyprlock` mostly because I did not have any better idea. I'm really not knowledgeable in Hyprland ecosystem in general and there may be a better solution to detect that the user is AFK. I'm really all ears on the topic and will be happy to implement it another way if pointed in the right direction.

Thoughts?

## Testing

Tested on my system, where I experience the fingerprint disconnection issue (Goodix Fingerprint Sensor 53xc). The timeout mechanism successfully prevents sensor driver disconnections while maintaining a responsive unlock experience.

---

**Fixes #702**

---

