### PR TITLE
lock-surface: improved handling of egl window and surface creation

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -82,20 +82,32 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
 
     surface->sendDamageBuffer(0, 0, 0xFFFF, 0xFFFF);
 
-    if (!eglWindow) {
+    if (eglWindow && eglSurface) {
+        Log::logger->log(Log::INFO, "Resizing existing eglWindow");
+        wl_egl_window_resize(eglWindow, size.x, size.y, 0, 0);
+    } else {
+        if (eglWindow)
+            wl_egl_window_destroy(eglWindow);
+
         eglWindow = wl_egl_window_create((wl_surface*)surface->resource(), size.x, size.y);
         if (!eglWindow) {
-            Debug::log(ERR, "Couldn't create eglWindow (GPU memory pressure?), will retry on next configure");
+            // Only fails when unable to allocate the wl_egl_window structure or size x or y is <= 0.
+            Log::logger->log(Log::CRIT, "Failed to create wayland egl window");
             readyForFrame = false;
             return;
         }
-    } else
-        wl_egl_window_resize(eglWindow, size.x, size.y, 0, 0);
 
-    if (!eglSurface) {
+        if (eglSurface)
+            eglDestroySurface(g_pEGL->eglDisplay, eglSurface);
+
         eglSurface = g_pEGL->eglCreatePlatformWindowSurfaceEXT(g_pEGL->eglDisplay, g_pEGL->eglConfig, eglWindow, nullptr);
-        if (!eglSurface) {
-            Debug::log(ERR, "Couldn't create eglSurface (GPU memory pressure?), will retry on next configure");
+        if (eglSurface == EGL_NO_SURFACE) {
+            EGLint eglError = eglGetError();
+            if (eglError == EGL_BAD_ALLOC)
+                Log::logger->log(Log::CRIT, "Failed to allocate egl window surface (EGL_BAD_ALLOC, GPU memory pressure?)");
+            else
+                Log::logger->log(Log::CRIT, "Failed to create egl window surface");
+
             readyForFrame = false;
             return;
         }

--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -84,13 +84,21 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
 
     if (!eglWindow) {
         eglWindow = wl_egl_window_create((wl_surface*)surface->resource(), size.x, size.y);
-        RASSERT(eglWindow, "Couldn't create eglWindow");
+        if (!eglWindow) {
+            Debug::log(ERR, "Couldn't create eglWindow (GPU memory pressure?), will retry on next configure");
+            readyForFrame = false;
+            return;
+        }
     } else
         wl_egl_window_resize(eglWindow, size.x, size.y, 0, 0);
 
     if (!eglSurface) {
         eglSurface = g_pEGL->eglCreatePlatformWindowSurfaceEXT(g_pEGL->eglDisplay, g_pEGL->eglConfig, eglWindow, nullptr);
-        RASSERT(eglSurface, "Couldn't create eglSurface");
+        if (!eglSurface) {
+            Debug::log(ERR, "Couldn't create eglSurface (GPU memory pressure?), will retry on next configure");
+            readyForFrame = false;
+            return;
+        }
     }
 
     if (readyForFrame && !(SAMESIZE && SAMESCALE)) {


### PR DESCRIPTION
Successor of #987

Thanks @lvnilesh

I revised the logging a bit and also updated the code path for when
configure is called again (e.g. on a scale update).  Just to make sure we only resize and don't associate an existing eglWindow with another eglSurface, which is invalid according to the docs for eglCreateWindowSurface.

I tried to provoke one of those errors, by allocating lots of gpu memory, but I wasn't able to make eglCreateWindowSurface fail. Compositor always froze before that.

From my comment in #987 I expect the following failure scenarios if either creating window or surface fails:

On startup:
1.    We fail to commit a lock surface to an output (there is no retry mechanism)
2.   After a slight delay the "lockscreen app died" image will render on that output. A solid color on other compositors.
3.    The compositor will kick us as the lock screen application, because we failed to commit a lock surface after some amount of time.
4.   hyprlock exits gracefully after receiving the finished event. (Which is better than an abort)

When a new output gets added at runtime (1) and (2) happens. After that nothing will happen. One should still be able to unlock even though there might not be any UI.