### PR TITLE
Fix crash when ext-session-lock-v1 is unavailable during startup

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -22,6 +22,7 @@
 #include <sdbus-c++/sdbus-c++.h>
 #include <hyprutils/os/Process.hpp>
 #include <malloc.h>
+#include <thread>
 
 using namespace Hyprutils::OS;
 
@@ -340,10 +341,22 @@ void CHyprlock::run() {
     wl_display_roundtrip(m_sWaylandState.display);
 
     if (!m_sWaylandState.sessionLock) {
-        Log::logger->log(Log::CRIT, "Couldn't bind to ext-session-lock-v1, does your compositor support it?");
-        exit(1);
-    }
+        Log::logger->log(Log::WARN, "ext-session-lock-v1 not ready yet, retrying...");
 
+        for (int i = 0; i < 5; ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            wl_display_roundtrip(m_sWaylandState.display);
+
+            if (m_sWaylandState.sessionLock)
+                break;
+        }
+
+        if (!m_sWaylandState.sessionLock) {
+            Log::logger->log(Log::CRIT, "Couldn't bind to ext-session-lock-v1 after retries. Does your compositor support it?");
+            exit(1);
+        }
+    }
     // Gather info about monitors
     wl_display_roundtrip(m_sWaylandState.display);
 


### PR DESCRIPTION
Fixes #999

When hyprlock is launched immediately at compositor startup,
ext-session-lock-v1 may not yet be available.

Previously this was treated as a fatal error, causing hyprlock
to abort.

This change retries binding for a short period, allowing the
compositor to finish initialization before failing.

Note: This introduces a short blocking wait (with brief delays and additional
Wayland roundtrips) during startup, ensuring globals are processed and avoiding
premature aborts (maximum ~500 ms).