### PR TITLE
fingerprint: reset device proxy on terminate

### DIFF
--- a/src/auth/Fingerprint.cpp
+++ b/src/auth/Fingerprint.cpp
@@ -99,6 +99,9 @@ bool CFingerprint::checkWaiting() {
 void CFingerprint::terminate() {
     if (!m_sDBUSState.abort)
         releaseDevice();
+
+    // The proxy borrows the bus connection and must not outlive it.
+    m_sDBUSState.device.reset();
 }
 
 bool CFingerprint::createDeviceProxy() {


### PR DESCRIPTION
Fixes #1067.

### The bug

`CFingerprint::terminate()` only released the fprintd device when the verification had not been aborted:

```cpp
void CFingerprint::terminate() {
    if (!m_sDBUSState.abort)
        releaseDevice();   // this is what resets m_sDBUSState.device
}
```

`m_sDBUSState.abort` is set in `handleVerifyStatus()` on `MATCH_DISCONNECTED`, i.e. whenever fprintd reports `verify-disconnected`. On that path the device proxy is kept alive.

The proxy is created with the reference overload:

```cpp
m_sDBUSState.device = sdbus::createProxy(*g_dbus->m_connection, FPRINT, path);
```

which borrows the connection instead of sharing ownership of it, so the proxy must not outlive it. But `run()` destroys the connection at `g_dbus.reset()` while `g_pAuth` is left to static destruction, so the ordering at exit is:

1. `g_pAuth->terminate()` — skips `releaseDevice()` because of `abort`, proxy survives
2. `g_dbus.reset()` — `CDbus` and `m_connection` destroyed
3. `main` returns, `exit()` destroys `g_pAuth` → `~CFingerprint` → `~Proxy`

`~Proxy` unrefs its signal slots through a lambda capturing the now-dangling `Connection`, and hyprlock segfaults in `Connection.cpp:640`. Backtrace and logs are in #1067.

The session is already unlocked at that point, so the user-visible damage is limited, but hyprlock terminates on a signal instead of returning 0.

### Regression

Yes, and I got this wrong in the issue — I have corrected it there.

Before 8bac7da (#1029) `SDBUSState` looked like this:

```cpp
struct SDBUSState {
    std::shared_ptr<sdbus::IConnection> connection;
    std::unique_ptr<sdbus::IProxy>      login;
    std::unique_ptr<sdbus::IProxy>      device;
    ...
};
```

Members are destroyed in reverse declaration order, so `device` was always destroyed before `connection` and the early return in `terminate()` was harmless. Moving the connection out to `g_dbus` removed that guarantee without changing `terminate()`. v0.9.6 is the first tag containing the commit.

### The fix

Reset the proxy unconditionally, so it cannot outlive the connection regardless of which branch was taken. `terminate()` runs before `g_dbus.reset()` in `run()`, so this is early enough.

### Note for maintainers

This makes the reported crash go away, but the underlying fragility is that `g_pAuth` is the only global in that teardown block left to static destruction — everything around it (`g_pSeatManager`, `g_asyncResourceManager`, `g_pRenderer`, `g_pEGL`) is reset explicitly before `g_dbus`. Adding `g_pAuth.reset();` before `g_dbus.reset();` would make the ordering explicit and cover any future proxy held by an auth implementation. I left it out to keep this diff to the actual bug — happy to add it if you would prefer that instead of, or on top of, this change.

### Testing

- Builds clean against sdbus-cpp 2.3.1, hyprutils 0.14.1, hyprlang 0.6.8, gcc 16.2.1.
- `clang-format --dry-run --Werror` clean.
- **Not verified at runtime against the crash.** I have a single core dump and no confirmed repro recipe yet — the fix follows from the destruction order in the backtrace rather than from an observed before/after. Flagging that explicitly so it gets the review it deserves.
