### PR TITLE
screencopy: flip the right 10bit formats

### DIFF
--- a/src/renderer/Screencopy.cpp
+++ b/src/renderer/Screencopy.cpp
@@ -373,7 +373,7 @@ void CSCSHMFrame::convertBuffer() {
                 Log::logger->log(Log::INFO, "[sc] [shm] Converting 10-bit channels to 8-bit");
                 uint8_t*   data = (uint8_t*)m_shmData;
 
-                const bool FLIP = m_shmFmt != WL_SHM_FORMAT_XBGR2101010;
+                const bool FLIP = m_shmFmt == WL_SHM_FORMAT_XRGB2101010 || m_shmFmt == WL_SHM_FORMAT_ARGB2101010;
 
                 for (uint32_t y = 0; y < m_h; ++y) {
                     for (uint32_t x = 0; x < m_w; ++x) {


### PR DESCRIPTION
seems the flip logic was flipping wrong formats
flip the right ones to fix red/blue swap on 10bit formats.

im not entirerly sure here asked AI even, seems very convulated flipping logic. but fixed the red/blue color swap on 10bit formats in hyprland when using screencopy_force_8b = false.