### PR TITLE
pam: start conversation right away

### DIFF
--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -27,18 +27,17 @@ int conv(int num_msg, const struct pam_message** msg, struct pam_response** resp
                 const auto PROMPTCHANGED = PROMPT != CONVERSATIONSTATE->prompt;
                 Log::logger->log(Log::INFO, "PAM_PROMPT: {}", PROMPT);
 
-                if (PROMPTCHANGED)
-                    g_pHyprlock->enqueueForceUpdateTimers();
-
                 // Some pam configurations ask for the password twice for whatever reason (Fedora su for example)
                 // When the prompt is the same as the last one, I guess our answer can be the same.
                 if (initialPrompt || PROMPTCHANGED) {
                     CONVERSATIONSTATE->prompt = PROMPT;
+                    g_pHyprlock->enqueueForceUpdateTimers();
+
                     CONVERSATIONSTATE->waitForInput();
                 }
 
                 // Needed for unlocks via SIGUSR1
-                if (g_pHyprlock->isUnlocked())
+                if (g_pHyprlock->m_bTerminate)
                     return PAM_CONV_ERR;
 
                 pamReply[i].resp = strdup(CONVERSATIONSTATE->input.c_str());
@@ -84,13 +83,13 @@ void CPam::init() {
             resetConversation();
 
             // For grace or SIGUSR1 unlocks
-            if (g_pHyprlock->isUnlocked())
+            if (g_pHyprlock->m_bTerminate)
                 return;
 
             const auto AUTHENTICATED = auth();
 
             // For SIGUSR1 unlocks
-            if (g_pHyprlock->isUnlocked())
+            if (g_pHyprlock->m_bTerminate)
                 return;
 
             if (!AUTHENTICATED)

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -32,7 +32,7 @@ int conv(int num_msg, const struct pam_message** msg, struct pam_response** resp
 
                 // Some pam configurations ask for the password twice for whatever reason (Fedora su for example)
                 // When the prompt is the same as the last one, I guess our answer can be the same.
-                if (!initialPrompt && PROMPTCHANGED) {
+                if (initialPrompt || PROMPTCHANGED) {
                     CONVERSATIONSTATE->prompt = PROMPT;
                     CONVERSATIONSTATE->waitForInput();
                 }
@@ -82,10 +82,6 @@ void CPam::init() {
     m_thread = std::thread([this]() {
         while (true) {
             resetConversation();
-
-            // Initial input
-            m_sConversationState.prompt = "Password: ";
-            waitForInput();
 
             // For grace or SIGUSR1 unlocks
             if (g_pHyprlock->isUnlocked())


### PR DESCRIPTION
Closes #926
Closes #998

Reverts #409

I think it does make sense, because we either have problems with obscure pam modules that implement a timeout or we have problems with obscure pam modules that rely on "hacky" interactivity. So it should be an ok tradeoff. I don't know of any pam modules that implement a timeout.