### PR TITLE
background: fix condition for image reload when crossfade is still in progress

### DIFF
--- a/src/renderer/AsyncResourceManager.cpp
+++ b/src/renderer/AsyncResourceManager.cpp
@@ -45,14 +45,14 @@ ResourceID CAsyncResourceManager::resourceIDForScreencopy(const std::string& por
 ResourceID CAsyncResourceManager::requestText(const CTextResource::STextResourceData& params, const AWP<IWidget>& widget) {
     const auto RESOURCEID = resourceIDForTextRequest(params);
     if (request(RESOURCEID, widget)) {
-        Log::logger->log(Log::TRACE, "Reusing text resource \"{}\" (resourceID: {})", params.text, RESOURCEID, (uintptr_t)widget.get());
+        Log::logger->log(Log::TRACE, "Reusing text resource \"{}\" (resourceID: {})", params.text, RESOURCEID);
         return RESOURCEID;
     }
 
     auto                                 resource = makeAtomicShared<CTextResource>(CTextResource::STextResourceData{params});
     CAtomicSharedPointer<IAsyncResource> resourceGeneric{resource};
 
-    Log::logger->log(Log::TRACE, "Requesting text resource \"{}\" (resourceID: {})", params.text, RESOURCEID, (uintptr_t)widget.get());
+    Log::logger->log(Log::TRACE, "Requesting text resource \"{}\" (resourceID: {})", params.text, RESOURCEID);
     enqueue(RESOURCEID, resourceGeneric, widget);
     return RESOURCEID;
 }
@@ -60,14 +60,14 @@ ResourceID CAsyncResourceManager::requestText(const CTextResource::STextResource
 ResourceID CAsyncResourceManager::requestTextCmd(const CTextResource::STextResourceData& params, size_t revision, const AWP<IWidget>& widget) {
     const auto RESOURCEID = resourceIDForTextCmdRequest(params, revision);
     if (request(RESOURCEID, widget)) {
-        Log::logger->log(Log::TRACE, "Reusing text cmd resource \"{}\" revision {} (resourceID: {})", params.text, revision, RESOURCEID, (uintptr_t)widget.get());
+        Log::logger->log(Log::TRACE, "Reusing text cmd resource \"{}\" revision {} (resourceID: {})", params.text, revision, RESOURCEID);
         return RESOURCEID;
     }
 
     auto                                 resource = makeAtomicShared<CTextCmdResource>(CTextResource::STextResourceData{params});
     CAtomicSharedPointer<IAsyncResource> resourceGeneric{resource};
 
-    Log::logger->log(Log::TRACE, "Requesting text cmd resource \"{}\" revision {} (resourceID: {})", params.text, revision, RESOURCEID, (uintptr_t)widget.get());
+    Log::logger->log(Log::TRACE, "Requesting text cmd resource \"{}\" revision {} (resourceID: {})", params.text, revision, RESOURCEID);
     enqueue(RESOURCEID, resourceGeneric, widget);
     return RESOURCEID;
 }
@@ -75,14 +75,14 @@ ResourceID CAsyncResourceManager::requestTextCmd(const CTextResource::STextResou
 ResourceID CAsyncResourceManager::requestImage(const std::string& path, size_t revision, const AWP<IWidget>& widget) {
     const auto RESOURCEID = resourceIDForImageRequest(path, revision);
     if (request(RESOURCEID, widget)) {
-        Log::logger->log(Log::TRACE, "Reusing image resource {} revision {} (resourceID: {})", path, revision, RESOURCEID, (uintptr_t)widget.get());
+        Log::logger->log(Log::TRACE, "Reusing image resource {} revision {} (resourceID: {})", path, revision, RESOURCEID);
         return RESOURCEID;
     }
 
     auto                                 resource = makeAtomicShared<CImageResource>(absolutePath(path, ""));
     CAtomicSharedPointer<IAsyncResource> resourceGeneric{resource};
 
-    Log::logger->log(Log::TRACE, "Requesting image resource {} revision {} (resourceID: {})", path, revision, RESOURCEID, (uintptr_t)widget.get());
+    Log::logger->log(Log::TRACE, "Requesting image resource {} revision {} (resourceID: {})", path, revision, RESOURCEID);
     enqueue(RESOURCEID, resourceGeneric, widget);
     return RESOURCEID;
 }

--- a/src/renderer/widgets/Background.cpp
+++ b/src/renderer/widgets/Background.cpp
@@ -267,8 +267,6 @@ bool CBackground::draw(const SRenderData& data) {
 }
 
 void CBackground::onAssetUpdate(ResourceID id, ASP<CTexture> newAsset) {
-    pendingResource = false;
-
     if (!newAsset)
         Log::logger->log(Log::ERR, "Background asset update failed, resourceID: {} not available on update!", id);
     else if (newAsset->m_iType == TEXTURE_INVALID) {
@@ -284,12 +282,15 @@ void CBackground::onAssetUpdate(ResourceID id, ASP<CTexture> newAsset) {
                 if (const auto PSELF = REF.lock()) {
                     if (PSELF->asset)
                         g_asyncResourceManager->unload(PSELF->asset);
+
                     PSELF->asset        = PSELF->pendingAsset;
                     PSELF->pendingAsset = nullptr;
                     PSELF->resourceID   = id;
 
                     PSELF->blurredFB->destroyBuffer();
                     PSELF->blurredFB = std::move(PSELF->pendingBlurredFB);
+
+                    PSELF->pendingResource = false;
                 }
             },
             true);
@@ -332,8 +333,10 @@ void CBackground::onReloadTimerUpdate() {
         return;
     }
 
-    if (pendingResource)
+    if (pendingResource) {
+        Log::logger->log(Log::WARN, "Background image update still pending! - Refusing to load {}", path);
         return;
+    }
 
     pendingResource = true;
 


### PR DESCRIPTION
Fixes a crash found in #1006.

I was able to reproduce this by spamming background reloads.
It makes sense that it happens with suspend as well.
