### PR TITLE
fix: use explicit cast for `m_pSeat`

### DIFF
--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -169,5 +169,5 @@ void CSeatManager::registerCursorShape(SP<CCWpCursorShapeManagerV1> shape) {
 }
 
 bool CSeatManager::registered() {
-    return static_cast<bool>(m_pSeat);
+    return !!m_pSeat;
 }

--- a/src/core/Seat.cpp
+++ b/src/core/Seat.cpp
@@ -169,5 +169,5 @@ void CSeatManager::registerCursorShape(SP<CCWpCursorShapeManagerV1> shape) {
 }
 
 bool CSeatManager::registered() {
-    return m_pSeat;
+    return static_cast<bool>(m_pSeat);
 }


### PR DESCRIPTION
Fix build failure due to https://github.com/hyprwm/hyprutils/commit/9d8bf6e810597152eef8906c670b96679af2faec.