### PR TITLE
fingerprint: rebuild device proxy and re-claim after waking from sleep

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -71,8 +71,20 @@ void CFingerprint::init() {
     g_dbus->m_freedesktopLogin1->uponSignal("PrepareForSleep").onInterface(LOGIN_MANAGER).call([this](bool start) {
         Log::logger->log(Log::INFO, "fprint: PrepareForSleep (start: {})", start);
         m_sDBUSState.sleeping = start;
-        if (!m_sDBUSState.sleeping && !m_sDBUSState.verifying)
-            startVerify();
+        if (m_sDBUSState.sleeping)
+            return;
+
+        // Some readers power down during sleep and re-enumerate on resume, and
+        // fprintd may have been restarted, so the pre-sleep claim (and even the
+        // device object path) may no longer exist. Release whatever we held —
+        // ignoring failures — and rebuild the proxy so startVerify() re-queries
+        // the device and claims it again.
+        if (m_sDBUSState.device) {
+            stopVerify();
+            releaseDevice();
+            m_sDBUSState.device.reset();
+        }
+        startVerify();
     });
 }
 


### PR DESCRIPTION
On machines where the fingerprint reader powers down during suspend (Synaptics Prometheus 06cb:00fc here, but any reader that re-enumerates on resume), fprintd's device object doesn't survive sleep. The claim hyprlock took before suspending is gone when the machine wakes up — and if a verify was still in flight when the system went down, fprintd can wedge badly enough that a restart is the only way to recover it, which also kills the claim.

The wake side of the `PrepareForSleep` handler currently just calls `startVerify()`, which sees the old device proxy and goes straight to `VerifyStart`. That fails with `Device was not claimed before use`, we log a warning, and that's the end of it — fingerprint auth is dead until hyprlock itself restarts. In practice: lock, close the lid, open it, and only the password works.

This treats post-sleep state as stale instead. On wake we stop verification and release whatever claim we held (both helpers already swallow errors, which is exactly what we want when the daemon was restarted underneath us), drop the proxy, and let `startVerify()` take its existing cold-start path: `GetDefaultDevice`, resubscribe the signals, claim, verify.

The release-before-reclaim order keeps readers that *do* survive suspend working: there the release succeeds and we simply claim again.

Tested on Arch (fprintd 1.94.5, libfprint 1.94.10) with the Prometheus sensor: fingerprint used to be dead after every single lid-close cycle, and comes back reliably with this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)