### PR TITLE
auth: start PAM authentication immediately without pre-collecting input

### DIFF
--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -17,32 +17,28 @@
 int conv(int num_msg, const struct pam_message** msg, struct pam_response** resp, void* appdata_ptr) {
     const auto           CONVERSATIONSTATE = (CPam::SPamConversationState*)appdata_ptr;
     struct pam_response* pamReply          = (struct pam_response*)calloc(num_msg, sizeof(struct pam_response));
-    bool                 initialPrompt     = true;
 
     for (int i = 0; i < num_msg; ++i) {
         switch (msg[i]->msg_style) {
             case PAM_PROMPT_ECHO_OFF:
             case PAM_PROMPT_ECHO_ON: {
-                const auto PROMPT        = std::string(msg[i]->msg);
-                const auto PROMPTCHANGED = PROMPT != CONVERSATIONSTATE->prompt;
+                const auto PROMPT = std::string(msg[i]->msg);
                 Log::logger->log(Log::INFO, "PAM_PROMPT: {}", PROMPT);
 
-                if (PROMPTCHANGED)
-                    g_pHyprlock->enqueueForceUpdateTimers();
-
-                // Some pam configurations ask for the password twice for whatever reason (Fedora su for example)
-                // When the prompt is the same as the last one, I guess our answer can be the same.
-                if (!initialPrompt && PROMPTCHANGED) {
-                    CONVERSATIONSTATE->prompt = PROMPT;
-                    CONVERSATIONSTATE->waitForInput();
-                }
+                // Update the prompt and wait for user input. Since
+                // pam_authenticate runs immediately (not after pre-collecting
+                // input), every prompt from a PAM module must block here.
+                // Non-interactive modules (face auth, FIDO2) never send
+                // prompts, so this only fires for password-based modules.
+                CONVERSATIONSTATE->prompt = PROMPT;
+                g_pHyprlock->enqueueForceUpdateTimers();
+                CONVERSATIONSTATE->waitForInput();
 
                 // Needed for unlocks via SIGUSR1
                 if (g_pHyprlock->isUnlocked())
                     return PAM_CONV_ERR;
 
                 pamReply[i].resp = strdup(CONVERSATIONSTATE->input.c_str());
-                initialPrompt    = false;
             } break;
             case PAM_ERROR_MSG: Log::logger->log(Log::ERR, "PAM: {}", msg[i]->msg); break;
             case PAM_TEXT_INFO:
@@ -83,9 +79,11 @@ void CPam::init() {
         while (true) {
             resetConversation();
 
-            // Initial input
-            m_sConversationState.prompt = "Password: ";
-            waitForInput();
+            // Start PAM authentication immediately. Non-interactive modules
+            // (e.g. pam_python/howdy for face recognition, FIDO2) run first
+            // without needing user input. If they succeed, we unlock instantly.
+            // If they fail, pam_unix will trigger the conv() callback which
+            // blocks for password input at that point.
 
             // For grace or SIGUSR1 unlocks
             if (g_pHyprlock->isUnlocked())


### PR DESCRIPTION
## Summary

- Remove the hardcoded "Password: " prompt and `waitForInput()` call from `CPam::init()` so that `pam_authenticate()` runs immediately on lock
- Modify the PAM conversation callback to block for input on every prompt, since input is no longer pre-collected
- Non-interactive PAM modules (face recognition via howdy/pam_python, FIDO2 devices) now run before any user interaction is required

## Problem

`CPam::init()` blocks on `waitForInput()` before ever calling `pam_authenticate()`. This means non-interactive PAM modules can never execute until the user types something and presses Enter. Face recognition (howdy), FIDO2 hardware keys, and any other passwordless PAM module are effectively broken — they only fire *after* the user has already submitted input, defeating the purpose of passwordless authentication.

This was acknowledged in #926 and is related to the security concerns in #535.

## Solution

Start `pam_authenticate()` immediately when the lock screen appears. The PAM stack evaluates modules in order:

1. Lock screen appears → `pam_authenticate()` fires
2. Non-interactive modules (e.g. howdy as `sufficient`) run first — no PAM conversation needed
3. **If they succeed** → `PAM_SUCCESS` → screen unlocks instantly, no keypress
4. **If they fail** → PAM continues to the next module (e.g. `pam_unix`)
5. `pam_unix` triggers the `conv()` callback with a "Password:" prompt → blocks for user input → normal password flow

The `conv()` callback no longer skips `waitForInput()` for the "initial" prompt, since input is no longer pre-collected before PAM runs.

## What this enables

- **Face unlock** (howdy + pam_python): camera fires immediately on lock, face match unlocks without any keypress
- **FIDO2 hardware keys**: device activates immediately instead of requiring an Enter press first
- **Any non-interactive PAM module**: works as the PAM stack intended

## Test plan

- [ ] Normal password unlock still works (type password, press Enter)
- [ ] Face recognition via howdy unlocks without keypress when configured as `sufficient` in `/etc/pam.d/hyprlock`
- [ ] Failed face recognition falls through to password prompt correctly
- [ ] SIGUSR1 unlock still works
- [ ] Grace period unlock still works
- [ ] Multiple failed attempts show correct fail text
- [ ] Fedora-style double password prompts still work (conv blocks on each prompt)

## Diff

One file changed: `src/auth/Pam.cpp` — 14 insertions, 16 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)