### PR TITLE
config: prevent crash on invalid numeric values

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -89,7 +89,12 @@ static Hyprlang::CParseResult configHandleLayoutOption(const char* v, void** dat
         rhs.pop_back();
     }
 
-    DATA->m_vValues = Hyprutils::Math::Vector2D{std::stof(lhs), std::stof(rhs)};
+    try {
+        DATA->m_vValues = Hyprutils::Math::Vector2D{std::stof(lhs), std::stof(rhs)};
+    } catch (const std::exception&) {
+        result.setError(std::format("invalid layout values: {}", VALUE).c_str());
+        return result;
+    }
 
     return result;
 }
@@ -595,34 +600,41 @@ std::optional<std::string> CConfigManager::handleSource(const std::string& comma
 }
 
 std::optional<std::string> CConfigManager::handleBezier(const std::string& command, const std::string& args) {
-    const auto  ARGS = CVarList(args);
+    const auto ARGS = CVarList(args);
 
     std::string bezierName = ARGS[0];
 
     if (ARGS[1] == "")
         return "too few arguments";
-    float p1x = std::stof(ARGS[1]);
-
     if (ARGS[2] == "")
         return "too few arguments";
-    float p1y = std::stof(ARGS[2]);
-
     if (ARGS[3] == "")
         return "too few arguments";
-    float p2x = std::stof(ARGS[3]);
-
     if (ARGS[4] == "")
         return "too few arguments";
-    float p2y = std::stof(ARGS[4]);
+
+    float p1x, p1y, p2x, p2y;
+
+    try {
+        p1x = std::stof(ARGS[1]);
+        p1y = std::stof(ARGS[2]);
+        p2x = std::stof(ARGS[3]);
+        p2y = std::stof(ARGS[4]);
+    } catch (const std::exception&) {
+        return "invalid bezier arguments";
+    }
 
     if (ARGS[5] != "")
         return "too many arguments";
 
-    g_pAnimationManager->addBezierWithName(bezierName, Vector2D(p1x, p1y), Vector2D(p2x, p2y));
+    g_pAnimationManager->addBezierWithName(
+        bezierName,
+        Vector2D(p1x, p1y),
+        Vector2D(p2x, p2y)
+    );
 
     return {};
 }
-
 std::optional<std::string> CConfigManager::handleAnimation(const std::string& command, const std::string& args) {
     const auto ARGS = CVarList(args);
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -600,7 +600,7 @@ std::optional<std::string> CConfigManager::handleSource(const std::string& comma
 }
 
 std::optional<std::string> CConfigManager::handleBezier(const std::string& command, const std::string& args) {
-    const auto ARGS = CVarList(args);
+    const auto  ARGS = CVarList(args);
 
     std::string bezierName = ARGS[0];
 
@@ -620,18 +620,12 @@ std::optional<std::string> CConfigManager::handleBezier(const std::string& comma
         p1y = std::stof(ARGS[2]);
         p2x = std::stof(ARGS[3]);
         p2y = std::stof(ARGS[4]);
-    } catch (const std::exception&) {
-        return "invalid bezier arguments";
-    }
+    } catch (const std::exception&) { return "invalid bezier arguments"; }
 
     if (ARGS[5] != "")
         return "too many arguments";
 
-    g_pAnimationManager->addBezierWithName(
-        bezierName,
-        Vector2D(p1x, p1y),
-        Vector2D(p2x, p2y)
-    );
+    g_pAnimationManager->addBezierWithName(bezierName, Vector2D(p1x, p1y), Vector2D(p2x, p2y));
 
     return {};
 }


### PR DESCRIPTION
Fixes a crash when invalid numeric values are used in the config.
For example, values like `size = abc, 200` or invalid bezier parameters would previously cause hyprlock to exit with `Config threw: stof`, due to unhandled exceptions from std::stof.
This change wraps the parsing so invalid values are reported as config errors instead of crashing. Faulty entries are ignored and hyprlock continues running normally.
Tested with both valid and invalid configs. Invalid values now produce an error without crashing, and valid configs behave as before. Also verified with valgrind using invalid input (no definitely lost memory).