### PR TITLE
core: move dbus connection from fprint to it's own thing

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -55,7 +55,7 @@ input-field {
 
     font_family = $font
     placeholder_text = Input password...
-    fail_text = $PAMFAIL
+    fail_text = $PAMFAIL$FPRINTFAIL
 
     # uncomment if you wish to display a message during authentication
     # check_text = Authenticating...

--- a/src/auth/Auth.cpp
+++ b/src/auth/Auth.cpp
@@ -61,15 +61,6 @@ size_t CAuth::getFailedAttempts() {
     return m_sCurrentFail.failedAttempts;
 }
 
-SP<IAuthImplementation> CAuth::getImpl(eAuthImplementations implType) {
-    for (const auto& i : m_vImpls) {
-        if (i->getImplType() == implType)
-            return i;
-    }
-
-    return nullptr;
-}
-
 void CAuth::terminate() {
     for (const auto& i : m_vImpls) {
         i->terminate();

--- a/src/auth/Auth.hpp
+++ b/src/auth/Auth.hpp
@@ -41,8 +41,6 @@ class CAuth {
     std::optional<std::string> getPrompt(eAuthImplementations implType);
     size_t                     getFailedAttempts();
 
-    SP<IAuthImplementation>    getImpl(eAuthImplementations implType);
-
     void                       terminate();
 
     void                       enqueueUnlock();

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -1,5 +1,6 @@
 #include "Fingerprint.hpp"
 #include "../core/hyprlock.hpp"
+#include "../core/Dbus.hpp"
 #include "../helpers/Log.hpp"
 #include "../config/ConfigManager.hpp"
 
@@ -47,27 +48,27 @@ CFingerprint::~CFingerprint() {
 }
 
 void CFingerprint::init() {
-    try {
-        m_sDBUSState.connection = sdbus::createSystemBusConnection();
-        m_sDBUSState.login      = sdbus::createProxy(*m_sDBUSState.connection, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});
-    } catch (sdbus::Error& e) {
-        Log::logger->log(Log::ERR, "fprint: Failed to setup dbus ({})", e.what());
-        m_sDBUSState.connection.reset();
+    if (!g_dbus->m_connection || !g_dbus->m_freedesktopLogin1) {
+        Log::logger->log(Log::ERR, "fprint: Missing dbus proxy?");
         return;
     }
 
-    m_sDBUSState.login->getPropertyAsync("PreparingForSleep").onInterface(LOGIN_MANAGER).uponReplyInvoke([this](std::optional<sdbus::Error> e, sdbus::Variant preparingForSleep) {
-        if (e) {
-            Log::logger->log(Log::WARN, "fprint: Failed getting value for PreparingForSleep: {}", e->what());
-            return;
-        }
-        m_sDBUSState.sleeping = preparingForSleep.get<bool>();
-        // When entering sleep, the wake signal will trigger startVerify().
-        if (m_sDBUSState.sleeping)
-            return;
-        startVerify();
-    });
-    m_sDBUSState.login->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
+    g_dbus->m_freedesktopLogin1->getPropertyAsync("PreparingForSleep")
+        .onInterface(LOGIN_MANAGER)
+        .uponReplyInvoke([this](std::optional<sdbus::Error> e, sdbus::Variant preparingForSleep) {
+            if (e) {
+                Log::logger->log(Log::WARN, "fprint: Failed getting value for PreparingForSleep: {}", e->what());
+                return;
+            }
+            m_sDBUSState.sleeping = preparingForSleep.get<bool>();
+            // When entering sleep, the wake signal will trigger startVerify().
+            if (m_sDBUSState.sleeping)
+                return;
+
+            startVerify();
+        });
+
+    g_dbus->m_freedesktopLogin1->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
         Log::logger->log(Log::INFO, "fprint: PrepareForSleep (start: {})", start);
         m_sDBUSState.sleeping = start;
         if (!m_sDBUSState.sleeping && !m_sDBUSState.verifying)
@@ -100,12 +101,8 @@ void CFingerprint::terminate() {
         releaseDevice();
 }
 
-std::shared_ptr<sdbus::IConnection> CFingerprint::getConnection() {
-    return m_sDBUSState.connection;
-}
-
 bool CFingerprint::createDeviceProxy() {
-    auto              proxy = sdbus::createProxy(*m_sDBUSState.connection, FPRINT, sdbus::ObjectPath{"/net/reactivated/Fprint/Manager"});
+    auto              proxy = sdbus::createProxy(*g_dbus->m_connection, FPRINT, sdbus::ObjectPath{"/net/reactivated/Fprint/Manager"});
 
     sdbus::ObjectPath path;
     try {
@@ -115,7 +112,7 @@ bool CFingerprint::createDeviceProxy() {
         return false;
     }
     Log::logger->log(Log::INFO, "fprint: using device path {}", path.c_str());
-    m_sDBUSState.device = sdbus::createProxy(*m_sDBUSState.connection, FPRINT, path);
+    m_sDBUSState.device = sdbus::createProxy(*g_dbus->m_connection, FPRINT, path);
 
     m_sDBUSState.device->uponSignal("VerifyFingerSelected").onInterface(DEVICE).call([](const std::string& finger) {
         Log::logger->log(Log::INFO, "fprint: finger selected: {}", finger);
@@ -265,8 +262,11 @@ bool CFingerprint::releaseDevice() {
         m_sDBUSState.device->callMethod("Release").onInterface(DEVICE);
     } catch (sdbus::Error& e) {
         Log::logger->log(Log::WARN, "fprint: could not release device, {}", e.what());
+        m_sDBUSState.device.reset();
         return false;
     }
+
+    m_sDBUSState.device.reset();
     Log::logger->log(Log::INFO, "fprint: released device");
     return true;
 }

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -15,26 +15,22 @@ class CFingerprint : public IAuthImplementation {
     virtual eAuthImplementations getImplType() {
         return AUTH_IMPL_FINGERPRINT;
     }
-    virtual void                        init();
-    virtual void                        handleInput(const std::string& input);
-    virtual bool                        checkWaiting();
-    virtual std::optional<std::string>  getLastFailText();
-    virtual std::optional<std::string>  getLastPrompt();
-    virtual void                        terminate();
-
-    std::shared_ptr<sdbus::IConnection> getConnection();
+    virtual void                       init();
+    virtual void                       handleInput(const std::string& input);
+    virtual bool                       checkWaiting();
+    virtual std::optional<std::string> getLastFailText();
+    virtual std::optional<std::string> getLastPrompt();
+    virtual void                       terminate();
 
   private:
     struct SDBUSState {
-        std::shared_ptr<sdbus::IConnection> connection;
-        std::unique_ptr<sdbus::IProxy>      login;
-        std::unique_ptr<sdbus::IProxy>      device;
+        std::unique_ptr<sdbus::IProxy> device;
 
-        bool                                abort     = false;
-        bool                                done      = false;
-        int                                 retries   = 0;
-        bool                                sleeping  = false;
-        bool                                verifying = false;
+        bool                           abort     = false;
+        bool                           done      = false;
+        int                            retries   = 0;
+        bool                           sleeping  = false;
+        bool                           verifying = false;
     } m_sDBUSState;
 
     std::string m_sFingerprintReady;

--- a/src/auth/Pam.cpp
+++ b/src/auth/Pam.cpp
@@ -51,8 +51,8 @@ int conv(int num_msg, const struct pam_message** msg, struct pam_response** resp
                 if (MSG.contains("left to unlock")) {
                     CONVERSATIONSTATE->failText        = MSG;
                     CONVERSATIONSTATE->failTextFromPam = true;
-                // This log targets the pam_fprintd.so module (Just so $PAMPROMPT reflects what is going on)
-                // Removing this module and instead using `auth:fingerprint:enabled = true` is adviced.
+                    // This log targets the pam_fprintd.so module (Just so $PAMPROMPT reflects what is going on)
+                    // Removing this module and instead using `auth:fingerprint:enabled = true` is adviced.
                 } else if (MSG.contains("Place your finger"))
                     CONVERSATIONSTATE->prompt = MSG;
             } break;

--- a/src/core/Dbus.cpp
+++ b/src/core/Dbus.cpp
@@ -1,0 +1,15 @@
+#include "Dbus.hpp"
+#include "../helpers/Log.hpp"
+
+CDbus::CDbus(bool enable) {
+    if (!enable)
+        return;
+    try {
+        m_connection        = sdbus::createSystemBusConnection();
+        m_freedesktopLogin1 = sdbus::createProxy(*m_connection, sdbus::ServiceName{"org.freedesktop.login1"}, sdbus::ObjectPath{"/org/freedesktop/login1"});
+    } catch (sdbus::Error& e) {
+        Log::logger->log(Log::ERR, "dbus: failed to create connection or login proxy ({})", e.what());
+        m_freedesktopLogin1.reset();
+        m_connection.reset();
+    }
+}

--- a/src/core/Dbus.hpp
+++ b/src/core/Dbus.hpp
@@ -1,0 +1,16 @@
+#include <sdbus-c++/sdbus-c++.h>
+#include <memory>
+
+#include "../defines.hpp"
+
+class CDbus {
+  public:
+    CDbus(bool enable);
+    ~CDbus() = default;
+
+    // nullptr if enable is false
+    std::shared_ptr<sdbus::IConnection> m_connection        = nullptr;
+    std::unique_ptr<sdbus::IProxy>      m_freedesktopLogin1 = nullptr;
+};
+
+inline UP<CDbus> g_dbus;

--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -5,6 +5,7 @@
 #include "../renderer/AsyncResourceManager.hpp"
 #include "../auth/Auth.hpp"
 #include "../auth/Fingerprint.hpp"
+#include "./Dbus.hpp"
 #include "./Egl.hpp"
 #include "./Seat.hpp"
 #include <chrono>
@@ -74,6 +75,9 @@ CHyprlock::CHyprlock(std::string_view wlDisplay, const bool immediateRender, con
     const auto CURRENTDESKTOP = getenv("XDG_CURRENT_DESKTOP");
     const auto SZCURRENTD     = std::string{CURRENTDESKTOP ? CURRENTDESKTOP : ""};
     m_sCurrentDesktop         = SZCURRENTD;
+
+    static const auto ENABLEFINGERPRINT = g_pConfigManager->getValue<Hyprlang::INT>("auth:fingerprint:enabled");
+    g_dbus                              = makeUnique<CDbus>(*ENABLEFINGERPRINT);
 }
 
 CHyprlock::~CHyprlock() {
@@ -375,9 +379,6 @@ void CHyprlock::run() {
         exit(1);
     }
 
-    const auto fingerprintAuth = g_pAuth->getImpl(AUTH_IMPL_FINGERPRINT);
-    const auto dbusConn        = (fingerprintAuth) ? ((CFingerprint*)fingerprintAuth.get())->getConnection() : nullptr;
-
     registerSignalAction(SIGUSR1, handleUnlockSignal, SA_RESTART);
     registerSignalAction(SIGUSR2, handleForceUpdateSignal);
     registerSignalAction(SIGRTMIN, handlePollTerminate);
@@ -387,13 +388,13 @@ void CHyprlock::run() {
         .fd     = wl_display_get_fd(m_sWaylandState.display),
         .events = POLLIN,
     };
-    if (dbusConn) {
+    if (g_dbus->m_connection) {
         pollfds[1] = {
-            .fd     = dbusConn->getEventLoopPollData().fd,
+            .fd     = g_dbus->m_connection->getEventLoopPollData().fd,
             .events = POLLIN,
         };
     }
-    size_t      fdcount = dbusConn ? 2 : 1;
+    size_t      fdcount = g_dbus->m_connection ? 2 : 1;
 
     std::thread pollThr([this, &pollfds, fdcount]() {
         while (!m_bTerminate) {
@@ -475,7 +476,7 @@ void CHyprlock::run() {
         m_sLoopState.wlDispatchCV.notify_all();
 
         if (pollfds[1].revents & POLLIN /* dbus */) {
-            while (dbusConn && dbusConn->processPendingEvent()) {
+            while (g_dbus->m_connection && g_dbus->m_connection->processPendingEvent()) {
                 ;
             }
         }
@@ -509,6 +510,8 @@ void CHyprlock::run() {
     g_pEGL.reset();
 
     wl_display_disconnect(DPY);
+
+    g_dbus.reset();
 
     Log::logger->log(Log::INFO, "Reached the end, exiting");
 }


### PR DESCRIPTION
Move the dbus connection out of the fingerprint implementation.
This will probably be useful for future work. Also it's nicer, because it's integrated into the eventloop and that way we don't have to pull out the fprint implementation and use it to get the connection. 