### PR TITLE
auth: add Visage face authentication module

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -1,6 +1,7 @@
 #include "Auth.hpp"
 #include "Pam.hpp"
 #include "Fingerprint.hpp"
+#include "Visage.hpp"
 #include "../config/ConfigManager.hpp"
 #include "../core/hyprlock.hpp"
 #include "src/helpers/Log.hpp"
@@ -15,6 +16,9 @@ CAuth::CAuth() {
     static const auto ENABLEFINGERPRINT = g_pConfigManager->getValue<Hyprlang::INT>("auth:fingerprint:enabled");
     if (*ENABLEFINGERPRINT)
         m_vImpls.emplace_back(makeShared<CFingerprint>());
+    static const auto ENABLEVISAGE = g_pConfigManager->getValue<Hyprlang::INT>("auth:visage:enabled");
+    if (*ENABLEVISAGE)
+        m_vImpls.emplace_back(makeShared<CVisage>());
 
     RASSERT(!m_vImpls.empty(), "At least one authentication method must be enabled!");
 }

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -9,6 +9,7 @@
 enum eAuthImplementations {
     AUTH_IMPL_PAM         = 0,
     AUTH_IMPL_FINGERPRINT = 1,
+    AUTH_IMPL_VISAGE      = 2,
 };
 
 class IAuthImplementation {

--- a/src/auth/DBus.cpp
+++ b/src/auth/DBus.cpp
@@ -1,0 +1,16 @@
+#include "DBus.hpp"
+#include "../helpers/Log.hpp"
+
+std::shared_ptr<sdbus::IConnection> g_dbus;
+
+bool initDBus() {
+    if (g_dbus)
+        return true;
+    try {
+        g_dbus = sdbus::createSystemBusConnection();
+    } catch (const sdbus::Error& e) {
+        Log::logger->log(Log::ERR, "dbus: failed to create system bus connection ({})", e.what());
+        return false;
+    }
+    return true;
+}

--- a/src/auth/DBus.hpp
+++ b/src/auth/DBus.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <memory>
+#include <sdbus-c++/sdbus-c++.h>
+
+// Shared system D-Bus connection used by auth backends (fingerprint, visage).
+// Lazily created by initDBus(); null if no backend requested it or setup failed.
+// Dispatched from the main loop via processPendingEvent() — see hyprlock.cpp.
+extern std::shared_ptr<sdbus::IConnection> g_dbus;
+
+bool initDBus();

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -1,4 +1,5 @@
 #include "Fingerprint.hpp"
+#include "DBus.hpp"
 #include "../core/hyprlock.hpp"
 #include "../helpers/Log.hpp"
 #include "../config/ConfigManager.hpp"
@@ -47,12 +48,15 @@ CFingerprint::~CFingerprint() {
 }
 
 void CFingerprint::init() {
+    if (!initDBus()) {
+        Log::logger->log(Log::ERR, "fprint: no dbus connection; disabled");
+        return;
+    }
+
     try {
-        m_sDBUSState.connection = sdbus::createSystemBusConnection();
-        m_sDBUSState.login      = sdbus::createProxy(*m_sDBUSState.connection, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});
+        m_sDBUSState.login = sdbus::createProxy(*g_dbus, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});
     } catch (sdbus::Error& e) {
         Log::logger->log(Log::ERR, "fprint: Failed to setup dbus ({})", e.what());
-        m_sDBUSState.connection.reset();
         return;
     }
 
@@ -100,12 +104,8 @@ void CFingerprint::terminate() {
         releaseDevice();
 }
 
-std::shared_ptr<sdbus::IConnection> CFingerprint::getConnection() {
-    return m_sDBUSState.connection;
-}
-
 bool CFingerprint::createDeviceProxy() {
-    auto              proxy = sdbus::createProxy(*m_sDBUSState.connection, FPRINT, sdbus::ObjectPath{"/net/reactivated/Fprint/Manager"});
+    auto              proxy = sdbus::createProxy(*g_dbus, FPRINT, sdbus::ObjectPath{"/net/reactivated/Fprint/Manager"});
 
     sdbus::ObjectPath path;
     try {
@@ -115,7 +115,7 @@ bool CFingerprint::createDeviceProxy() {
         return false;
     }
     Log::logger->log(Log::INFO, "fprint: using device path {}", path.c_str());
-    m_sDBUSState.device = sdbus::createProxy(*m_sDBUSState.connection, FPRINT, path);
+    m_sDBUSState.device = sdbus::createProxy(*g_dbus, FPRINT, path);
 
     m_sDBUSState.device->uponSignal("VerifyFingerSelected").onInterface(DEVICE).call([](const std::string& finger) {
         Log::logger->log(Log::INFO, "fprint: finger selected: {}", finger);

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -22,11 +22,8 @@ class CFingerprint : public IAuthImplementation {
     virtual std::optional<std::string>  getLastPrompt();
     virtual void                        terminate();
 
-    std::shared_ptr<sdbus::IConnection> getConnection();
-
   private:
     struct SDBUSState {
-        std::shared_ptr<sdbus::IConnection> connection;
         std::unique_ptr<sdbus::IProxy>      login;
         std::unique_ptr<sdbus::IProxy>      device;
 

--- a/src/auth/Visage.cpp
+++ b/src/auth/Visage.cpp
@@ -1,0 +1,147 @@
+#include "Visage.hpp"
+#include "DBus.hpp"
+#include "../core/hyprlock.hpp"
+#include "../helpers/Log.hpp"
+#include "../config/ConfigManager.hpp"
+
+#include <chrono>
+#include <pwd.h>
+#include <unistd.h>
+
+// Per-call timeout on the Verify D-Bus method. visaged opens the camera, runs
+// inference, and replies (typically ~500-1500ms). After hibernate or on a
+// stale camera fd it can take far longer; cap so a stuck visaged can't
+// deadlock the dispatch.
+constexpr int VERIFY_TIMEOUT_MS = 30'000;
+
+// Backoff parameters when Verify keeps failing (visaged unavailable,
+// restarting, etc). delay = min(retry_delay << min(errors, MAX_BACKOFF_SHIFT),
+// MAX_BACKOFF_MS).
+constexpr int MAX_BACKOFF_MS    = 5'000;
+constexpr int MAX_BACKOFF_SHIFT = 4;
+
+static const auto VISAGE_SERVICE   = sdbus::ServiceName{"org.freedesktop.Visage1"};
+static const auto VISAGE_OBJECT    = sdbus::ObjectPath{"/org/freedesktop/Visage1"};
+static const auto VISAGE_INTERFACE = sdbus::InterfaceName{"org.freedesktop.Visage1"};
+static const auto LOGIN_MANAGER    = sdbus::ServiceName{"org.freedesktop.login1.Manager"};
+
+CVisage::CVisage() {
+    static const auto READYMSG = g_pConfigManager->getValue<Hyprlang::STRING>("auth:visage:ready_message");
+    static const auto RETRYDLY = g_pConfigManager->getValue<Hyprlang::INT>("auth:visage:retry_delay");
+    static const auto STARTDLY = g_pConfigManager->getValue<Hyprlang::INT>("auth:visage:start_delay");
+    m_readyMessage = *READYMSG;
+    m_retryDelayMs = *RETRYDLY;
+    m_startDelayMs = *STARTDLY;
+
+    if (auto* pw = getpwuid(getuid()); pw && pw->pw_name)
+        m_username = pw->pw_name;
+}
+
+CVisage::~CVisage() = default;
+
+void CVisage::init() {
+    if (m_username.empty()) {
+        Log::logger->log(Log::ERR, "visage: could not resolve current username; disabled");
+        return;
+    }
+
+    if (!initDBus()) {
+        Log::logger->log(Log::ERR, "visage: no dbus connection; disabled");
+        return;
+    }
+
+    try {
+        m_proxy = sdbus::createProxy(*g_dbus, VISAGE_SERVICE, VISAGE_OBJECT);
+        m_login = sdbus::createProxy(*g_dbus, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});
+    } catch (const sdbus::Error& e) {
+        Log::logger->log(Log::ERR, "visage: failed to create proxies ({})", e.what());
+        m_proxy.reset();
+        m_login.reset();
+        return;
+    }
+
+    m_login->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
+        Log::logger->log(Log::INFO, "visage: PrepareForSleep (start: {})", start);
+        m_sleeping = start;
+        if (!start && !m_inFlight && !m_authenticated && !m_aborted)
+            scheduleVerify(m_retryDelayMs);
+    });
+
+    m_prompt = m_readyMessage;
+    scheduleVerify(m_startDelayMs);
+}
+
+void CVisage::handleInput(const std::string& /*input*/) {
+    // Nudge a fresh attempt — useful while visaged is recovering after
+    // hibernate-resume and the user hits Enter to retry.
+    if (m_aborted || m_authenticated || m_inFlight || m_sleeping || !m_proxy)
+        return;
+    Log::logger->log(Log::INFO, "visage: nudge - retry triggered by user input");
+    startVerify();
+}
+
+bool CVisage::checkWaiting() {
+    return false;
+}
+
+std::optional<std::string> CVisage::getLastFailText() {
+    return std::nullopt;
+}
+
+std::optional<std::string> CVisage::getLastPrompt() {
+    if (!m_prompt.empty())
+        return std::optional(m_prompt);
+    return std::nullopt;
+}
+
+void CVisage::terminate() {
+    m_aborted = true;
+}
+
+void CVisage::scheduleVerify(int delayMs) {
+    if (m_aborted || m_authenticated)
+        return;
+    g_pHyprlock->addTimer(
+        std::chrono::milliseconds(delayMs), [](ASP<CTimer>, void* data) { ((CVisage*)data)->startVerify(); }, this);
+}
+
+void CVisage::startVerify() {
+    if (m_aborted || m_authenticated || m_sleeping || m_inFlight || !m_proxy)
+        return;
+
+    m_inFlight = true;
+    m_proxy->callMethodAsync("Verify")
+        .onInterface(VISAGE_INTERFACE)
+        .withTimeout(std::chrono::milliseconds(VERIFY_TIMEOUT_MS))
+        .withArguments(m_username)
+        .uponReplyInvoke([this](std::optional<sdbus::Error> e, bool matched) { onVerifyReply(std::move(e), matched); });
+}
+
+void CVisage::onVerifyReply(std::optional<sdbus::Error> error, bool matched) {
+    m_inFlight = false;
+    if (m_aborted || m_authenticated)
+        return;
+
+    if (error) {
+        ++m_consecutiveErrors;
+        // visaged can take 30-90s to come back after hibernate-resume; log
+        // first + every 10th to avoid spamming.
+        if (m_consecutiveErrors == 1 || m_consecutiveErrors % 10 == 0)
+            Log::logger->log(Log::WARN, "visage: Verify failed ({}x): {}", m_consecutiveErrors, error->what());
+        const int shift   = std::min(m_consecutiveErrors, MAX_BACKOFF_SHIFT);
+        const int backoff = std::min(m_retryDelayMs * (1 << shift), MAX_BACKOFF_MS);
+        scheduleVerify(backoff);
+        return;
+    }
+
+    m_consecutiveErrors = 0;
+
+    if (matched) {
+        Log::logger->log(Log::INFO, "visage: face matched - unlocking");
+        m_authenticated = true;
+        g_pAuth->enqueueUnlock();
+        return;
+    }
+
+    scheduleVerify(m_retryDelayMs);
+}

--- a/src/auth/Visage.hpp
+++ b/src/auth/Visage.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "Auth.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <sdbus-c++/sdbus-c++.h>
+
+// Face-authentication backend that talks to visaged
+// (https://github.com/sovren-software/visage) over D-Bus. Calls
+// Verify(username) asynchronously on the shared g_dbus connection; on a
+// positive match calls g_pAuth->enqueueUnlock().
+//
+// Designed to coexist with the password (PAM) backend: either succeeding
+// unlocks the session. A user submit (Enter) wakes a retry immediately,
+// useful while visaged is recovering after hibernate-resume.
+class CVisage : public IAuthImplementation {
+  public:
+    CVisage();
+    ~CVisage() override;
+
+    eAuthImplementations getImplType() override {
+        return AUTH_IMPL_VISAGE;
+    }
+
+    void                       init() override;
+    void                       handleInput(const std::string& input) override;
+    bool                       checkWaiting() override;
+    std::optional<std::string> getLastFailText() override;
+    std::optional<std::string> getLastPrompt() override;
+    void                       terminate() override;
+
+  private:
+    void scheduleVerify(int delayMs);
+    void startVerify();
+    void onVerifyReply(std::optional<sdbus::Error> error, bool matched);
+
+    std::unique_ptr<sdbus::IProxy> m_proxy;
+    std::unique_ptr<sdbus::IProxy> m_login;
+
+    std::string m_username;
+    std::string m_prompt;
+    std::string m_readyMessage;
+
+    int  m_retryDelayMs      = 500;
+    int  m_startDelayMs      = 2000;
+    int  m_consecutiveErrors = 0;
+
+    bool m_authenticated = false;
+    bool m_aborted       = false;
+    bool m_sleeping      = false;
+    bool m_inFlight      = false;
+};

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -254,6 +254,10 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
     m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
+    m_config.addConfigValue("auth:visage:enabled", Hyprlang::INT{0});
+    m_config.addConfigValue("auth:visage:ready_message", Hyprlang::STRING{"(Look at the camera to unlock)"});
+    m_config.addConfigValue("auth:visage:retry_delay", Hyprlang::INT{500});
+    m_config.addConfigValue("auth:visage:start_delay", Hyprlang::INT{2000});
 
     m_config.addConfigValue("animations:enabled", Hyprlang::INT{1});
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -4,7 +4,7 @@
 #include "../renderer/Renderer.hpp"
 #include "../renderer/AsyncResourceManager.hpp"
 #include "../auth/Auth.hpp"
-#include "../auth/Fingerprint.hpp"
+#include "../auth/DBus.hpp"
 #include "./Egl.hpp"
 #include "./Seat.hpp"
 #include <chrono>
@@ -374,8 +374,7 @@ void CHyprlock::run() {
         exit(1);
     }
 
-    const auto fingerprintAuth = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
-    const auto dbusConn        = (fingerprintAuth) ? ((CFingerprint*)fingerprintAuth.get())->getConnection() : nullptr;
+    const auto dbusConn = g_dbus;
 
     registerSignalAction(SIGUSR1, handleUnlockSignal, SA_RESTART);
     registerSignalAction(SIGUSR2, handleForceUpdateSignal);


### PR DESCRIPTION
Adds a parallel face-auth backend that talks directly to [Visage](https://github.com/sovren-software/visage)'s system D-Bus interface (`org.freedesktop.Visage1`) instead of going through `pam_visage.so`. This mirrors the approach taken for fingerprint in #514: PAM modules are evaluated as soon as `pam_authenticate` starts, which means the face check fires the instant the lock appears and unlocks immediately if a face is in front of the camera. Direct D-Bus integration lets us add a small `start_delay` after lock and gate retries on a condvar so submitting input nudges a fresh attempt.

A worker thread polls `Verify(username)` and on a match calls `g_pAuth->enqueueUnlock()`. PAM continues to run in parallel as before, so password unlock works unchanged.

Disabled by default. Enable with `auth.visage.enabled = 1`. Other knobs are `ready_message`, `retry_delay` (default 500 ms), and `start_delay` (default 2000 ms).

Verify calls are bounded with `withTimeout(30s)` so a hung daemon can't deadlock `terminate()`. On D-Bus errors the worker backs off exponentially up to 5 s and never permanently gives up — visaged commonly takes 30–90 s to come back after a hibernate resume on Surface devices, and the user may also be waiting on `visage-resume.service` to restart it. If visaged isn't running at hyprlock start, the worker retries the connection every 2 s.

I did not add a `PrepareForSleep` handler like fingerprint has. The retry loop recovers organically once visaged is reachable again, so it didn't seem worth the extra dbus connection. Happy to add it if you'd rather mirror the fingerprint structure exactly.
