### PR TITLE
Fix config file not found error message

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -186,7 +186,7 @@ static std::expected<std::string, std::string> getMainConfigPath() {
     if (PATHS.first.has_value())
         return PATHS.first.value();
     else
-        return std::unexpected{"Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr."};
+        return std::unexpected{"Could not find config. Searched in order: XDG_CONFIG_HOME, HOME, XDG_CONFIG_DIRS, /etc/xdg"};
 }
 
 std::expected<std::string, std::string> CConfigManager::resolveConfigPath(std::optional<std::string_view> explicitPath) {


### PR DESCRIPTION
Fixes a wrong path, `/etc/hypr` -> `/etc/xdg`, and specifies the lookup order.

Reference from `hyprutils`:
```C
    using T = std::optional<std::string>;
    std::pair<T, T> findConfig(std::string programName) {
        bool              xdgConfigHomeExists = false;
        static const auto xdgConfigHome       = getXdgConfigHome();
        if (xdgConfigHome.has_value()) {
            xdgConfigHomeExists = true;
            if (checkConfigExists(xdgConfigHome.value(), programName))
                return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName), xdgConfigHome);
        }

        bool              homeExists = false;
        static const auto home       = getHome();
        if (home.has_value()) {
            homeExists = true;
            if (checkConfigExists(home.value(), programName))
                return std::make_pair(fullConfigPath(home.value(), programName), home);
        }

        static const auto xdgConfigDirs = getXdgConfigDirs();
        if (xdgConfigDirs.has_value()) {
            for (auto& dir : xdgConfigDirs.value()) {
                if (checkConfigExists(dir, programName))
                    return std::make_pair(fullConfigPath(dir, programName), std::nullopt);
            }
        }

        if (checkConfigExists("/etc/xdg", programName))
            return std::make_pair(fullConfigPath("/etc/xdg", programName), std::nullopt);

        if (xdgConfigHomeExists)
            return std::make_pair(std::nullopt, xdgConfigHome);
        else if (homeExists)
            return std::make_pair(std::nullopt, home);

        return std::make_pair(std::nullopt, std::nullopt);
    }