### PR TITLE
fingerprint: restart verification after unknown error

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -165,9 +165,9 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
             }
             break;
         case MATCH_UNKNOWN_ERROR:
-            stopVerify();
-            m_sFailureReason = "Fingerprint auth disabled (unknown error)";
-            break;
+    Log::logger->log(Log::INFO, "fprint: restarting verification after unknown error");
+    restartVerification();
+    return;
         case MATCH_MATCHED:
             stopVerify();
             authenticated = true;
@@ -269,4 +269,20 @@ bool CFingerprint::releaseDevice() {
     }
     Log::logger->log(Log::INFO, "fprint: released device");
     return true;
+}
+
+void CFingerprint::restartVerification() {
+    stopVerify();
+
+    releaseDevice();
+
+    m_sDBUSState.done      = false;
+    m_sDBUSState.abort     = false;
+    m_sDBUSState.verifying = false;
+    m_sDBUSState.retries   = 0;
+
+    m_sFailureReason.clear();
+    m_sPrompt.clear();
+
+    claimDevice();
 }

--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -142,6 +142,12 @@ bool CFingerprint::createDeviceProxy() {
 }
 
 void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
+
+    // Some fingerprint drivers (e.g. ELAN Match-on-Chip)
+    // report verify-unknown-error after an idle timeout.
+    // Recover by recreating the verification session instead
+    // of permanently disabling fingerprint authentication.
+
     Log::logger->log(Log::INFO, "fprint: handling status {}", result);
     auto matchResult   = s_mapStringToTestType[result];
     bool authenticated = false;
@@ -165,9 +171,9 @@ void CFingerprint::handleVerifyStatus(const std::string& result, bool done) {
             }
             break;
         case MATCH_UNKNOWN_ERROR:
-    Log::logger->log(Log::INFO, "fprint: restarting verification after unknown error");
-    restartVerification();
-    return;
+            Log::logger->log(Log::INFO, "fprint: restarting verification after unknown error");
+            restartVerification();
+            return;
         case MATCH_MATCHED:
             stopVerify();
             authenticated = true;
@@ -272,17 +278,15 @@ bool CFingerprint::releaseDevice() {
 }
 
 void CFingerprint::restartVerification() {
-    stopVerify();
+    if (!stopVerify())
+        Log::logger->log(Log::WARN, "fprint: failed to stop verification during restart");
 
-    releaseDevice();
+    if (!releaseDevice()) {
+        Log::logger->log(Log::WARN, "fprint: failed to release device during restart");
+        return;
+    }
 
-    m_sDBUSState.done      = false;
-    m_sDBUSState.abort     = false;
-    m_sDBUSState.verifying = false;
-    m_sDBUSState.retries   = 0;
-
-    m_sFailureReason.clear();
-    m_sPrompt.clear();
+    m_sDBUSState.done = false;
 
     claimDevice();
 }

--- a/src/auth/Fingerprint.hpp
+++ b/src/auth/Fingerprint.hpp
@@ -46,6 +46,7 @@ class CFingerprint : public IAuthImplementation {
     void        handleVerifyStatus(const std::string& result, const bool done);
 
     bool        createDeviceProxy();
+    void        restartVerification();
     void        claimDevice();
     void        startVerify(bool isRetry = false);
     bool        stopVerify();


### PR DESCRIPTION
- **fingerprint: restart verification after unknown verify error**
- **fingerprint: recover from unknown verify errors**
## Summary

Some fingerprint drivers (e.g. ELAN Match-on-Chip) emit `verify-unknown-error`
after being idle for some time.

Currently hyprlock disables fingerprint authentication after receiving this
status. This change recreates the verification session by stopping
verification, releasing the device, reclaiming it, and starting verification
again.

## Tested

- ELAN Match-on-Chip 2
- Arch Linux
- Hyprlock v0.9.5

This restores fingerprint authentication automatically after the idle timeout
without requiring hyprlock to be restarted.
