### PR TITLE
feat: allow attaching a custom fragment shader to any widget

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -240,6 +240,8 @@ void CConfigManager::init() {
 
 #define CLICKABLE(name) m_config.addSpecialConfigValue(name, "onclick", Hyprlang::STRING{""});
 
+#define SHADERABLE(name) m_config.addSpecialConfigValue(name, "attach_shader", Hyprlang::STRING{""});
+
     m_config.addConfigValue("general:text_trim", Hyprlang::INT{1});
     m_config.addConfigValue("general:hide_cursor", Hyprlang::INT{0});
     m_config.addConfigValue("general:ignore_empty_input", Hyprlang::INT{0});
@@ -272,6 +274,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("background", "reload_time", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("background", "reload_cmd", Hyprlang::STRING{""});
     m_config.addSpecialConfigValue("background", "crossfade_time", Hyprlang::FLOAT{-1.0});
+    SHADERABLE("background");
 
     m_config.addSpecialCategory("shape", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("shape", "monitor", Hyprlang::STRING{""});
@@ -288,6 +291,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("shape", "zindex", Hyprlang::INT{0});
     SHADOWABLE("shape");
     CLICKABLE("shape");
+    SHADERABLE("shape");
 
     m_config.addSpecialCategory("image", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("image", "monitor", Hyprlang::STRING{""});
@@ -305,6 +309,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("image", "zindex", Hyprlang::INT{0});
     SHADOWABLE("image");
     CLICKABLE("image");
+    SHADERABLE("image");
 
     m_config.addSpecialCategory("input-field", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("input-field", "monitor", Hyprlang::STRING{""});
@@ -339,6 +344,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "swap_font_color", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "zindex", Hyprlang::INT{0});
     SHADOWABLE("input-field");
+    SHADERABLE("input-field");
 
     m_config.addSpecialCategory("label", Hyprlang::SSpecialCategoryOptions{.key = nullptr, .anonymousKeyBased = true});
     m_config.addSpecialConfigValue("label", "monitor", Hyprlang::STRING{""});
@@ -354,6 +360,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("label", "zindex", Hyprlang::INT{0});
     SHADOWABLE("label");
     CLICKABLE("label");
+    SHADERABLE("label");
 
     m_config.registerHandler(&::handleSource, "source", {.allowFlags = false});
     m_config.registerHandler(&::handleBezier, "bezier", {.allowFlags = false});
@@ -400,8 +407,10 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
     {"shadow_size", m_config.getSpecialConfigValue(name, "shadow_size", k.c_str())}, {"shadow_passes", m_config.getSpecialConfigValue(name, "shadow_passes", k.c_str())},          \
         {"shadow_color", m_config.getSpecialConfigValue(name, "shadow_color", k.c_str())}, {"shadow_boost", m_config.getSpecialConfigValue(name, "shadow_boost", k.c_str())}
 
-#define CLICKABLE(name)                                                                                                                                                            \
-    { "onclick", m_config.getSpecialConfigValue(name, "onclick", k.c_str()) }
+#define CLICKABLE(name) {"onclick", m_config.getSpecialConfigValue(name, "onclick", k.c_str())}
+
+#define SHADERABLE_VAL(name)                                                                                                                                                       \
+    { "attach_shader", m_config.getSpecialConfigValue(name, "attach_shader", k.c_str()) }
 
     //
     auto keys = m_config.listKeysForSpecialCategory("background");
@@ -425,6 +434,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"reload_time", m_config.getSpecialConfigValue("background", "reload_time", k.c_str())},
                 {"reload_cmd", m_config.getSpecialConfigValue("background", "reload_cmd", k.c_str())},
                 {"crossfade_time", m_config.getSpecialConfigValue("background", "crossfade_time", k.c_str())},
+                SHADERABLE_VAL("background"),
             }
         });
         // clang-format on
@@ -451,6 +461,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"zindex", m_config.getSpecialConfigValue("shape", "zindex", k.c_str())},
                 SHADOWABLE("shape"),
                 CLICKABLE("shape"),
+                SHADERABLE_VAL("shape"),
             }
         });
         // clang-format on
@@ -478,6 +489,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"zindex", m_config.getSpecialConfigValue("image", "zindex", k.c_str())},
                 SHADOWABLE("image"),
                 CLICKABLE("image"),
+                SHADERABLE_VAL("image"),
             }
         });
         // clang-format on
@@ -521,6 +533,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"swap_font_color", m_config.getSpecialConfigValue("input-field", "swap_font_color", k.c_str())},
                 {"zindex", m_config.getSpecialConfigValue("input-field", "zindex", k.c_str())},
                 SHADOWABLE("input-field"),
+                SHADERABLE_VAL("input-field"),
             }
         });
         // clang-format on
@@ -545,6 +558,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"zindex", m_config.getSpecialConfigValue("label", "zindex", k.c_str())},
                 SHADOWABLE("label"),
                 CLICKABLE("label"),
+                SHADERABLE_VAL("label"),
             }
         });
         // clang-format on

--- a/src/renderer/Renderer.cpp
+++ b/src/renderer/Renderer.cpp
@@ -76,6 +76,8 @@ static void glMessageCallbackA(GLenum source, GLenum type, GLuint id, GLenum sev
 }
 
 CRenderer::CRenderer() {
+    firstFullFrameTime = std::chrono::system_clock::now();
+
     g_pEGL->makeCurrent(nullptr);
 
     glEnable(GL_DEBUG_OUTPUT);
@@ -219,7 +221,28 @@ CRenderer::SRenderFeedback CRenderer::renderLock(const CSessionLockSurface& surf
     // render widgets
     const auto WIDGETS = getOrCreateWidgetsFor(surf);
     for (auto& w : WIDGETS) {
-        feedback.needsFrame = w->draw({opacity->value()}) || feedback.needsFrame;
+        if (w->hasCustomShader && w->customShader.program != 0) {
+            if (!w->customFB.isAllocated() || w->customFB.m_vSize != w->viewport) {
+                w->customFB.alloc(w->viewport.x, w->viewport.y, true);
+            }
+
+            pushFb(w->customFB.m_iFb);
+
+            glClearColor(0.0, 0.0, 0.0, 0.0);
+            glClear(GL_COLOR_BUFFER_BIT);
+
+            bool needsFrame = w->draw({opacity->value()});
+
+            popFb();
+
+            CBox viewportBox = {0, 0, w->viewport.x, w->viewport.y};
+            renderTextureWithShader(viewportBox, w->customFB.m_cTex, w->customShader, opacity->value(), 0, HYPRUTILS_TRANSFORM_NORMAL);
+
+            bool hasTime = w->hasTime;
+            feedback.needsFrame = hasTime || needsFrame || feedback.needsFrame;
+        } else {
+            feedback.needsFrame = w->draw({opacity->value()}) || feedback.needsFrame;
+        }
     }
 
     glDisable(GL_BLEND);
@@ -334,6 +357,44 @@ void CRenderer::renderTexture(const CBox& box, const CTexture& tex, float a, int
     glBindTexture(tex.m_iTarget, 0);
 }
 
+void CRenderer::renderTextureWithShader(const CBox& box, const CTexture& tex, CShader& shader, float a, int rounding, std::optional<eTransform> tr) {
+    const auto ROUNDEDBOX = box.copy().round();
+    Mat3x3     matrix     = projMatrix.projectBox(ROUNDEDBOX, tr.value_or(HYPRUTILS_TRANSFORM_FLIPPED_180), box.rot);
+    Mat3x3     glMatrix   = projection.copy().multiply(matrix);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(tex.m_iTarget, tex.m_iTexID);
+
+    glUseProgram(shader.program);
+
+    glUniformMatrix3fv(shader.proj, 1, GL_TRUE, glMatrix.getMatrix().data());
+    glUniform1i(shader.tex, 0);
+    glUniform1f(shader.alpha, a);
+
+    // Set standard time and resolution uniforms if they exist in the custom shader
+    float elapsed = std::chrono::duration<float>(std::chrono::system_clock::now() - firstFullFrameTime).count();
+    GLint timeLoc = shader.getUniformLocation("time");
+    if (timeLoc != -1)
+        glUniform1f(timeLoc, elapsed);
+
+    GLint resLoc = shader.getUniformLocation("resolution");
+    if (resLoc != -1)
+        glUniform2f(resLoc, ROUNDEDBOX.width, ROUNDEDBOX.height);
+
+    glVertexAttribPointer(shader.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
+    glVertexAttribPointer(shader.texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
+
+    glEnableVertexAttribArray(shader.posAttrib);
+    glEnableVertexAttribArray(shader.texAttrib);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    glDisableVertexAttribArray(shader.posAttrib);
+    glDisableVertexAttribArray(shader.texAttrib);
+
+    glBindTexture(tex.m_iTarget, 0);
+}
+
 void CRenderer::renderTextureMix(const CBox& box, const CTexture& tex, const CTexture& tex2, float a, float mixFactor, int rounding, std::optional<eTransform> tr) {
     const auto ROUNDEDBOX = box.copy().round();
     Mat3x3     matrix     = projMatrix.projectBox(ROUNDEDBOX, tr.value_or(HYPRUTILS_TRANSFORM_FLIPPED_180), box.rot);
@@ -418,7 +479,15 @@ std::vector<ASP<IWidget>>& CRenderer::getOrCreateWidgetsFor(const CSessionLockSu
                 continue;
             }
 
-            widgets[surf.m_outputID].back()->configure(c.values, POUTPUT);
+            auto& w = widgets[surf.m_outputID].back();
+            w->viewport = POUTPUT->getViewport();
+            if (c.values.contains("attach_shader")) {
+                w->shaderPath = std::any_cast<Hyprlang::STRING>(c.values.at("attach_shader"));
+                if (!w->shaderPath.empty()) {
+                    w->compileCustomShader();
+                }
+            }
+            w->configure(c.values, POUTPUT);
         }
     }
 

--- a/src/renderer/Renderer.hpp
+++ b/src/renderer/Renderer.hpp
@@ -33,6 +33,7 @@ class CRenderer {
     void            renderRect(const CBox& box, const CHyprColor& col, int rounding = 0);
     void            renderBorder(const CBox& box, const CGradientValueData& gradient, int thickness, int rounding = 0, float alpha = 1.0);
     void            renderTexture(const CBox& box, const CTexture& tex, float a = 1.0, int rounding = 0, std::optional<eTransform> tr = {});
+    void            renderTextureWithShader(const CBox& box, const CTexture& tex, CShader& shader, float a = 1.0, int rounding = 0, std::optional<eTransform> tr = {});
     void renderTextureMix(const CBox& box, const CTexture& tex, const CTexture& tex2, float a = 1.0, float mixFactor = 0.0, int rounding = 0, std::optional<eTransform> tr = {});
     void blurFB(const CFramebuffer& outfb, SBlurParams params);
 

--- a/src/renderer/widgets/IWidget.cpp
+++ b/src/renderer/widgets/IWidget.cpp
@@ -2,6 +2,11 @@
 #include "../../helpers/Log.hpp"
 #include "../../core/hyprlock.hpp"
 #include "../../auth/Auth.hpp"
+#include "../Renderer.hpp"
+#include "../Shaders.hpp"
+#include "../../helpers/MiscFunctions.hpp"
+#include <fstream>
+#include <sstream>
 #include <chrono>
 #include <hyprgraphics/resource/resources/TextResource.hpp>
 #include <unistd.h>
@@ -288,4 +293,78 @@ bool IWidget::isHovered() const {
 
 bool IWidget::containsPoint(const Vector2D& pos) const {
     return getBoundingBoxWl().containsPoint(pos);
+}
+
+static GLuint compileShaderSource(const GLuint& type, const std::string& src) {
+    auto shader       = glCreateShader(type);
+    auto shaderSource = src.c_str();
+    glShaderSource(shader, 1, &shaderSource, nullptr);
+    glCompileShader(shader);
+    GLint ok;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (ok == GL_FALSE) {
+        char infoLog[512];
+        glGetShaderInfoLog(shader, 512, nullptr, infoLog);
+        Log::logger->log(Log::ERR, "Custom shader compilation failed: {}", infoLog);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+void IWidget::compileCustomShader() {
+    std::string   absPath = absolutePath(shaderPath, "");
+    std::ifstream file(absPath);
+    if (!file.is_open()) {
+        Log::logger->log(Log::ERR, "Could not open custom shader file: {}", absPath);
+        return;
+    }
+
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    std::string fragSource = buffer.str();
+
+    GLuint      vertCompiled = compileShaderSource(GL_VERTEX_SHADER, TEXVERTSRC);
+    GLuint      fragCompiled = compileShaderSource(GL_FRAGMENT_SHADER, fragSource);
+
+    if (!vertCompiled || !fragCompiled) {
+        Log::logger->log(Log::ERR, "Failed to compile custom shader program parts.");
+        if (vertCompiled)
+            glDeleteShader(vertCompiled);
+        if (fragCompiled)
+            glDeleteShader(fragCompiled);
+        return;
+    }
+
+    GLuint prog = glCreateProgram();
+    glAttachShader(prog, vertCompiled);
+    glAttachShader(prog, fragCompiled);
+    glLinkProgram(prog);
+
+    glDetachShader(prog, vertCompiled);
+    glDetachShader(prog, fragCompiled);
+    glDeleteShader(vertCompiled);
+    glDeleteShader(fragCompiled);
+
+    GLint ok;
+    glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+    if (ok == GL_FALSE) {
+        char infoLog[512];
+        glGetProgramInfoLog(prog, 512, nullptr, infoLog);
+        Log::logger->log(Log::ERR, "Custom shader program linking failed: {}", infoLog);
+        glDeleteProgram(prog);
+        return;
+    }
+
+    customShader.program   = prog;
+    customShader.proj      = glGetUniformLocation(prog, "proj");
+    customShader.tex       = glGetUniformLocation(prog, "tex");
+    customShader.alpha     = glGetUniformLocation(prog, "alpha");
+    customShader.posAttrib = glGetAttribLocation(prog, "pos");
+    customShader.texAttrib = glGetAttribLocation(prog, "texcoord");
+
+    hasTime = glGetUniformLocation(prog, "time") != -1;
+
+    hasCustomShader = true;
+    Log::logger->log(Log::INFO, "Successfully loaded custom shader: {}", absPath);
 }

--- a/src/renderer/widgets/IWidget.hpp
+++ b/src/renderer/widgets/IWidget.hpp
@@ -4,6 +4,8 @@
 #include "../../helpers/Math.hpp"
 #include "../../core/Seat.hpp"
 #include "../Texture.hpp"
+#include "../Shader.hpp"
+#include "../Framebuffer.hpp"
 
 #include <hyprgraphics/resource/resources/TextResource.hpp>
 #include <string>
@@ -50,6 +52,15 @@ class IWidget {
 
     void                 setHover(bool hover);
     bool                 isHovered() const;
+
+    std::string          shaderPath;
+    CShader              customShader;
+    bool                 hasCustomShader = false;
+    bool                 hasTime         = false;
+    CFramebuffer         customFB;
+    Vector2D             viewport;
+
+    void                 compileCustomShader();
 
   private:
     bool hovered = false;


### PR DESCRIPTION
This PR introduces the ability to attach a custom fragment shader to any widget by adding a new  `attach_shader` configuration option.

---

## Implementation detials

#### Offscreen Framebuffer Wrapping
Widgets with custom shaders are rendered onto a temporary viewport-sized offscreen framebuffer. This texture is then drawn to the screen using the custom shader, leaving the drawing logic of individual widgets completely untouched.

#### Power-Saving Optimization
The renderer dynamically checks if the custom shader uses the  time  uniform. If it doesn't, hyprlock falls back to standard static redraws instead of rendering continuously.

#### Graceful Fallback
If the custom shader fails to compile or link, an error is printed to the log, and the widget automatically falls back to rendering normally with its default shaders.

---

### Example

```hyprlock.conf
label {
    ...
    attach_shader = ~/.config/hypr/shaders/crt.frag
}
```
```crt.frag
precision highp float;
varying vec2 v_texcoord;
uniform sampler2D tex;
uniform float alpha;
uniform float time;
uniform vec2 resolution;

// Pseudo-random noise helper
float hash(vec2 p) {
  p = fract(p * vec2(123.34, 456.21));
  p += dot(p, p + 45.32);
  return fract(p.x * p.y);
}

void main() {
  vec2 uv = v_texcoord;

  // 1 - Generate horizontal glitch offsets (tearing lines)
  float timeSnap = floor(time * 8.0); // 8 glitch steps per second
  float lineNoise = hash(vec2(floor(uv.y * 12.0), timeSnap));

  float glitchShift = 0.0;
  if (lineNoise > 0.82) { // 18% chance of glitch shift per band
    glitchShift = (hash(vec2(timeSnap, uv.y)) - 0.5) * 0.04;
  }

  // Add a periodic vertical rolling warp
  float roll = sin(uv.y * 3.0 - time * 2.0);
  if (hash(vec2(timeSnap)) > 0.95) { // Occasional extreme roll
    glitchShift += roll * 0.02;
  }

  // Apply the horizontal offset
  uv.x += glitchShift;

  // 2 - Chromatic Aberration (RGB channel splitting)
  float splitAmount = 0.007 + sin(time * 5.0) * 0.004;

  vec2 uvR = uv + vec2(splitAmount, 0.0);
  vec2 uvG = uv;
  vec2 uvB = uv - vec2(splitAmount, 0.0);

  // Keep coordinates within bounds to avoid wrapping edge issues
  uvR = clamp(uvR, 0.0, 1.0);
  uvB = clamp(uvB, 0.0, 1.0);

  float r = texture2D(tex, uvR).r;
  float g = texture2D(tex, uvG).g;
  float b = texture2D(tex, uvB).b;
  float a = (texture2D(tex, uvR).a + texture2D(tex, uvG).a + texture2D(tex, uvB).a) / 3.0;

  vec4 color = vec4(r, g, b, a);

  // 3 - CRT Scanline overlay                                                                                         
  float scanline = sin(uv.y * resolution.y * 0.8 + time * 12.0) * 0.08;
  color.rgb -= vec3(scanline);

  // 4 - Low-fi TV Static Grain
  float grain = (hash(uv * time) - 0.5) * 0.06;
  color.rgb += vec3(grain);

  gl_FragColor = color * alpha;
}


```


https://github.com/user-attachments/assets/7c5f6d55-d6c5-4bb5-b5bd-2c3d430e76f0