### PR TITLE
Change reload_time to float

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -241,7 +241,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("background", "vibrancy", Hyprlang::FLOAT{0.1686});
     m_config.addSpecialConfigValue("background", "vibrancy_darkness", Hyprlang::FLOAT{0.05});
     m_config.addSpecialConfigValue("background", "zindex", Hyprlang::INT{-1});
-    m_config.addSpecialConfigValue("background", "reload_time", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("background", "reload_time", Hyprlang::FLOAT{-1});
     m_config.addSpecialConfigValue("background", "reload_cmd", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("background", "crossfade_time", Hyprlang::FLOAT{-1.0});
 
@@ -272,7 +272,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("image", "halign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("image", "valign", Hyprlang::STRING{"center"});
     m_config.addSpecialConfigValue("image", "rotate", Hyprlang::FLOAT{0});
-    m_config.addSpecialConfigValue("image", "reload_time", Hyprlang::INT{-1});
+    m_config.addSpecialConfigValue("image", "reload_time", Hyprlang::FLOAT{-1});
     m_config.addSpecialConfigValue("image", "reload_cmd", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("image", "zindex", Hyprlang::INT{0});
     SHADOWABLE("image");

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -40,7 +40,7 @@ void CBackground::configure(const std::unordered_map<std::string, std::any>& pro
         contrast          = std::any_cast<Hyprlang::FLOAT>(props.at("contrast"));
         path              = std::any_cast<Hyprlang::STRING>(props.at("path"));
         reloadCommand     = std::any_cast<Hyprlang::STRING>(props.at("reload_cmd"));
-        reloadTime        = std::any_cast<Hyprlang::INT>(props.at("reload_time"));
+        reloadTime        = std::any_cast<Hyprlang::FLOAT>(props.at("reload_time"));
 
     } catch (const std::bad_any_cast& e) {
         RASSERT(false, "Failed to construct CBackground: {}", e.what()); //
@@ -72,7 +72,7 @@ void CBackground::configure(const std::unordered_map<std::string, std::any>& pro
     } else if (!path.empty())
         resourceID = g_asyncResourceManager->requestImage(path, m_imageRevision, nullptr);
 
-    if (!reloadCommand.empty() && reloadTime > -1) {
+    if (!reloadCommand.empty() && reloadTime > -1.0) {
         try {
             if (!isScreenshot)
                 modificationTime = std::filesystem::last_write_time(absolutePath(path, ""));
@@ -281,10 +281,10 @@ void CBackground::onAssetUpdate(ResourceID id, ASP<CTexture> newAsset) {
 
 void CBackground::plantReloadTimer() {
 
-    if (reloadTime == 0)
+    if (reloadTime == 0.0)
         reloadTimer = g_pHyprlock->addTimer(std::chrono::hours(1), [REF = m_self](auto, auto) { onReloadTimer(REF); }, nullptr, true);
-    else if (reloadTime > 0)
-        reloadTimer = g_pHyprlock->addTimer(std::chrono::seconds(reloadTime), [REF = m_self](auto, auto) { onReloadTimer(REF); }, nullptr, true);
+    else if (reloadTime > 0.0)
+        reloadTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((uint64_t)(reloadTime * 1000.0)), [REF = m_self](auto, auto) { onReloadTimer(REF); }, nullptr, true);
 }
 
 void CBackground::onReloadTimerUpdate() {

--- a/src/renderer/widgets/Background.hpp
+++ b/src/renderer/widgets/Background.hpp
@@ -77,7 +77,7 @@ class CBackground : public IWidget {
     bool                            isScreenshot = false;
     bool                            firstRender  = true;
 
-    int                             reloadTime = -1;
+    float                           reloadTime = -1;
     std::string                     reloadCommand;
     ASP<CTimer>                     reloadTimer;
     std::filesystem::file_time_type modificationTime;

--- a/src/renderer/widgets/Image.cpp
+++ b/src/renderer/widgets/Image.cpp
@@ -69,10 +69,10 @@ void CImage::onTimerUpdate() {
 
 void CImage::plantTimer() {
 
-    if (reloadTime == 0) {
+    if (reloadTime == 0.0) {
         imageTimer = g_pHyprlock->addTimer(std::chrono::hours(1), [REF = m_self](auto, auto) { onTimer(REF); }, nullptr, true);
-    } else if (reloadTime > 0)
-        imageTimer = g_pHyprlock->addTimer(std::chrono::seconds(reloadTime), [REF = m_self](auto, auto) { onTimer(REF); }, nullptr, false);
+    } else if (reloadTime > 0.0)
+        imageTimer = g_pHyprlock->addTimer(std::chrono::milliseconds((uint64_t)(reloadTime * 1000.0)), [REF = m_self](auto, auto) { onTimer(REF); }, nullptr, false);
 }
 
 void CImage::configure(const std::unordered_map<std::string, std::any>& props, const SP<COutput>& pOutput) {
@@ -94,7 +94,7 @@ void CImage::configure(const std::unordered_map<std::string, std::any>& props, c
         angle     = std::any_cast<Hyprlang::FLOAT>(props.at("rotate"));
 
         path           = std::any_cast<Hyprlang::STRING>(props.at("path"));
-        reloadTime     = std::any_cast<Hyprlang::INT>(props.at("reload_time"));
+        reloadTime     = std::any_cast<Hyprlang::FLOAT>(props.at("reload_time"));
         reloadCommand  = std::any_cast<Hyprlang::STRING>(props.at("reload_cmd"));
         onclickCommand = std::any_cast<Hyprlang::STRING>(props.at("onclick"));
     } catch (const std::bad_any_cast& e) {
@@ -106,7 +106,7 @@ void CImage::configure(const std::unordered_map<std::string, std::any>& props, c
     resourceID = g_asyncResourceManager->requestImage(path, m_imageRevision, nullptr);
     angle      = angle * M_PI / 180.0;
 
-    if (reloadTime > -1) {
+    if (reloadTime > -1.0) {
         try {
             modificationTime = std::filesystem::last_write_time(absolutePath(path, ""));
         } catch (std::exception& e) { Debug::log(ERR, "{}", e.what()); }
@@ -126,7 +126,7 @@ void CImage::reset() {
 
     imageFB.destroyBuffer();
 
-    if (asset && reloadTime > -1) // Don't unload asset if it's a static image
+    if (asset && reloadTime > -1.0) // Don't unload asset if it's a static image
         g_asyncResourceManager->unload(asset);
 
     asset             = nullptr;

--- a/src/renderer/widgets/Image.hpp
+++ b/src/renderer/widgets/Image.hpp
@@ -53,7 +53,7 @@ class CImage : public IWidget {
 
     bool                            firstRender = true;
 
-    int                             reloadTime;
+    float                           reloadTime;
     std::string                     reloadCommand;
     std::string                     onclickCommand;
 


### PR DESCRIPTION
Changes reload_time to be a fractional value, so png sequences can be displayed as animations in hyprlock.