### PR TITLE
core: fix freeze when a monitor is DPMS-off during lock

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -105,6 +105,13 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
             readyForFrame = false;
             return;
         }
+
+        // Disable vsync throttling so eglSwapBuffers never blocks waiting for
+        // wl_buffer.release. Without this, a DPMS-off monitor can stall the main
+        // thread indefinitely because the compositor never releases the buffer.
+        // Rendering rate is already governed by wl_surface.frame callbacks.
+        g_pEGL->makeCurrent(eglSurface);
+        eglSwapInterval(g_pEGL->eglDisplay, 0);
     }
 
     if (readyForFrame && !(SAMESIZE && SAMESCALE)) {


### PR DESCRIPTION
# Summary                  

Fix hyprlock freezing indefinitely when one monitor is DPMS-off at lock time, by preventing eglSwapBuffers from blocking on a compositor that will never release the buffer for a powered-off display.

**Caveat:** most of the work here was done by Claude. I am a developer, but I haven't done any C++ in ~15 years and don't have a good understanding of the internal workings of hyprland or display servers, etc. in general. However, I noticed there have been a lot of related issues posted, so I thought I would put this up for review by the maintainers. I'm happy to help further.

# Problem                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                       
This seems possibly related to #953, #695, and maybe others. I have an NVidia RTX 3060Ti, a Samsung G9 (ultrawide) monitor, and an older 24" Samsung monitor. I'm currently using the nvidia-open drivers (595.58.03) on nixos.

The exact behavior I was seeing:

* On transition to lock screen, the screen would freeze (I would see my session with a shadow of the lock screen over it).
* I could enter my password (blindly), but the screen would still be frozen until I manually powercycled my monitor
* After powercycling, the system would unlock
* After the freezing issue was fixed, I also noticed that hyprlock would segfault on unlock, so that is addressed here as well.

I tried setting `screencopy_mode = 1` to see if that had any effect, but it did not.
                                                                                                                                                                                                                                                                                         
 # Solution                                                                                                                                                                                                                                                                             

  Egl.cpp — Call eglSwapInterval(0) in `configure`. This makes the swap non-blocking: the buffer is committed to the compositor and the call returns immediately. Rendering rate is already properly throttled by wl_surface.frame callbacks, so this does not cause over-rendering.


  ~~LockSurface.cpp — When configure() acknowledges a new serial, reset any pending frame callback before calling render(). This ensures every ack_configure is followed by a committed frame, breaking the protocol deadlock during rapid output reconfiguration.~~
  ~~hyprlock.cpp — Skip zwp_linux_dmabuf_v1 binding when screencopy_mode=1. The GBM device created in the dmabuf feedback callback is only needed for DMABUF screencopy; creating it unnecessarily can block on the DRM render node under the same adverse conditions.~~
  ~~Output.cpp — Guard createSessionLockSurface() with m_bTerminate to prevent a segfault when an output reconnects during session unlock teardown (the session lock object is already destroyed at that point).~~

# Test steps
  - Normal password unlock works without monitor power-cycle
  - Fade-in and fade-out animations play correctly on all monitors
  - Lock/unlock works with a monitor in DPMS-off state at lock time 
  - ~~No segfault when a monitor reconnects during unlock~~                                                                                                                                                                                                                 
  - ~~screencopy_mode = 1 no longer attempts dmabuf setup~~
  - ~~Default DMABUF screencopy mode still works when monitors are active~~

🤖 Generated with Claude Code