### PR TITLE
fix: guard CSCDMAFrame destructor against destroyed EGL context

### DIFF
--- a/src/renderer/Screencopy.cpp
+++ b/src/renderer/Screencopy.cpp
@@ -110,8 +110,9 @@ CSCDMAFrame::CSCDMAFrame(SP<CCZwlrScreencopyFrameV1> sc) : m_sc(sc) {
 }
 
 CSCDMAFrame::~CSCDMAFrame() {
-    if (g_pEGL)
-        eglDestroyImage(g_pEGL->eglDisplay, m_image);
+    // operator bool() only tests impl_base*, not _data — use get() to check the actual CEGL is alive
+    if (auto* egl = g_pEGL.get(); egl && m_image != EGL_NO_IMAGE)
+        eglDestroyImage(egl->eglDisplay, m_image);
 
     // leaks bo and stuff but lives throughout so for now who cares
 }


### PR DESCRIPTION
## Problem

`CSCDMAFrame::~CSCDMAFrame()` crashes with SIGSEGV during process exit when calling `eglDestroyImage`.

The root cause: `CUniquePointer::operator bool()` only tests the `impl_base*` pointer — not `impl_->_data` (the actual CEGL object). If the CEGL is already destroyed (e.g. due to global-destructor ordering or a weak-ref keeping `impl_base` alive), `impl_base*` remains non-null but `_data` is nullptr. The old `if (g_pEGL)` check passed in this state, then dereferencing `g_pEGL->eglDisplay` (which goes through `_data`) segfaulted.

Crash confirmed via `coredumpctl` — SIGSEGV at the `mov (%rax), %rdi` instruction immediately before the `call eglDestroyImage` in the compiled binary, consistent with a null `_data` dereference.

## Fix

- Use `g_pEGL.get()` instead of `g_pEGL` for the null check; `get()` returns nullptr once the CEGL object's `_data` has been cleared.
- Also guard `m_image != EGL_NO_IMAGE` to avoid calling `eglDestroyImage` with an uninitialised image handle (frames destroyed before `onBufferReady` completes have `m_image == nullptr`).