### PR TITLE
input-field: add dots_random_text

### DIFF
--- a/assets/example.conf
+++ b/assets/example.conf
@@ -65,6 +65,12 @@ input-field {
     # dots_size = 0.4
     dots_spacing = 0.3
 
+    # uncomment to pick a random character for every typed one.
+    # dots_text_format then is a comma separated list of the characters to pick from,
+    # alphanumeric ones are used when it is empty.
+    # dots_random_text = true
+    # dots_text_format = a, b, c
+
     # uncomment to use an input indicator that does not show the password length (similar to swaylock's input indicator)
     # hide_input = true
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -317,6 +317,7 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("input-field", "dots_spacing", Hyprlang::FLOAT{0.2});
     m_config.addSpecialConfigValue("input-field", "dots_rounding", Hyprlang::INT{-1});
     m_config.addSpecialConfigValue("input-field", "dots_text_format", Hyprlang::STRING{""});
+    m_config.addSpecialConfigValue("input-field", "dots_random_text", Hyprlang::INT{0});
     m_config.addSpecialConfigValue("input-field", "fade_on_empty", Hyprlang::INT{1});
     m_config.addSpecialConfigValue("input-field", "fade_timeout", Hyprlang::INT{2000});
     m_config.addSpecialConfigValue("input-field", "font_color", Hyprlang::INT{0xFF000000});
@@ -499,6 +500,7 @@ std::vector<CConfigManager::SWidgetConfig> CConfigManager::getWidgetConfigs() {
                 {"dots_center", m_config.getSpecialConfigValue("input-field", "dots_center", k.c_str())},
                 {"dots_rounding", m_config.getSpecialConfigValue("input-field", "dots_rounding", k.c_str())},
                 {"dots_text_format", m_config.getSpecialConfigValue("input-field", "dots_text_format", k.c_str())},
+                {"dots_random_text", m_config.getSpecialConfigValue("input-field", "dots_random_text", k.c_str())},
                 {"fade_on_empty", m_config.getSpecialConfigValue("input-field", "fade_on_empty", k.c_str())},
                 {"fade_timeout", m_config.getSpecialConfigValue("input-field", "fade_timeout", k.c_str())},
                 {"font_color", m_config.getSpecialConfigValue("input-field", "font_color", k.c_str())},

--- a/src/renderer/widgets/PasswordInputField.cpp
+++ b/src/renderer/widgets/PasswordInputField.cpp
@@ -12,10 +12,26 @@
 #include <hyprgraphics/resource/resources/TextResource.hpp>
 #include <hyprutils/math/Vector2D.hpp>
 #include <hyprutils/string/String.hpp>
+#include <hyprutils/string/VarList.hpp>
 #include <algorithm>
 #include <hyprlang.hpp>
 
 using namespace Hyprutils::String;
+
+// Used for `dots_random_text` when no `dots_text_format` is given.
+static std::vector<std::string> alphanumericDotTexts() {
+    std::vector<std::string> texts;
+    texts.reserve(62);
+
+    for (char c = '0'; c <= '9'; ++c)
+        texts.emplace_back(1, c);
+    for (char c = 'a'; c <= 'z'; ++c)
+        texts.emplace_back(1, c);
+    for (char c = 'A'; c <= 'Z'; ++c)
+        texts.emplace_back(1, c);
+
+    return texts;
+}
 
 CPasswordInputField::~CPasswordInputField() {
     reset();
@@ -44,6 +60,7 @@ void CPasswordInputField::configure(const std::unordered_map<std::string, std::a
         dots.center              = std::any_cast<Hyprlang::INT>(props.at("dots_center"));
         dots.rounding            = std::any_cast<Hyprlang::INT>(props.at("dots_rounding"));
         dots.textFormat          = std::any_cast<Hyprlang::STRING>(props.at("dots_text_format"));
+        dots.randomText          = std::any_cast<Hyprlang::INT>(props.at("dots_random_text"));
         fadeOnEmpty              = std::any_cast<Hyprlang::INT>(props.at("fade_on_empty"));
         fadeTimeoutMs            = std::any_cast<Hyprlang::INT>(props.at("fade_timeout"));
         hiddenInputState.enabled = std::any_cast<Hyprlang::INT>(props.at("hide_input"));
@@ -88,13 +105,33 @@ void CPasswordInputField::configure(const std::unordered_map<std::string, std::a
 
     pos = posFromHVAlign(viewport, size->goal(), configPos, halign, valign);
 
-    if (!dots.textFormat.empty()) {
+    std::vector<std::string> dotTexts;
+    if (dots.randomText) {
+        // Every comma separated entry of `dots_text_format` is one character to randomly pick from.
+        const CVarList ENTRIES(dots.textFormat, 0, ',', true);
+        for (const auto& entry : ENTRIES) {
+            if (!entry.empty())
+                dotTexts.emplace_back(entry);
+        }
+
+        if (dotTexts.empty())
+            dotTexts = alphanumericDotTexts();
+    } else if (!dots.textFormat.empty())
+        dotTexts.emplace_back(dots.textFormat);
+
+    if (!dotTexts.empty()) {
         Hyprgraphics::CTextResource::STextResourceData request;
-        request.text        = dots.textFormat;
-        request.font        = fontFamily;
-        request.color       = colorConfig.font.asRGB();
-        request.fontSize    = (int)(std::nearbyint(configSize.y * dots.size * 0.5f) * 2.f);
-        dots.textResourceID = g_asyncResourceManager->requestText(request, nullptr);
+        request.font     = fontFamily;
+        request.color    = colorConfig.font.asRGB();
+        request.fontSize = (int)(std::nearbyint(configSize.y * dots.size * 0.5f) * 2.f);
+
+        dots.textResourceIDs.reserve(dotTexts.size());
+        for (const auto& text : dotTexts) {
+            request.text = text;
+            dots.textResourceIDs.emplace_back(g_asyncResourceManager->requestText(request, nullptr));
+        }
+
+        dots.textAssets.resize(dots.textResourceIDs.size(), nullptr);
     }
 
     // request the inital placeholder asset
@@ -116,6 +153,14 @@ void CPasswordInputField::reset() {
     placeholder.asset      = nullptr;
     placeholder.resourceID = 0;
     placeholder.currentText.clear();
+
+    for (const auto& id : dots.textResourceIDs)
+        g_asyncResourceManager->unloadById(id);
+
+    dots.textResourceIDs.clear();
+    dots.textAssets.clear();
+    dots.randomIndices.clear();
+    dots.lastLength = 0;
 }
 
 static void fadeOutCallback(AWP<CPasswordInputField> ref) {
@@ -161,6 +206,18 @@ void CPasswordInputField::updateFade() {
 }
 
 void CPasswordInputField::updateDots() {
+    // Pick a character for every newly typed dot. Entries past passwordLength are kept around,
+    // because removed dots are still rendered while they animate out.
+    if (dots.randomText && !dots.textResourceIDs.empty() && passwordLength > dots.lastLength) {
+        if (dots.randomIndices.size() < passwordLength)
+            dots.randomIndices.resize(passwordLength, 0);
+
+        for (size_t i = dots.lastLength; i < passwordLength; ++i)
+            dots.randomIndices[i] = rand() % dots.textResourceIDs.size();
+    }
+
+    dots.lastLength = passwordLength;
+
     if (dots.currentAmount->goal() == passwordLength)
         return;
 
@@ -239,14 +296,28 @@ bool CPasswordInputField::draw(const SRenderData& data) {
         Vector2D  passSize{RECTPASSSIZE, RECTPASSSIZE};
         int       passSpacing = std::floor(passSize.x * dots.spacing);
 
-        if (!dots.textFormat.empty()) {
-            if (!dots.textAsset)
-                dots.textAsset = g_asyncResourceManager->getAssetByID(dots.textResourceID);
+        const bool USETEXT   = !dots.textResourceIDs.empty();
+        bool       textReady = USETEXT;
 
-            if (!dots.textAsset)
+        if (USETEXT) {
+            // Every dot occupies the same cell, sized to fit the widest character.
+            Vector2D maxSize;
+            for (size_t i = 0; i < dots.textAssets.size(); ++i) {
+                if (!dots.textAssets[i])
+                    dots.textAssets[i] = g_asyncResourceManager->getAssetByID(dots.textResourceIDs[i]);
+
+                if (!dots.textAssets[i]) {
+                    textReady = false;
+                    continue;
+                }
+
+                maxSize = Vector2D{std::max(maxSize.x, dots.textAssets[i]->m_vSize.x), std::max(maxSize.y, dots.textAssets[i]->m_vSize.y)};
+            }
+
+            if (!textReady)
                 forceReload = true;
             else {
-                passSize    = dots.textAsset->m_vSize;
+                passSize    = maxSize;
                 passSpacing = std::floor(passSize.x * dots.spacing);
             }
         }
@@ -285,14 +356,20 @@ bool CPasswordInputField::draw(const SRenderData& data) {
 
             Vector2D dotPosition = inputFieldBox.pos() + Vector2D{xstart + (i * (passSize.x + passSpacing)), (inputFieldBox.h / 2.0) - (passSize.y / 2.0)};
             CBox     box{dotPosition, passSize};
-            if (!dots.textFormat.empty()) {
-                if (!dots.textAsset) {
-                    forceReload = true;
-                    fontCol.a   = DOTALPHA;
+            if (USETEXT) {
+                if (!textReady) {
+                    fontCol.a = DOTALPHA;
                     break;
                 }
 
-                g_pRenderer->renderTexture(box, *dots.textAsset, fontCol.a, dots.rounding);
+                const size_t TEXTIDX = (dots.randomText && (size_t)i < dots.randomIndices.size()) ? dots.randomIndices[i] : 0;
+                const auto&  ASSET   = dots.textAssets[std::min(TEXTIDX, dots.textAssets.size() - 1)];
+
+                // Center the character in its cell, as characters may differ in size.
+                CBox textBox{dotPosition + (passSize - ASSET->m_vSize) / 2.0, ASSET->m_vSize};
+                // dots.rounding is derived from the cell, clamp it so it can't cut into narrower characters.
+                const int TEXTROUND = std::min<double>(dots.rounding, std::min(ASSET->m_vSize.x, ASSET->m_vSize.y) / 2.0);
+                g_pRenderer->renderTexture(textBox, *ASSET, fontCol.a, TEXTROUND);
             } else
                 g_pRenderer->renderRect(box, fontCol, dots.rounding);
 

--- a/src/renderer/widgets/PasswordInputField.hpp
+++ b/src/renderer/widgets/PasswordInputField.hpp
@@ -62,14 +62,20 @@ class CPasswordInputField : public IWidget {
     int                      outThick, rounding;
 
     struct {
-        PHLANIMVAR<float> currentAmount;
-        bool              center         = false;
-        float             size           = 0;
-        float             spacing        = 0;
-        int               rounding       = 0;
-        size_t            textResourceID = 0;
-        std::string       textFormat     = "";
-        ASP<CTexture>     textAsset      = nullptr;
+        PHLANIMVAR<float>          currentAmount;
+        bool                       center     = false;
+        float                      size       = 0;
+        float                      spacing    = 0;
+        int                        rounding   = 0;
+        std::string                textFormat = "";
+        bool                       randomText = false;
+        // One entry per character the dots can be rendered with.
+        // Holds a single entry when `dots_text_format` is used without `dots_random_text`, and is empty for plain dots.
+        std::vector<ResourceID>    textResourceIDs;
+        std::vector<ASP<CTexture>> textAssets;
+        // Index into textResourceIDs/textAssets for every already typed character, so the chosen glyphs don't change every frame.
+        std::vector<size_t>        randomIndices;
+        size_t                     lastLength = 0;
     } dots;
 
     struct {


### PR DESCRIPTION
Closes #1058

Adds `dots_random_text` to `input-field`, which displays a random character for every typed one instead of the same dot or `dots_text_format` string.

```ini
input-field {
    dots_random_text = true
    dots_text_format = x, y, z
}
```

When `dots_random_text` is enabled, `dots_text_format` is read as a comma separated set of characters to pick from. If it is empty, the alphanumeric set is used. With the option off, `dots_text_format` keeps its current meaning, so existing configs are unaffected.

The character for a dot is picked once, when it is typed, and kept afterwards, so the field doesn't reshuffle on every frame. Entries for removed dots are kept around while they animate out.

Since characters can differ in size, every dot now occupies a cell sized to fit the widest candidate and is centered within it, which keeps the spacing even. `dots_rounding` is derived from that cell, so it is clamped per character to avoid cutting into narrower ones.

`reset()` now also releases the dot text resources — the single one was previously never unloaded on reconfigure.

### Testing

Built and run against headless sway with software rendering, typing into the field and capturing the result:

- random pick from a custom set, and the alphanumeric fallback when `dots_text_format` is empty
- mixed width sets (`i, W, m, l, @, .`) render evenly spaced with no clipping
- glyphs stay stable while idle; backspacing and retyping keeps the prefix and picks fresh characters for the new positions
- typing past the visible dot limit still scrolls correctly
- degenerate `dots_text_format = , ,` falls back to the alphanumeric set rather than rendering nothing
- no crashes or log errors with `hide_input` or `dots_rounding = 0`

For regression, a pristine build of `main` and this branch produce pixel identical output for plain dots, `dots_text_format = *`, and `dots_text_format = W`.
