### PR TITLE
fingerprint: make hardcoded messages configurable

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -21,6 +21,16 @@ general {
 #         enabled = true
 #         ready_message = Scan fingerprint to unlock
 #         present_message = Scanning...
+#         retry_scan_message = Please retry fingerprint scan
+#         swipe_too_short_message = Swipe too short - try again
+#         finger_not_centered_message = Finger not centered - try again
+#         remove_and_retry_message = Remove your finger and try again
+#         no_match_retry_message = Could not match fingerprint. Try again.
+#         no_match_fail_message = Fingerprint did not match
+#         too_many_attempts_message = Fingerprint auth disabled (too many failed attempts)
+#         unknown_error_message = Fingerprint auth disabled (unknown error)
+#         failed_to_restart_message = Fingerprint auth disabled (failed to restart)
+#         device_disconnected_message = Fingerprint device disconnected
 #         retry_delay = 250 # in milliseconds
 #     }
 # }

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -37,10 +37,30 @@ static std::map<std::string, MatchResult> s_mapStringToTestType = {{"verify-no-m
                                                                    {"verify-unknown-error", MATCH_UNKNOWN_ERROR}};
 
 CFingerprint::CFingerprint() {
-    static const auto FINGERPRINTREADY   = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:ready_message");
-    m_sFingerprintReady                  = *FINGERPRINTREADY;
-    static const auto FINGERPRINTPRESENT = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:present_message");
-    m_sFingerprintPresent                = *FINGERPRINTPRESENT;
+    static const auto FINGERPRINTREADY               = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:ready_message");
+    static const auto FINGERPRINTPRESENT             = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:present_message");
+    static const auto FINGERPRINTRETRYSCAN           = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:retry_scan_message");
+    static const auto FINGERPRINTSWIPETOOSHORT       = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:swipe_too_short_message");
+    static const auto FINGERPRINTFINGERNOTCENTERED   = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:finger_not_centered_message");
+    static const auto FINGERPRINTREMOVEANDRETRY      = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:remove_and_retry_message");
+    static const auto FINGERPRINTNOMATCHRETRY        = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:no_match_retry_message");
+    static const auto FINGERPRINTNOMATCHFAIL         = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:no_match_fail_message");
+    static const auto FINGERPRINTTOOMANYATTEMPTS     = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:too_many_attempts_message");
+    static const auto FINGERPRINTUNKNOWNERROR        = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:unknown_error_message");
+    static const auto FINGERPRINTFAILEDTORESTART     = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:failed_to_restart_message");
+    static const auto FINGERPRINTDEVICEDISCONNECTED  = g_pConfigManager->getValue<Hyprlang::STRING>("auth:fingerprint:device_disconnected_message");
+    m_sFingerprintReady                              = *FINGERPRINTREADY;
+    m_sFingerprintPresent                            = *FINGERPRINTPRESENT;
+    m_sFingerprintRetryScan                          = *FINGERPRINTRETRYSCAN;
+    m_sFingerprintSwipeTooShort                      = *FINGERPRINTSWIPETOOSHORT;
+    m_sFingerprintFingerNotCentered                  = *FINGERPRINTFINGERNOTCENTERED;
+    m_sFingerprintRemoveAndRetry                     = *FINGERPRINTREMOVEANDRETRY;
+    m_sFingerprintNoMatchRetry                       = *FINGERPRINTNOMATCHRETRY;
+    m_sFingerprintNoMatchFail                        = *FINGERPRINTNOMATCHFAIL;
+    m_sFingerprintTooManyAttempts                    = *FINGERPRINTTOOMANYATTEMPTS;
+    m_sFingerprintUnknownError                       = *FINGERPRINTUNKNOWNERROR;
+    m_sFingerprintFailedToRestart                    = *FINGERPRINTFAILEDTORESTART;
+    m_sFingerprintDeviceDisconnected                 = *FINGERPRINTDEVICEDISCONNECTED;
 }
 
 CFingerprint::~CFingerprint() {
@@ -153,17 +173,17 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
         case MATCH_NO_MATCH:
             stopVerify();
             if (m_sDBUSState.retries >= 3) {
-                m_sFailureReason = "Fingerprint auth disabled (too many failed attempts)";
+                m_sFailureReason = m_sFingerprintTooManyAttempts;
             } else {
                 done                         = false;
                 static const auto RETRYDELAY = g_pConfigManager->getValue<Hyprlang::INT>("auth:fingerprint:retry_delay");
                 g_pHyprlock->addTimer(std::chrono::milliseconds(*RETRYDELAY), [](ASP<CTimer> self, void* data) { ((CFingerprint*)data)->startVerify(true); }, this);
-                m_sFailureReason = "Fingerprint did not match";
+                m_sFailureReason = m_sFingerprintNoMatchFail;
             }
             break;
         case MATCH_UNKNOWN_ERROR:
             stopVerify();
-            m_sFailureReason = "Fingerprint auth disabled (unknown error)";
+            m_sFailureReason = m_sFingerprintUnknownError;
             break;
         case MATCH_MATCHED:
             stopVerify();
@@ -172,22 +192,22 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
             break;
         case MATCH_RETRY:
             retry     = true;
-            m_sPrompt = "Please retry fingerprint scan";
+            m_sPrompt = m_sFingerprintRetryScan;
             break;
         case MATCH_SWIPE_TOO_SHORT:
             retry     = true;
-            m_sPrompt = "Swipe too short - try again";
+            m_sPrompt = m_sFingerprintSwipeTooShort;
             break;
         case MATCH_FINGER_NOT_CENTERED:
             retry     = true;
-            m_sPrompt = "Finger not centered - try again";
+            m_sPrompt = m_sFingerprintFingerNotCentered;
             break;
         case MATCH_REMOVE_AND_RETRY:
             retry     = true;
-            m_sPrompt = "Remove your finger and try again";
+            m_sPrompt = m_sFingerprintRemoveAndRetry;
             break;
         case MATCH_DISCONNECTED:
-            m_sFailureReason   = "Fingerprint device disconnected";
+            m_sFailureReason   = m_sFingerprintDeviceDisconnected;
             m_sDBUSState.abort = true;
             break;
     }
@@ -227,13 +247,13 @@ void CFingerprint::startVerify(bool isRetry) {
         if (e) {
             Log::logger->log(Log::WARN, "fprint: could not start verifying, {}", e->what());
             if (isRetry)
-                m_sFailureReason = "Fingerprint auth disabled (failed to restart)";
+                m_sFailureReason = m_sFingerprintFailedToRestart;
 
         } else {
             Log::logger->log(Log::INFO, "fprint: started verifying");
             if (isRetry) {
                 m_sDBUSState.retries++;
-                m_sPrompt = "Could not match fingerprint. Try again.";
+                m_sPrompt = m_sFingerprintNoMatchRetry;
             } else
                 m_sPrompt = m_sFingerprintReady;
         }

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -35,6 +35,16 @@ class CFingerprint : public IAuthImplementation {
 
     std::string m_sFingerprintReady;
     std::string m_sFingerprintPresent;
+    std::string m_sFingerprintRetryScan;
+    std::string m_sFingerprintSwipeTooShort;
+    std::string m_sFingerprintFingerNotCentered;
+    std::string m_sFingerprintRemoveAndRetry;
+    std::string m_sFingerprintNoMatchRetry;
+    std::string m_sFingerprintNoMatchFail;
+    std::string m_sFingerprintTooManyAttempts;
+    std::string m_sFingerprintUnknownError;
+    std::string m_sFingerprintFailedToRestart;
+    std::string m_sFingerprintDeviceDisconnected;
 
     std::string m_sPrompt{""};
     std::string m_sFailureReason{""};

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -253,6 +253,16 @@ void CConfigManager::init() {
     m_config.addConfigValue("auth:fingerprint:enabled", Hyprlang::INT{0});
     m_config.addConfigValue("auth:fingerprint:ready_message", Hyprlang::STRING{"(Scan fingerprint to unlock)"});
     m_config.addConfigValue("auth:fingerprint:present_message", Hyprlang::STRING{"Scanning fingerprint"});
+    m_config.addConfigValue("auth:fingerprint:retry_scan_message", Hyprlang::STRING{"Please retry fingerprint scan"});
+    m_config.addConfigValue("auth:fingerprint:swipe_too_short_message", Hyprlang::STRING{"Swipe too short - try again"});
+    m_config.addConfigValue("auth:fingerprint:finger_not_centered_message", Hyprlang::STRING{"Finger not centered - try again"});
+    m_config.addConfigValue("auth:fingerprint:remove_and_retry_message", Hyprlang::STRING{"Remove your finger and try again"});
+    m_config.addConfigValue("auth:fingerprint:no_match_retry_message", Hyprlang::STRING{"Could not match fingerprint. Try again."});
+    m_config.addConfigValue("auth:fingerprint:no_match_fail_message", Hyprlang::STRING{"Fingerprint did not match"});
+    m_config.addConfigValue("auth:fingerprint:too_many_attempts_message", Hyprlang::STRING{"Fingerprint auth disabled (too many failed attempts)"});
+    m_config.addConfigValue("auth:fingerprint:unknown_error_message", Hyprlang::STRING{"Fingerprint auth disabled (unknown error)"});
+    m_config.addConfigValue("auth:fingerprint:failed_to_restart_message", Hyprlang::STRING{"Fingerprint auth disabled (failed to restart)"});
+    m_config.addConfigValue("auth:fingerprint:device_disconnected_message", Hyprlang::STRING{"Fingerprint device disconnected"});
     m_config.addConfigValue("auth:fingerprint:retry_delay", Hyprlang::INT{250});
 
     m_config.addConfigValue("animations:enabled", Hyprlang::INT{1});


### PR DESCRIPTION
Makes the remaining fingerprint messages configurable under `auth:fingerprint`.

`ready_message` and `present_message` were already configurable, but retry/failure messages like `Could not match fingerprint. Try again.` and `Fingerprint auth disabled (unknown error)` were still hardcoded.

This adds config options for 10 more fingerprint messages. The existing strings are kept as defaults, so behavior is unchanged unless users override them.

AI disclosure:
I used a clanker to write this
