### PR TITLE
fix: handle EGL surface creation failure gracefully instead of aborting

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -84,13 +84,21 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
 
     if (!eglWindow) {
         eglWindow = wl_egl_window_create((wl_surface*)surface->resource(), size.x, size.y);
-        RASSERT(eglWindow, "Couldn't create eglWindow");
+        if (!eglWindow) {
+            Debug::log(ERR, "Couldn't create eglWindow (GPU memory pressure?), will retry on next configure");
+            readyForFrame = false;
+            return;
+        }
     } else
         wl_egl_window_resize(eglWindow, size.x, size.y, 0, 0);
 
     if (!eglSurface) {
         eglSurface = g_pEGL->eglCreatePlatformWindowSurfaceEXT(g_pEGL->eglDisplay, g_pEGL->eglConfig, eglWindow, nullptr);
-        RASSERT(eglSurface, "Couldn't create eglSurface");
+        if (!eglSurface) {
+            Debug::log(ERR, "Couldn't create eglSurface (GPU memory pressure?), will retry on next configure");
+            readyForFrame = false;
+            return;
+        }
     }
 
     if (readyForFrame && !(SAMESIZE && SAMESCALE)) {


### PR DESCRIPTION
## Summary

- Replace `RASSERT` (which calls `std::abort()`) with error logging and early return when `wl_egl_window_create` or `eglCreatePlatformWindowSurfaceEXT` fails in `CSessionLockSurface::configure()`
- Sets `readyForFrame = false` so the next configure event retries the allocation
- Allows hyprlock to survive transient GPU memory pressure instead of crashing and leaving the session in a broken lock state

## Problem

When GPU VRAM is exhausted (e.g., a large LLM loaded in VRAM), EGL surface allocation fails and `RASSERT` calls `std::abort()`, producing a SIGABRT crash. This leaves Hyprland displaying the "lockscreen app died" message with no way to recover without restarting the compositor.

See #986 for full crash details, stack traces, and coredumps.

## Test plan

- [ ] Exhaust GPU VRAM (e.g. allocate >90% with another process)
- [ ] Trigger screen lock via hyprlock
- [ ] Verify hyprlock logs the error instead of crashing
- [ ] Free VRAM and verify hyprlock recovers on next configure event
- [ ] Verify normal lock/unlock works without VRAM pressure
