### PR TITLE
core: handle compositor connection loss gracefully instead of aborting

### DIFF
--- a/src/core/hyprlock.cpp
+++ b/src/core/hyprlock.cpp
@@ -405,17 +405,31 @@ void CHyprlock::run() {
                 events = poll(pollfds, fdcount, 5000);
 
                 if (events < 0) {
-                    RASSERT(errno == EINTR, "[core] Polling fds failed with {}", errno);
                     wl_display_cancel_read(m_sWaylandState.display);
+
+                    if (errno != EINTR) {
+                        Log::logger->log(Log::CRIT, "[core] Polling fds failed with {}", errno);
+                        m_bConnectionLost = true;
+                        break;
+                    }
+
                     continue;
                 }
 
                 for (size_t i = 0; i < fdcount; ++i) {
-                    RASSERT(!(pollfds[i].revents & POLLHUP), "[core] Disconnected from pollfd id {}", i);
+                    if (pollfds[i].revents & (POLLHUP | POLLERR)) {
+                        Log::logger->log(Log::CRIT, "[core] Disconnected from pollfd id {}", i);
+                        m_bConnectionLost = true;
+                    }
                 }
 
+                // read even after a disconnect: it surfaces a protocol error the
+                // compositor may have posted right before closing the connection
                 wl_display_read_events(m_sWaylandState.display);
                 m_sLoopState.wlDispatched = false;
+
+                if (m_bConnectionLost)
+                    break;
             }
 
             if (events > 0 || !preparedToRead) {
@@ -426,6 +440,24 @@ void CHyprlock::run() {
 
                 m_sLoopState.wlDispatchCV.wait_for(lk, std::chrono::milliseconds(100), [this] { return m_sLoopState.wlDispatched; });
             }
+        }
+
+        if (m_bConnectionLost) {
+            const auto ERR = wl_display_get_error(m_sWaylandState.display);
+            if (ERR == EPROTO) {
+                const wl_interface* iface = nullptr;
+                uint32_t            id    = 0;
+                const uint32_t      code  = wl_display_get_protocol_error(m_sWaylandState.display, &iface, &id);
+                Log::logger->log(Log::CRIT, "[core] Compositor posted a protocol error on {}@{}: code {}", iface ? iface->name : "?", id, code);
+            } else if (ERR != 0)
+                Log::logger->log(Log::CRIT, "[core] Compositor connection lost with {}", ERR);
+
+            // also lets the auth thread exit, same as SIGUSR1 unlocks
+            m_fadeOutOrTerminate = true;
+            m_bTerminate         = true;
+            std::lock_guard<std::mutex> lg(m_sLoopState.eventLoopMutex);
+            m_sLoopState.event = true;
+            m_sLoopState.loopCV.notify_all();
         }
     });
 
@@ -499,6 +531,13 @@ void CHyprlock::run() {
     pollThr.join();
     timersThr.join();
 
+    if (m_bConnectionLost) {
+        // the compositor is gone: drop the lock object without sending
+        // unlock_and_destroy on the dead connection
+        m_sLockState.lock.reset();
+        m_sLockState.locked = false;
+    }
+
     // Now safe to destroy globals — no more timer callbacks can fire
     m_sWaylandState = {};
     dma             = {};
@@ -512,6 +551,13 @@ void CHyprlock::run() {
     wl_display_disconnect(DPY);
 
     g_dbus.reset();
+
+    if (m_bConnectionLost) {
+        // exit nonzero so a lost compositor connection is distinguishable from a
+        // successful unlock (e.g. for supervisors respawning us on failure)
+        Log::logger->log(Log::CRIT, "Compositor connection was lost, exiting");
+        exit(1);
+    }
 
     Log::logger->log(Log::INFO, "Reached the end, exiting");
 }

--- a/src/core/hyprlock.hpp
+++ b/src/core/hyprlock.hpp
@@ -123,6 +123,7 @@ class CHyprlock {
     bool m_lockAquired        = false;
     bool m_fadeOutOrTerminate = false;
     bool m_bTerminate         = false;
+    bool m_bConnectionLost    = false;
 
     struct {
         wl_display*                      display     = nullptr;


### PR DESCRIPTION
## Description

Currently, when the compositor closes hyprlock's connection (compositor crash, or the client being disconnected serverside), the poll thread hits `RASSERT` → `abort()`, leaving a SIGABRT coredump — and, with ext-session-lock semantics, a locked session with no locker UI.

This is the crash signature behind at least some reports in #991: I have two coredumps (Arch hyprlock 0.9.5-4, NVIDIA 610.43.03, single monitor on DP-2) that both show `[core] Disconnected from pollfd id 0` fired in `pollThr` while the compositor log was full of DPMS-induced connector disconnect/reconnect cycles. Detailed analysis posted in #991.

This PR makes connection loss a graceful, diagnosable exit instead of an abort:

- Log the disconnect, and read the connection one last time so any protocol error the compositor posted right before closing gets logged too (`wl_display_get_protocol_error`) — future reports of #991-style crashes will then contain the actual serverside reason.
- Handle `POLLERR` the same way (previously ignored entirely).
- Shut down through the existing termination machinery. Two latent bugs in that path surfaced while testing, both fixed here:
  - the PAM conversation thread waits on `inputSubmittedCondition` with predicate `!inputRequested || isFadingOutOrTerminating()`, so a termination that never sets `m_fadeOutOrTerminate` hangs forever in `CPam::terminate()`'s join. The disconnect path now sets it (same mechanism as SIGUSR1 unlocks).
  - `m_sLockState.lock` was still alive at `exit()`, so the global destructor chain sent `unlock_and_destroy` through `wl_proxy_marshal_flags` on the already-`wl_display_disconnect`ed display → SIGSEGV. The disconnect path now drops the lock object locally without sending on the dead connection.
- `exit(1)` so a lost connection is distinguishable from a successful unlock (relevant for supervisors/wrappers that respawn hyprlock on failure, which works well combined with `misc:allow_session_lock_restore`).

## Testing

- Nested Hyprland (0.55.4) session, patched hyprlock locking it, then `kill -9` of the nested compositor: hyprlock logs `Disconnected from pollfd id 0` + `Compositor connection lost with 32` (EPIPE), auth thread exits, process exits with code 1, no coredump.
- SIGUSR1 unlock regression: still exits 0 through the normal `Unlocked, exiting!` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
