### PR TITLE
core: eglReleaseThread when no outputs and egl error logging

### DIFF
--- a/src/core/AnimationManager.cpp
+++ b/src/core/AnimationManager.cpp
@@ -78,7 +78,7 @@ void updateGradientVariable(CAnimatedVariable<CGradientValueData>& av, const flo
 
 void CHyprlockAnimationManager::tick() {
     static const auto ANIMATIONSENABLED = g_pConfigManager->getValue<Hyprlang::INT>("animations:enabled");
-    const auto        CPY = m_vActiveAnimatedVariables;
+    const auto        CPY               = m_vActiveAnimatedVariables;
 
     for (const auto& PAV : CPY) {
         if (!PAV || !PAV->ok())

--- a/src/core/Egl.cpp
+++ b/src/core/Egl.cpp
@@ -85,6 +85,46 @@ CEGL::~CEGL() {
     eglReleaseThread();
 }
 
+static const char* eglErrorToString(EGLint error) {
+    switch (error) {
+        case EGL_SUCCESS: return "EGL_SUCCESS";
+        case EGL_NOT_INITIALIZED: return "EGL_NOT_INITIALIZED";
+        case EGL_BAD_ACCESS: return "EGL_BAD_ACCESS";
+        case EGL_BAD_ALLOC: return "EGL_BAD_ALLOC";
+        case EGL_BAD_ATTRIBUTE: return "EGL_BAD_ATTRIBUTE";
+        case EGL_BAD_CONTEXT: return "EGL_BAD_CONTEXT";
+        case EGL_BAD_CONFIG: return "EGL_BAD_CONFIG";
+        case EGL_BAD_CURRENT_SURFACE: return "EGL_BAD_CURRENT_SURFACE";
+        case EGL_BAD_DISPLAY: return "EGL_BAD_DISPLAY";
+        case EGL_BAD_DEVICE_EXT: return "EGL_BAD_DEVICE_EXT";
+        case EGL_BAD_SURFACE: return "EGL_BAD_SURFACE";
+        case EGL_BAD_MATCH: return "EGL_BAD_MATCH";
+        case EGL_BAD_PARAMETER: return "EGL_BAD_PARAMETER";
+        case EGL_BAD_NATIVE_PIXMAP: return "EGL_BAD_NATIVE_PIXMAP";
+        case EGL_BAD_NATIVE_WINDOW: return "EGL_BAD_NATIVE_WINDOW";
+        case EGL_CONTEXT_LOST: return "EGL_CONTEXT_LOST";
+    }
+    return "Unknown";
+}
+
+EGLSurface CEGL::createPlatformWindowSurfaceEXT(wl_egl_window* eglWindow) {
+    EGLSurface eglSurface = eglCreatePlatformWindowSurfaceEXT(g_pEGL->eglDisplay, g_pEGL->eglConfig, eglWindow, nullptr);
+    if (eglSurface == EGL_NO_SURFACE)
+        Log::logger->log(Log::ERR, "Failed to allocate egl window surface, error: {}", eglErrorToString(eglGetError()));
+
+    return eglSurface;
+}
+
 void CEGL::makeCurrent(EGLSurface surf) {
-    eglMakeCurrent(eglDisplay, surf, surf, eglContext);
+    if (eglMakeCurrent(eglDisplay, surf, surf, eglContext) == EGL_FALSE)
+        Log::logger->log(Log::ERR, "Failed to eglMakeCurrent, error:  {}", eglErrorToString(eglGetError()));
+}
+
+bool CEGL::swapBuffers(EGLSurface surf) {
+    if (eglSwapBuffers(eglDisplay, surf) == EGL_FALSE) {
+        Log::logger->log(Log::ERR, "Failed to eglSwapBuffers, error:  {}", eglErrorToString(eglGetError()));
+        return false;
+    }
+
+    return true;
 }

--- a/src/core/Egl.hpp
+++ b/src/core/Egl.hpp
@@ -2,6 +2,7 @@
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <wayland-egl.h>
 
 #include "../defines.hpp"
 
@@ -10,15 +11,18 @@ class CEGL {
     CEGL(wl_display*);
     ~CEGL();
 
-    EGLDisplay                               eglDisplay;
-    EGLConfig                                eglConfig;
-    EGLContext                               eglContext;
+    EGLDisplay eglDisplay;
+    EGLConfig  eglConfig;
+    EGLContext eglContext;
 
+    EGLSurface createPlatformWindowSurfaceEXT(wl_egl_window* eglWindow);
+    void       makeCurrent(EGLSurface surf);
+    bool       swapBuffers(EGLSurface surf);
+
+    bool       m_isNvidia = false;
+
+  private:
     PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC eglCreatePlatformWindowSurfaceEXT;
-
-    void                                     makeCurrent(EGLSurface surf);
-
-    bool                                     m_isNvidia = false;
 };
 
 inline UP<CEGL> g_pEGL;

--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -100,14 +100,8 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
         if (eglSurface)
             eglDestroySurface(g_pEGL->eglDisplay, eglSurface);
 
-        eglSurface = g_pEGL->eglCreatePlatformWindowSurfaceEXT(g_pEGL->eglDisplay, g_pEGL->eglConfig, eglWindow, nullptr);
+        eglSurface = g_pEGL->createPlatformWindowSurfaceEXT(eglWindow);
         if (eglSurface == EGL_NO_SURFACE) {
-            EGLint eglError = eglGetError();
-            if (eglError == EGL_BAD_ALLOC)
-                Log::logger->log(Log::CRIT, "Failed to allocate egl window surface (EGL_BAD_ALLOC, GPU memory pressure?)");
-            else
-                Log::logger->log(Log::CRIT, "Failed to create egl window surface");
-
             readyForFrame = false;
             return;
         }
@@ -152,7 +146,7 @@ void CSessionLockSurface::render() {
         onCallback();
     });
 
-    if (eglSwapBuffers(g_pEGL->eglDisplay, eglSurface) != EGL_TRUE) {
+    if (!g_pEGL->swapBuffers(eglSurface)) {
         frameCallback.reset();
         needsFrame = true;
         return;

--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -152,7 +152,11 @@ void CSessionLockSurface::render() {
         onCallback();
     });
 
-    eglSwapBuffers(g_pEGL->eglDisplay, eglSurface);
+    if (eglSwapBuffers(g_pEGL->eglDisplay, eglSurface) != EGL_TRUE) {
+        frameCallback.reset();
+        needsFrame = true;
+        return;
+    }
 
     needsFrame = FEEDBACK.needsFrame || g_pAnimationManager->shouldTickForNext();
 }

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -306,6 +306,9 @@ void CHyprlock::run() {
             g_pRenderer->removeWidgetsFor((*outputIt)->m_ID);
             m_vOutputs.erase(outputIt);
         }
+
+        if (m_vOutputs.empty())
+            eglReleaseThread();
     });
 
     wl_display_roundtrip(m_sWaylandState.display);

--- a/src/renderer/AsyncResourceManager.cpp
+++ b/src/renderer/AsyncResourceManager.cpp
@@ -5,6 +5,7 @@
 #include "../helpers/MiscFunctions.hpp"
 #include "../core/hyprlock.hpp"
 #include "../config/ConfigManager.hpp"
+#include "../core/Egl.hpp"
 
 #include <algorithm>
 #include <cstdint>
@@ -313,6 +314,8 @@ void CAsyncResourceManager::onResourceFinished(ResourceID id) {
         return;
 
     Log::logger->log(Log::TRACE, "Resource to texture id:{}", id);
+
+    g_pEGL->makeCurrent(nullptr);
 
     const auto           texture = makeAtomicShared<CTexture>();
 

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -69,8 +69,9 @@ static GLuint createProgram(const std::string& vert, const std::string& frag) {
 }
 
 static void glMessageCallbackA(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar* message, const void* userParam) {
-    if (type != GL_DEBUG_TYPE_ERROR)
+    if (type != GL_DEBUG_TYPE_ERROR && !Log::logger->verbose())
         return;
+
     Log::logger->log(Log::INFO, "[gl] {}", (const char*)message);
 }
 


### PR DESCRIPTION
To try to reproduce #991, I plugged in a old GTX 980 card into my computer and installed the nvidia 580 drivers.
I was able to reproduce a very similar type of error, but I have no idea if it is the same.

On this setup`eglSwapSurface` returned EGL_NOT_INITIALIZED after the monitor was turned on again and stuff was successfully initialized.
What fixed that was 84aa55d2235b10b80d6e2c2c6f3fd2dd53b28777, which calls `eglReleaseThread` when we have no outputs and makes sure we do `eglMakeCurrent` in the asyncResourceManager.

I also added some logging, which might be helpful with those types of bugs in the future.