### PR TITLE
output: create session lock surface before mode commit

### DIFF
--- a/src/core/LockSurface.cpp
+++ b/src/core/LockSurface.cpp
@@ -66,6 +66,15 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
     logicalSize  = size_;
     appliedScale = fractionalScale;
 
+    if (!SAMESERIAL)
+        lockSurface->sendAckConfigure(serial);
+
+    if (size_.x <= 0 || size_.y <= 0) {
+        Log::logger->log(Log::WARN, "output {} configure with zero size, waiting for valid configure", m_outputID);
+        readyForFrame = false;
+        return;
+    }
+
     if (fractional) {
         size = (size_ * fractionalScale).floor();
         viewport->sendSetDestination(logicalSize.x, logicalSize.y);
@@ -74,9 +83,6 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
         size = size_ * POUTPUT->scale;
         surface->sendSetBufferScale(POUTPUT->scale);
     }
-
-    if (!SAMESERIAL)
-        lockSurface->sendAckConfigure(serial);
 
     Log::logger->log(Log::INFO, "Configuring surface for logical {} and pixel {}", logicalSize, size);
 
@@ -92,7 +98,7 @@ void CSessionLockSurface::configure(const Vector2D& size_, uint32_t serial_) {
         eglWindow = wl_egl_window_create((wl_surface*)surface->resource(), size.x, size.y);
         if (!eglWindow) {
             // Only fails when unable to allocate the wl_egl_window structure or size x or y is <= 0.
-            Log::logger->log(Log::CRIT, "Failed to create wayland egl window");
+            Log::logger->log(Log::WARN, "Failed to create wayland egl window (size {}x{}), waiting for valid configure", size.x, size.y);
             readyForFrame = false;
             return;
         }

--- a/src/core/Output.cpp
+++ b/src/core/Output.cpp
@@ -56,11 +56,6 @@ void COutput::createSessionLockSurface() {
         return;
     }
 
-    if (size == Vector2D{0, 0}) {
-        Log::logger->log(Log::WARN, "output {} refusing to create a lock surface with size 0x0", m_ID);
-        return;
-    }
-
     m_sessionLockSurface = makeUnique<CSessionLockSurface>(m_self.lock());
 }
 


### PR DESCRIPTION
Ran into this while connecting my dock after a suspend with the screen locked. The external monitors showed the lockdead texture briefly instead of the lock screen, which looked like the session had unlocked.

When a new output appears during resume, Hyprland registers the wl_output global at size {0, 0} while the DRM session is still inactive. Commits fail until the session activates, so the output enters the global registry with no valid mode. The size guard in `createSessionLockSurface()` bailed out in that state and left `m_sessionLockSurface` null.

Once the session activated and the real mode landed, `wl_output.done` arrived and the `setDone` handler created the surface. But then hyprlock had to go through `get_lock_surface`, wait for Hyprland to respond with `configure`, and only then render. The lockdead fallback texture was visible for the whole duration of that extra wait.

The actual fix is simpler than it sounds. Hyprland registers a `monitorMode` listener on `SSessionLockSurface` when it receives `get_lock_surface`. If the surface exists before the mode change, `modeChanged` fires `sendConfigure()` directly without needing another full exchange. Creating the surface upfront is all that is needed.

Here is what the Hyprland log looked like during the bad resume:

```
Session got deactivated!
drm: Connector DP-3 connected
Monitor DP-3 has NO FALLBACK MODES, and an INVALID one was requested: 2560x1440@59.95Hz
Added new monitor with name DP-3 at [-1, -1] with size [0, 0]
[IWaylandProtocol] Registered global [WLOutput (DP-3)]
...
Session got activated!
Monitor DP-3: requested 2560x1440@59.95Hz, using preferred mode 2560x1440@59.95Hz
drm: Modesetting DP-3 with 2560x1440@59.95Hz
```

Remove the size guard and move the handling into `configure()` instead. Ack the serial first, then return early if the size is not positive. That avoids a `wp_viewport.set_destination(0, 0)` protocol error and a zero dimension `wl_egl_window_create()` call, both of which would have crashed or killed the connection if we had let them through.