### PR TITLE
feat: add `success_text` for successful authentication

### DIFF
--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -76,12 +76,27 @@ void CAuth::terminate() {
     }
 }
 
+static void passwordSuccCallback(ASP<CTimer> self, void* data) {
+    g_pAuth->m_bDisplaySuccText = true;
+
+    g_pHyprlock->enqueueForceUpdateTimers();
+
+    g_pHyprlock->renderAllOutputs();
+}
+
 static void unlockCallback(ASP<CTimer> self, void* data) {
     g_pHyprlock->fadeOutAndUnlock();
 }
 
 void CAuth::enqueueUnlock() {
-    g_pHyprlock->addTimer(std::chrono::milliseconds(0), unlockCallback, nullptr);
+    static const auto SUCCTIMEOUT = g_pConfigManager->getValue<Hyprlang::INT>("general:succ_timeout");
+
+    if (*SUCCTIMEOUT > 0) {
+        g_pHyprlock->addTimer(std::chrono::milliseconds(0), passwordSuccCallback, nullptr);
+        g_pHyprlock->addTimer(std::chrono::milliseconds(*SUCCTIMEOUT), unlockCallback, nullptr);
+    } else {
+        g_pHyprlock->addTimer(std::chrono::milliseconds(0), unlockCallback, nullptr);
+    }
 }
 
 static void passwordFailCallback(ASP<CTimer> self, void* data) {

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -76,27 +76,24 @@ void CAuth::terminate() {
     }
 }
 
-static void passwordSuccCallback(ASP<CTimer> self, void* data) {
-    g_pAuth->m_bDisplaySuccText = true;
-
-    g_pHyprlock->enqueueForceUpdateTimers();
-
-    g_pHyprlock->renderAllOutputs();
-}
-
 static void unlockCallback(ASP<CTimer> self, void* data) {
-    g_pHyprlock->fadeOutAndUnlock();
+    static const auto SUCCESSTIMEOUT = g_pConfigManager->getValue<Hyprlang::INT>("general:success_timeout");
+
+    if (!g_pAuth->m_bDisplaySuccessText && *SUCCESSTIMEOUT > 0) {
+        g_pAuth->m_bDisplaySuccessText = true;
+
+        g_pHyprlock->enqueueForceUpdateTimers();
+
+        g_pHyprlock->renderAllOutputs();
+
+        g_pHyprlock->addTimer(std::chrono::milliseconds(*SUCCESSTIMEOUT), unlockCallback, nullptr);
+    } else {
+        g_pHyprlock->fadeOutAndUnlock();
+    }
 }
 
 void CAuth::enqueueUnlock() {
-    static const auto SUCCTIMEOUT = g_pConfigManager->getValue<Hyprlang::INT>("general:succ_timeout");
-
-    if (*SUCCTIMEOUT > 0) {
-        g_pHyprlock->addTimer(std::chrono::milliseconds(0), passwordSuccCallback, nullptr);
-        g_pHyprlock->addTimer(std::chrono::milliseconds(*SUCCTIMEOUT), unlockCallback, nullptr);
-    } else {
-        g_pHyprlock->addTimer(std::chrono::milliseconds(0), unlockCallback, nullptr);
-    }
+    g_pHyprlock->addTimer(std::chrono::milliseconds(0), unlockCallback, nullptr);
 }
 
 static void passwordFailCallback(ASP<CTimer> self, void* data) {

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -51,8 +51,8 @@ class CAuth {
     void                       resetDisplayFail();
 
     // Should only be set via the main thread
-    bool m_bDisplaySuccText = false;
-    bool m_bDisplayFailText = false;
+    bool m_bDisplaySuccessText = false;
+    bool m_bDisplayFailText    = false;
 
   private:
     struct {

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -51,6 +51,7 @@ class CAuth {
     void                       resetDisplayFail();
 
     // Should only be set via the main thread
+    bool m_bDisplaySuccText = false;
     bool m_bDisplayFailText = false;
 
   private:

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -95,6 +95,7 @@ void CPam::init() {
             if (!AUTHENTICATED)
                 g_pAuth->enqueueFail(m_sConversationState.failText, AUTH_IMPL_PAM);
             else {
+                m_bBlockInput = false;
                 g_pAuth->enqueueUnlock();
                 return;
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -246,7 +246,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});
     m_config.addConfigValue("general:screencopy_mode", Hyprlang::INT{0});
-    m_config.addConfigValue("general:succ_timeout", Hyprlang::INT{0});
+    m_config.addConfigValue("general:success_timeout", Hyprlang::INT{0});
     m_config.addConfigValue("general:fail_timeout", Hyprlang::INT{2000});
 
     m_config.addConfigValue("auth:pam:enabled", Hyprlang::INT{1});
@@ -330,9 +330,9 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "hide_input_base_color", Hyprlang::INT{0xEE00FF99});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "check_color", GRADIENTCONFIG("0xFF22CC88"));
-    m_config.addSpecialConfigValue("input-field", "succ_color", GRADIENTCONFIG("0xFF22CC88"));
+    m_config.addSpecialConfigValue("input-field", "success_color", GRADIENTCONFIG("0xFF22CC88"));
     m_config.addSpecialConfigValue("input-field", "fail_color", GRADIENTCONFIG("0xFFCC2222"));
-    m_config.addSpecialConfigValue("input-field", "succ_text", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("input-field", "success_text", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{"<i>$FAIL</i>"});
     m_config.addSpecialConfigValue("input-field", "check_text", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "capslock_color", GRADIENTCONFIG(""));
@@ -514,9 +514,9 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"hide_input_base_color", m_config.getSpecialConfigValue("input-field", "hide_input_base_color", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
                 {"check_color", m_config.getSpecialConfigValue("input-field", "check_color", k.c_str())},
-                {"succ_color", m_config.getSpecialConfigValue("input-field", "succ_color", k.c_str())},
+                {"success_color", m_config.getSpecialConfigValue("input-field", "success_color", k.c_str())},
                 {"fail_color", m_config.getSpecialConfigValue("input-field", "fail_color", k.c_str())},
-                {"succ_text", m_config.getSpecialConfigValue("input-field", "succ_text", k.c_str())},
+                {"success_text", m_config.getSpecialConfigValue("input-field", "success_text", k.c_str())},
                 {"fail_text", m_config.getSpecialConfigValue("input-field", "fail_text", k.c_str())},
                 {"check_text", m_config.getSpecialConfigValue("input-field", "check_text", k.c_str())},
                 {"capslock_color", m_config.getSpecialConfigValue("input-field", "capslock_color", k.c_str())},

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -246,6 +246,7 @@ void CConfigManager::init() {
     m_config.addConfigValue("general:immediate_render", Hyprlang::INT{0});
     m_config.addConfigValue("general:fractional_scaling", Hyprlang::INT{2});
     m_config.addConfigValue("general:screencopy_mode", Hyprlang::INT{0});
+    m_config.addConfigValue("general:succ_timeout", Hyprlang::INT{0});
     m_config.addConfigValue("general:fail_timeout", Hyprlang::INT{2000});
 
     m_config.addConfigValue("auth:pam:enabled", Hyprlang::INT{1});
@@ -329,7 +330,9 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "hide_input_base_color", Hyprlang::INT{0xEE00FF99});
     m_config.addSpecialConfigValue("input-field", "rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "check_color", GRADIENTCONFIG("0xFF22CC88"));
+    m_config.addSpecialConfigValue("input-field", "succ_color", GRADIENTCONFIG("0xFF22CC88"));
     m_config.addSpecialConfigValue("input-field", "fail_color", GRADIENTCONFIG("0xFFCC2222"));
+    m_config.addSpecialConfigValue("input-field", "succ_text", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "fail_text", Hyprlang::STRING{"<i>$FAIL</i>"});
     m_config.addSpecialConfigValue("input-field", "check_text", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("input-field", "capslock_color", GRADIENTCONFIG(""));
@@ -511,7 +514,9 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"hide_input_base_color", m_config.getSpecialConfigValue("input-field", "hide_input_base_color", k.c_str())},
                 {"rounding", m_config.getSpecialConfigValue("input-field", "rounding", k.c_str())},
                 {"check_color", m_config.getSpecialConfigValue("input-field", "check_color", k.c_str())},
+                {"succ_color", m_config.getSpecialConfigValue("input-field", "succ_color", k.c_str())},
                 {"fail_color", m_config.getSpecialConfigValue("input-field", "fail_color", k.c_str())},
+                {"succ_text", m_config.getSpecialConfigValue("input-field", "succ_text", k.c_str())},
                 {"fail_text", m_config.getSpecialConfigValue("input-field", "fail_text", k.c_str())},
                 {"check_text", m_config.getSpecialConfigValue("input-field", "check_text", k.c_str())},
                 {"capslock_color", m_config.getSpecialConfigValue("input-field", "capslock_color", k.c_str())},

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -629,6 +629,9 @@ void CHyprlock::onKey(uint32_t key, bool down) {
         return;
     }
 
+    if (g_pAuth->m_bDisplaySuccText)
+        return;
+
     if (g_pAuth->m_bDisplayFailText)
         g_pAuth->resetDisplayFail();
 

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -629,7 +629,7 @@ void CHyprlock::onKey(uint32_t key, bool down) {
         return;
     }
 
-    if (g_pAuth->m_bDisplaySuccText)
+    if (g_pAuth->m_bDisplaySuccessText)
         return;
 
     if (g_pAuth->m_bDisplayFailText)

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -49,14 +49,14 @@ void CPasswordInputField::configure(const std::unordered_map<std::string, std::a
         hiddenInputState.enabled = std::any_cast<Hyprlang::INT>(props.at("hide_input"));
         rounding                 = std::any_cast<Hyprlang::INT>(props.at("rounding"));
         configPlaceholderText    = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
-        configSuccText           = std::any_cast<Hyprlang::STRING>(props.at("succ_text"));
+        configSuccessText        = std::any_cast<Hyprlang::STRING>(props.at("success_text"));
         configFailText           = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
         configCheckText          = std::any_cast<Hyprlang::STRING>(props.at("check_text"));
         fontFamily               = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
         colorConfig.outer        = CGradientValueData::fromAnyPv(props.at("outer_color"));
         colorConfig.inner        = std::any_cast<Hyprlang::INT>(props.at("inner_color"));
         colorConfig.font         = std::any_cast<Hyprlang::INT>(props.at("font_color"));
-        colorConfig.succ         = CGradientValueData::fromAnyPv(props.at("succ_color"));
+        colorConfig.success      = CGradientValueData::fromAnyPv(props.at("success_color"));
         colorConfig.fail         = CGradientValueData::fromAnyPv(props.at("fail_color"));
         colorConfig.check        = CGradientValueData::fromAnyPv(props.at("check_color"));
         colorConfig.both         = CGradientValueData::fromAnyPv(props.at("bothlock_color"));
@@ -186,7 +186,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
 
     passwordLength = g_pHyprlock->getPasswordBufferDisplayLen();
     checkWaiting   = g_pAuth->checkWaiting();
-    displaySucc    = g_pAuth->m_bDisplaySuccText;
+    displaySuccess = g_pAuth->m_bDisplaySuccessText;
     displayFail    = g_pAuth->m_bDisplayFailText;
 
     updateFade();
@@ -351,8 +351,8 @@ void CPasswordInputField::updatePlaceholder() {
     if (displayFail) {
         newText                    = formatString(configFailText).formatted;
         placeholder.failedAttempts = g_pAuth->getFailedAttempts();
-    } else if (displaySucc && !configSuccText.empty())
-        newText = formatString(configSuccText).formatted;
+    } else if (displaySuccess && !configSuccessText.empty())
+        newText = formatString(configSuccessText).formatted;
     else if (checkWaiting && !configCheckText.empty())
         newText = formatString(configCheckText).formatted;
     else
@@ -445,8 +445,8 @@ void CPasswordInputField::updateColors() {
 
     if (checkWaiting)
         targetGrad = colorConfig.check;
-    else if (displaySucc)
-        targetGrad = colorConfig.succ;
+    else if (displaySuccess)
+        targetGrad = colorConfig.success;
     else if (displayFail && passwordLength == 0)
         targetGrad = colorConfig.fail;
 
@@ -454,8 +454,8 @@ void CPasswordInputField::updateColors() {
     CHyprColor          innerTarget = colorConfig.inner;
     CHyprColor          fontTarget  = colorConfig.font;
 
-    if (displaySucc)
-        fontTarget = colorConfig.succ->m_vColors.front();
+    if (displaySuccess)
+        fontTarget = colorConfig.success->m_vColors.front();
     else if (displayFail)
         fontTarget = colorConfig.fail->m_vColors.front();
     else if (checkWaiting)

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -49,12 +49,14 @@ void CPasswordInputField::configure(const std::unordered_map<std::string, std::a
         hiddenInputState.enabled = std::any_cast<Hyprlang::INT>(props.at("hide_input"));
         rounding                 = std::any_cast<Hyprlang::INT>(props.at("rounding"));
         configPlaceholderText    = std::any_cast<Hyprlang::STRING>(props.at("placeholder_text"));
+        configSuccText           = std::any_cast<Hyprlang::STRING>(props.at("succ_text"));
         configFailText           = std::any_cast<Hyprlang::STRING>(props.at("fail_text"));
         configCheckText          = std::any_cast<Hyprlang::STRING>(props.at("check_text"));
         fontFamily               = std::any_cast<Hyprlang::STRING>(props.at("font_family"));
         colorConfig.outer        = CGradientValueData::fromAnyPv(props.at("outer_color"));
         colorConfig.inner        = std::any_cast<Hyprlang::INT>(props.at("inner_color"));
         colorConfig.font         = std::any_cast<Hyprlang::INT>(props.at("font_color"));
+        colorConfig.succ         = CGradientValueData::fromAnyPv(props.at("succ_color"));
         colorConfig.fail         = CGradientValueData::fromAnyPv(props.at("fail_color"));
         colorConfig.check        = CGradientValueData::fromAnyPv(props.at("check_color"));
         colorConfig.both         = CGradientValueData::fromAnyPv(props.at("bothlock_color"));
@@ -184,6 +186,7 @@ bool CPasswordInputField::draw(const SRenderData& data) {
 
     passwordLength = g_pHyprlock->getPasswordBufferDisplayLen();
     checkWaiting   = g_pAuth->checkWaiting();
+    displaySucc    = g_pAuth->m_bDisplaySuccText;
     displayFail    = g_pAuth->m_bDisplayFailText;
 
     updateFade();
@@ -348,7 +351,9 @@ void CPasswordInputField::updatePlaceholder() {
     if (displayFail) {
         newText                    = formatString(configFailText).formatted;
         placeholder.failedAttempts = g_pAuth->getFailedAttempts();
-    } else if (checkWaiting && !configCheckText.empty())
+    } else if (displaySucc && !configSuccText.empty())
+        newText = formatString(configSuccText).formatted;
+    else if (checkWaiting && !configCheckText.empty())
         newText = formatString(configCheckText).formatted;
     else
         newText = formatString(configPlaceholderText).formatted;
@@ -440,6 +445,8 @@ void CPasswordInputField::updateColors() {
 
     if (checkWaiting)
         targetGrad = colorConfig.check;
+    else if (displaySucc)
+        targetGrad = colorConfig.succ;
     else if (displayFail && passwordLength == 0)
         targetGrad = colorConfig.fail;
 
@@ -447,7 +454,9 @@ void CPasswordInputField::updateColors() {
     CHyprColor          innerTarget = colorConfig.inner;
     CHyprColor          fontTarget  = colorConfig.font;
 
-    if (displayFail)
+    if (displaySucc)
+        fontTarget = colorConfig.succ->m_vColors.front();
+    else if (displayFail)
         fontTarget = colorConfig.fail->m_vColors.front();
     else if (checkWaiting)
         fontTarget = configCheckText.empty() ? colorConfig.font : colorConfig.check->m_vColors.front();

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -43,11 +43,11 @@ class CPasswordInputField : public IWidget {
     void                     updateInputState();
     void                     updateColors();
 
-    bool                     firstRender  = true;
-    bool                     redrawShadow = false;
-    bool                     checkWaiting = false;
-    bool                     displaySucc  = false;
-    bool                     displayFail  = false;
+    bool                     firstRender    = true;
+    bool                     redrawShadow   = false;
+    bool                     checkWaiting   = false;
+    bool                     displaySuccess = false;
+    bool                     displayFail    = false;
 
     size_t                   passwordLength = 0;
 
@@ -57,7 +57,7 @@ class CPasswordInputField : public IWidget {
     Vector2D                 configPos;
     Vector2D                 configSize;
 
-    std::string              halign, valign, configSuccText, configFailText, configCheckText, outputStringPort, configPlaceholderText, fontFamily;
+    std::string              halign, valign, configSuccessText, configFailText, configCheckText, outputStringPort, configPlaceholderText, fontFamily;
     uint64_t                 configFailTimeoutMs = 2000;
 
     int                      outThick, rounding;
@@ -99,12 +99,12 @@ class CPasswordInputField : public IWidget {
         CGradientValueData* outer = nullptr;
         CHyprColor          inner;
         CHyprColor          font;
-        CGradientValueData* succ  = nullptr;
-        CGradientValueData* fail  = nullptr;
-        CGradientValueData* check = nullptr;
-        CGradientValueData* caps  = nullptr;
-        CGradientValueData* num   = nullptr;
-        CGradientValueData* both  = nullptr;
+        CGradientValueData* success = nullptr;
+        CGradientValueData* fail    = nullptr;
+        CGradientValueData* check   = nullptr;
+        CGradientValueData* caps    = nullptr;
+        CGradientValueData* num     = nullptr;
+        CGradientValueData* both    = nullptr;
 
         CHyprColor          hiddenBase;
 

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -46,6 +46,7 @@ class CPasswordInputField : public IWidget {
     bool                     firstRender  = true;
     bool                     redrawShadow = false;
     bool                     checkWaiting = false;
+    bool                     displaySucc  = false;
     bool                     displayFail  = false;
 
     size_t                   passwordLength = 0;
@@ -56,7 +57,7 @@ class CPasswordInputField : public IWidget {
     Vector2D                 configPos;
     Vector2D                 configSize;
 
-    std::string              halign, valign, configFailText, configCheckText, outputStringPort, configPlaceholderText, fontFamily;
+    std::string              halign, valign, configSuccText, configFailText, configCheckText, outputStringPort, configPlaceholderText, fontFamily;
     uint64_t                 configFailTimeoutMs = 2000;
 
     int                      outThick, rounding;
@@ -98,6 +99,7 @@ class CPasswordInputField : public IWidget {
         CGradientValueData* outer = nullptr;
         CHyprColor          inner;
         CHyprColor          font;
+        CGradientValueData* succ  = nullptr;
         CGradientValueData* fail  = nullptr;
         CGradientValueData* check = nullptr;
         CGradientValueData* caps  = nullptr;


### PR DESCRIPTION
Introduce `input-field:success_text`, `input-field:success_color`, and `general:success_timeout` to provide visual confirmation after successful authentication.

- Added `general:success_timeout` (default 0) to delay unlocking.
- Added `input-field:success_text` and `input-field:success_color` for custom feedback.